### PR TITLE
fix: incoming call notification while phone locked

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -41,7 +41,6 @@ class IncomingCallNotificationBuilder() : NotificationBuilder() {
             setCategory(NotificationCompat.CATEGORY_CALL)
             setContentTitle(title)
             text?.let { setContentText(it) }
-            setAutoCancel(true)
         }
     }
 
@@ -67,7 +66,6 @@ class IncomingCallNotificationBuilder() : NotificationBuilder() {
         val declineButton = R.string.decline_button_text
 
         val builder = baseNotificationBuilder(title, description).apply {
-            setOngoing(true)
             setFullScreenIntent(buildOpenAppIntent(context), true)
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/MissedCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/MissedCallNotificationBuilder.kt
@@ -27,9 +27,7 @@ class MissedCallNotificationBuilder() : NotificationBuilder() {
             setContentTitle(context.getString(R.string.push_notification_missed_call_channel_title))
             setContentText("You have a missed call from ${callMetaData.name}")
             setAutoCancel(true)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                setCategory(Notification.CATEGORY_MISSED_CALL)
-            }
+            setCategory(NotificationCompat.CATEGORY_MISSED_CALL)
             setFullScreenIntent(buildOpenAppIntent(context), true)
         }
         val notification = notificationBuilder.build()


### PR DESCRIPTION
## Description
Fixe for incoming call notification bug that not turns screen on if device is locked
## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
