### PR TITLE
feat: extend reportEndCall action for unanswered call handling

### DIFF
--- a/webtrit_callkeep/lib/src/callkeep.dart
+++ b/webtrit_callkeep/lib/src/callkeep.dart
@@ -89,10 +89,11 @@ class Callkeep {
   }
 
   /// Report the end of call with the given [callId].
+  /// The [displayName] of the call is required for reporting miseed call metadata.
   /// The [reason] for ending the call is required.
   /// Returns [Future] that completes when the operation is done.
-  Future<void> reportEndCall(String callId, CallkeepEndCallReason reason) {
-    return platform.reportEndCall(callId, reason);
+  Future<void> reportEndCall(String callId, String displayName, CallkeepEndCallReason reason) {
+    return platform.reportEndCall(callId, displayName, reason);
   }
 
   /// Start a call with the given [callId], [handle], [displayNameOrContactIdentifier] and [hasVideo] flag.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -502,7 +502,7 @@ interface PHostApi {
   fun reportConnectingOutgoingCall(callId: String, callback: (Result<Unit>) -> Unit)
   fun reportConnectedOutgoingCall(callId: String, callback: (Result<Unit>) -> Unit)
   fun reportUpdateCall(callId: String, handle: PHandle?, displayName: String?, hasVideo: Boolean?, proximityEnabled: Boolean?, callback: (Result<Unit>) -> Unit)
-  fun reportEndCall(callId: String, reason: PEndCallReason, callback: (Result<Unit>) -> Unit)
+  fun reportEndCall(callId: String, displayName: String, reason: PEndCallReason, callback: (Result<Unit>) -> Unit)
   fun startCall(callId: String, handle: PHandle, displayNameOrContactIdentifier: String?, video: Boolean, proximityEnabled: Boolean, callback: (Result<PCallRequestError?>) -> Unit)
   fun answerCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit)
   fun endCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit)
@@ -661,8 +661,9 @@ interface PHostApi {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val callIdArg = args[0] as String
-            val reasonArg = args[1] as PEndCallReason
-            api.reportEndCall(callIdArg, reasonArg) { result: Result<Unit> ->
+            val displayNameArg = args[1] as String
+            val reasonArg = args[2] as PEndCallReason
+            api.reportEndCall(callIdArg, displayNameArg, reasonArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))
@@ -868,7 +869,7 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
     }
   }
   fun continueStartCallIntent(handleArg: PHandle, displayNameArg: String?, videoArg: Boolean, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.continueStartCallIntent"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(handleArg, displayNameArg, videoArg)) {
@@ -880,11 +881,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun didPushIncomingCall(handleArg: PHandle, displayNameArg: String?, videoArg: Boolean, callIdArg: String, errorArg: PIncomingCallError?, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didPushIncomingCall"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(handleArg, displayNameArg, videoArg, callIdArg, errorArg)) {
@@ -896,11 +897,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performStartCall(callIdArg: String, handleArg: PHandle, displayNameOrContactIdentifierArg: String?, videoArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performStartCall"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, handleArg, displayNameOrContactIdentifierArg, videoArg)) {
@@ -915,11 +916,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performAnswerCall(callIdArg: String, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAnswerCall"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg)) {
@@ -934,11 +935,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performEndCall(callIdArg: String, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performEndCall"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg)) {
@@ -953,11 +954,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performSetHeld(callIdArg: String, onHoldArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetHeld"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, onHoldArg)) {
@@ -972,11 +973,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performSetMuted(callIdArg: String, mutedArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetMuted"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, mutedArg)) {
@@ -991,11 +992,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performSetSpeaker(callIdArg: String, enabledArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetSpeaker"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, enabledArg)) {
@@ -1010,11 +1011,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun performSendDTMF(callIdArg: String, keyArg: String, callback: (Result<Boolean>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSendDTMF"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, keyArg)) {
@@ -1029,11 +1030,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun didActivateAudioSession(callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didActivateAudioSession"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(null) {
@@ -1045,11 +1046,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun didDeactivateAudioSession(callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didDeactivateAudioSession"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(null) {
@@ -1061,11 +1062,11 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun didReset(callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didReset"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(null) {
@@ -1077,7 +1078,7 @@ class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -1091,7 +1092,7 @@ class PDelegateBackgroundServiceFlutterApi(private val binaryMessenger: BinaryMe
     }
   }
   fun performEndCall(callIdArg: String, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.performEndCall"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg)) {
@@ -1103,11 +1104,11 @@ class PDelegateBackgroundServiceFlutterApi(private val binaryMessenger: BinaryMe
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun endCallReceived(callIdArg: String, numberArg: String, videoArg: Boolean, createdTimeArg: Long, acceptedTimeArg: Long?, hungUpTimeArg: Long?, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.endCallReceived"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(callIdArg, numberArg, videoArg, createdTimeArg, acceptedTimeArg, hungUpTimeArg)) {
@@ -1119,7 +1120,7 @@ class PDelegateBackgroundServiceFlutterApi(private val binaryMessenger: BinaryMe
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -1164,7 +1165,7 @@ class PPushRegistryDelegateFlutterApi(private val binaryMessenger: BinaryMesseng
     }
   }
   fun didUpdatePushTokenForPushTypeVoIP(tokenArg: String?, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PPushRegistryDelegateFlutterApi.didUpdatePushTokenForPushTypeVoIP"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(tokenArg)) {
@@ -1176,7 +1177,7 @@ class PPushRegistryDelegateFlutterApi(private val binaryMessenger: BinaryMesseng
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -1190,7 +1191,7 @@ class PDelegateLogsFlutterApi(private val binaryMessenger: BinaryMessenger) {
     }
   }
   fun onLog(typeArg: PLogTypeEnum, tagArg: String, messageArg: String, callback: (Result<Unit>) -> Unit)
-{
+  {
     val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateLogsFlutterApi.onLog"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(typeArg.raw, tagArg, messageArg)) {
@@ -1202,7 +1203,7 @@ class PDelegateLogsFlutterApi(private val binaryMessenger: BinaryMessenger) {
         }
       } else {
         callback(Result.failure(createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PigeonActivityApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PigeonActivityApi.kt
@@ -105,10 +105,11 @@ class PigeonActivityApi(
     }
 
     override fun reportEndCall(
-        callId: String, reason: PEndCallReason, callback: (Result<Unit>) -> Unit
+        callId: String, displayName:String, reason: PEndCallReason, callback: (Result<Unit>) -> Unit
     ) {
         val callMetaData = CallMetadata(
-            callId = callId
+            callId = callId,
+            displayName = displayName
         )
         foregroundCallkeepApi.reportEndCall(callMetaData, reason, callback)
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/api/foreground/ProxyForegroundCallkeepApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/api/foreground/ProxyForegroundCallkeepApi.kt
@@ -6,6 +6,7 @@ import com.webtrit.callkeep.FlutterLog
 import com.webtrit.callkeep.PCallRequestError
 import com.webtrit.callkeep.PDelegateFlutterApi
 import com.webtrit.callkeep.PEndCallReason
+import com.webtrit.callkeep.PEndCallReasonEnum
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.POptions
 import com.webtrit.callkeep.common.StorageDelegate
@@ -76,6 +77,9 @@ class ProxyForegroundCallkeepApi(
         audioService.stopRingtone()
         if (Platform.isLockScreen(activity)) {
             activity.finish()
+        }
+        if(reason.value == PEndCallReasonEnum.UNANSWERED) {
+            notificationService.showMissedCallNotification(metadata)
         }
         callback.invoke(Result.success(Unit))
     }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -621,7 +621,7 @@ class PHostApi {
     }
   }
 
-  Future<void> reportEndCall(String callId, PEndCallReason reason) async {
+  Future<void> reportEndCall(String callId, String displayName, PEndCallReason reason) async {
     const String __pigeon_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportEndCall';
     final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
@@ -629,7 +629,7 @@ class PHostApi {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[callId, reason]) as List<Object?>?;
+        await __pigeon_channel.send(<Object?>[callId, displayName, reason]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -110,9 +110,10 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   @override
   Future<void> reportEndCall(
     String callId,
+    String displayName,
     CallkeepEndCallReason reason,
   ) {
-    return _api.reportEndCall(callId, PEndCallReason(value: reason.toPigeon()));
+    return _api.reportEndCall(callId, displayName, PEndCallReason(value: reason.toPigeon()));
   }
 
   @override

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -168,9 +168,9 @@ abstract class PHostApi {
     bool? proximityEnabled,
   );
 
-  @ObjCSelector('reportEndCall:reason:')
+  @ObjCSelector('reportEndCall:displayName:reason:')
   @async
-  void reportEndCall(String callId, PEndCallReason reason);
+  void reportEndCall(String callId, String displayName, PEndCallReason reason);
 
   @ObjCSelector('startCall:handle:displayNameOrContactIdentifier:video:proximityEnabled:')
   @async

--- a/webtrit_callkeep_ios/ios/Classes/Generated.h
+++ b/webtrit_callkeep_ios/ios/Classes/Generated.h
@@ -188,7 +188,7 @@ NSObject<FlutterMessageCodec> *WTPHostApiGetCodec(void);
 - (void)reportConnectingOutgoingCall:(NSString *)uuidString completion:(void (^)(FlutterError *_Nullable))completion;
 - (void)reportConnectedOutgoingCall:(NSString *)uuidString completion:(void (^)(FlutterError *_Nullable))completion;
 - (void)reportUpdateCall:(NSString *)uuidString handle:(nullable WTPHandle *)handle displayName:(nullable NSString *)displayName hasVideo:(nullable NSNumber *)hasVideo proximityEnabled:(nullable NSNumber *)proximityEnabled completion:(void (^)(FlutterError *_Nullable))completion;
-- (void)reportEndCall:(NSString *)uuidString reason:(WTPEndCallReason *)reason completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)reportEndCall:(NSString *)uuidString displayName:(NSString *)displayName reason:(WTPEndCallReason *)reason completion:(void (^)(FlutterError *_Nullable))completion;
 - (void)startCall:(NSString *)uuidString handle:(WTPHandle *)handle displayNameOrContactIdentifier:(nullable NSString *)displayNameOrContactIdentifier video:(BOOL)video proximityEnabled:(BOOL)proximityEnabled completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;
 - (void)answerCall:(NSString *)uuidString completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;
 - (void)endCall:(NSString *)uuidString completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;

--- a/webtrit_callkeep_ios/ios/Classes/Generated.m
+++ b/webtrit_callkeep_ios/ios/Classes/Generated.m
@@ -644,12 +644,13 @@ void SetUpWTPHostApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<WTPHos
         binaryMessenger:binaryMessenger
         codec:WTPHostApiGetCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(reportEndCall:reason:completion:)], @"WTPHostApi api (%@) doesn't respond to @selector(reportEndCall:reason:completion:)", api);
+      NSCAssert([api respondsToSelector:@selector(reportEndCall:displayName:reason:completion:)], @"WTPHostApi api (%@) doesn't respond to @selector(reportEndCall:displayName:reason:completion:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
         NSString *arg_uuidString = GetNullableObjectAtIndex(args, 0);
-        WTPEndCallReason *arg_reason = GetNullableObjectAtIndex(args, 1);
-        [api reportEndCall:arg_uuidString reason:arg_reason completion:^(FlutterError *_Nullable error) {
+        NSString *arg_displayName = GetNullableObjectAtIndex(args, 1);
+        WTPEndCallReason *arg_reason = GetNullableObjectAtIndex(args, 2);
+        [api reportEndCall:arg_uuidString displayName:arg_displayName reason:arg_reason completion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
         }];
       }];

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -588,7 +588,7 @@ class PHostApi {
     }
   }
 
-  Future<void> reportEndCall(String uuidString, PEndCallReason reason) async {
+  Future<void> reportEndCall(String uuidString, String displayName, PEndCallReason reason) async {
     const String __pigeon_channelName = 'dev.flutter.pigeon.webtrit_callkeep_ios.PHostApi.reportEndCall';
     final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
@@ -596,7 +596,7 @@ class PHostApi {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[uuidString, reason]) as List<Object?>?;
+        await __pigeon_channel.send(<Object?>[uuidString, displayName, reason]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
+++ b/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
@@ -115,8 +115,12 @@ class WebtritCallkeep extends WebtritCallkeepPlatform {
   }
 
   @override
-  Future<void> reportEndCall(String callId, CallkeepEndCallReason reason) async {
-    return _api.reportEndCall(_uuidToCallIdMapping.put(callId: callId), PEndCallReason(value: reason.toPigeon()));
+  Future<void> reportEndCall(String callId, String displayName, CallkeepEndCallReason reason) async {
+    return _api.reportEndCall(
+      _uuidToCallIdMapping.put(callId: callId),
+      displayName,
+      PEndCallReason(value: reason.toPigeon()),
+    );
   }
 
   @override

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -156,9 +156,9 @@ abstract class PHostApi {
     bool? proximityEnabled,
   );
 
-  @ObjCSelector('reportEndCall:reason:')
+  @ObjCSelector('reportEndCall:displayName:reason:')
   @async
-  void reportEndCall(String uuidString, PEndCallReason reason);
+  void reportEndCall(String uuidString,String displayName, PEndCallReason reason);
 
   @ObjCSelector('startCall:handle:displayNameOrContactIdentifier:video:proximityEnabled:')
   @async

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -98,7 +98,7 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
   }
 
   /// Report an update to the call metadata.
-  /// The [displayName] and [hasVideo] flag can be updated.
+  /// The [displayName] of the call is required for reporting miseed call metadata.
   /// Returns [Future] that completes when the operation is done.
   Future<void> reportUpdateCall(
     String callId,
@@ -111,9 +111,10 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
   }
 
   /// Report the end of call with the given [callId].
+  /// The [displayName] is required for missed call metadata.
   /// The [reason] for ending the call is required.
   /// Returns [Future] that completes when the operation is done.
-  Future<void> reportEndCall(String callId, CallkeepEndCallReason reason) {
+  Future<void> reportEndCall(String callId, String displayName, CallkeepEndCallReason reason) {
     throw UnimplementedError('reportEndCall() has not been implemented.');
   }
 


### PR DESCRIPTION
## Description

Extend reportEndCall action for unanswered call handling for ios and as bonus for non telephony api in android with showing dysplay name of calle.

Attention: linked with https://github.com/WebTrit/webtrit_phone/pull/258 pr and should be merged together.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
