### PR TITLE
fix: add lifecycle-based signaling startup for Android 15+ and restore notification intent

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -52,13 +52,30 @@
 
         <service android:name=".services.services.foreground.ForegroundService" />
 
+        <!--
+          Receiver for starting the signaling service (SignalingIsolateService) on system events,
+          only if the service is enabled in app settings.
+
+          Used to relaunch the service on:
+            - device boot (BOOT_COMPLETED, LOCKED_BOOT_COMPLETED),
+            - app update (MY_PACKAGE_REPLACED),
+            - quick boot on some legacy HTC/Motorola devices (QUICKBOOT_POWERON)
+
+           Note:
+            - On Android 14+ (API 34), BOOT_COMPLETED can no longer start a ForegroundService
+              of type "phone call". The service must be started later from WebtritCallkeepPlugin.
+
+          See: ForegroundCallBootReceiver.kt
+        -->
         <receiver
             android:name=".services.services.signaling.receivers.ForegroundCallBootReceiver"
-            android:enabled="false"
+            android:enabled="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     </application>

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ForegroundCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ForegroundCallNotificationBuilder.kt
@@ -1,9 +1,12 @@
 package com.webtrit.callkeep.notifications
 
 import android.app.Notification
+import android.app.PendingIntent
+import android.content.Intent
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder.context
 import com.webtrit.callkeep.managers.NotificationChannelManager.FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID
+import com.webtrit.callkeep.services.services.signaling.SignalingIsolateService
 
 class ForegroundCallNotificationBuilder() : NotificationBuilder() {
     private var title = ""
@@ -20,18 +23,23 @@ class ForegroundCallNotificationBuilder() : NotificationBuilder() {
     override fun build(): Notification {
         if (title.isEmpty() || content.isEmpty()) throw IllegalStateException("Title and content must be set")
 
+        val intent = Intent(context, SignalingIsolateService::class.java).apply {
+            action = ACTION_RESTORE_NOTIFICATION
+        }
+        val deleteIntent = PendingIntent.getService(
+            context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val notificationBuilder = Notification.Builder(context, FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID).apply {
             setSmallIcon(R.drawable.call_foreground_icon)
             setContentTitle(title)
             setContentText(content)
             setAutoCancel(false)
             setOngoing(true)
+            setDeleteIntent(deleteIntent)
             setCategory(Notification.CATEGORY_CALL)
             setVisibility(Notification.VISIBILITY_PUBLIC)
-
-            setFullScreenIntent(
-                buildOpenAppIntent(context), true
-            )
+            setFullScreenIntent(buildOpenAppIntent(context), true)
             setContentIntent(buildOpenAppIntent(context))
         }
         val notification = notificationBuilder.build()
@@ -41,5 +49,6 @@ class ForegroundCallNotificationBuilder() : NotificationBuilder() {
 
     companion object {
         const val NOTIFICATION_ID = 3
+        const val ACTION_RESTORE_NOTIFICATION = "FOREGROUND_CALL_ACTION_RESTORE_NOTIFICATION"
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/receivers/ForegroundCallBootReceiver.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/receivers/ForegroundCallBootReceiver.kt
@@ -3,36 +3,98 @@ package com.webtrit.callkeep.services.services.signaling.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.core.content.ContextCompat
+import androidx.work.*
 import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.services.services.signaling.SignalingIsolateService
+import java.util.concurrent.TimeUnit
 
+/**
+ * BroadcastReceiver that triggers the startup of the [SignalingIsolateService] on device boot.
+ *
+ * ## Behavior by Android Version:
+ * - **Android 13 and below (API < 34):** Allowed to start foreground services (FGS) from BOOT_COMPLETED.
+ * - **Android 14 and above (API 34+):** FGS for phone calls cannot be started from BOOT_COMPLETED.
+ *   In this case, the service must be started manually from [WebtritCallkeepPlugin.onAttachedToActivity].
+ *
+ * ## Notes:
+ * - The service will only start if signaling is enabled and push notifications are not in use.
+ * - The receiver responds to system boot events and package replacement events.
+ */
 class ForegroundCallBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        val action = intent.action
-        if (action == Intent.ACTION_MY_PACKAGE_REPLACED || action == Intent.ACTION_BOOT_COMPLETED || action == ACTION_QUICKBOOT_POWERON) {
-            val wakeLock = SignalingIsolateService.Companion.getLock(context)
-            wakeLock?.let {
-                if (!it.isHeld) {
-                    it.acquire(10 * 60 * 1000L /*10 minutes*/)
-                }
-            }
+        val action = intent.action.orEmpty()
 
-            try {
-                ContextCompat.startForegroundService(
-                    context, Intent(context, SignalingIsolateService::class.java)
-                )
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+        // Skip startup if signaling service is disabled by user or replaced with push notifications
+        if (!StorageDelegate.SignalingService.isSignalingServiceEnabled(context)) {
+            Log.i(TAG, "Signaling service is disabled, skipping")
+            return
+        }
 
-        } else {
-            Log.w(TAG, "Received unexpected action: $action")
+        if (action !in listOf(
+                Intent.ACTION_MY_PACKAGE_REPLACED,
+                Intent.ACTION_BOOT_COMPLETED,
+                Intent.ACTION_LOCKED_BOOT_COMPLETED,
+                ACTION_QUICKBOOT_POWERON
+            )
+        ) {
+            Log.w(TAG, "Unhandled broadcast action: $action")
+            return
+        }
+
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Log.w(TAG, "PhoneCall-type FGS not allowed to start from BOOT_COMPLETED on Android 14+")
+            return
+        }
+
+        enqueueSignalingWorker(context)
+    }
+
+    /**
+     * Schedules a one-time worker via [WorkManager] to start the signaling service.
+     * A slight delay is added to ensure the system is ready.
+     */
+    private fun enqueueSignalingWorker(context: Context) {
+
+        val workRequest = OneTimeWorkRequestBuilder<SignalingStartWorker>().setInitialDelay(2, TimeUnit.SECONDS).build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest
+        )
+    }
+
+    companion object {
+        private const val TAG = "ForegroundCallBootReceiver"
+        private const val WORK_NAME = "SignalingStartWorker"
+        private const val ACTION_QUICKBOOT_POWERON = "android.intent.action.QUICKBOOT_POWERON"
+    }
+}
+
+/**
+ * A [CoroutineWorker] responsible for launching [SignalingIsolateService] in the background
+ * after system boot or package update, using [WorkManager].
+ *
+ * This ensures the service is launched reliably without conflicting with boot-time restrictions.
+ */
+class SignalingStartWorker(
+    context: Context, params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val serviceIntent = Intent(applicationContext, SignalingIsolateService::class.java)
+            ContextCompat.startForegroundService(applicationContext, serviceIntent)
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start SignalingIsolateService:  ${e.message}")
+            Result.failure()
         }
     }
 
     companion object {
-        private const val ACTION_QUICKBOOT_POWERON = "android.intent.action.QUICKBOOT_POWERON"
-        private const val TAG = "ForegroundCallBootReceiver"
+        private const val TAG = "SignalingStartWorker"
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This pull request improves the robustness and lifecycle-awareness of the signaling service startup across Android versions:

- Add deleteIntent to restore call notification on dismissal
- Manually start signaling service on Android 15+ due to FGS boot restrictions
- Use WorkManager to start signaling service on boot with Android 14+ compatibility

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
