### PR TITLE
fix: broken app compatibility with software.telecom requiring

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -23,10 +23,6 @@
         android:name="android.hardware.telephony"
         android:required="false" />
 
-    <uses-feature
-        android:name="android.software.telecom"
-        android:required="true" />
-
     <application>
         <service
             android:name=".services.services.connection.PhoneConnectionService"


### PR DESCRIPTION

## Description
Somehow this flag breaks up google play aab compatibility handling.
If install apk or destruct aab with bundletool and istall manualy app works ok, but using google play it breaks compatibility from 12000 to 2000 devices or show error if uses internal sharing or app distribution.
![Screenshot](https://github.com/user-attachments/assets/1f0e9fe2-f215-481f-b139-860110cb4bdc)
![photo_2025-05-13_13-40-48](https://github.com/user-attachments/assets/42ca3fe8-52d2-4f9e-8cdc-f5648c3f96ab)
TODO: investigate deeper what this flag does or report an issue to google.
## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
