### PR TITLE
fix(android): use consistent context to unregister broadcast receivers

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -119,7 +119,7 @@ class SignalingIsolateService : Service(), PHostBackgroundSignalingIsolateApi {
         latestSignalingStatus = null
 
         // Unregister the service from receiving lifecycle events
-        ActivityLifecycleBroadcaster.unregister(baseContext, lifecycleEventReceiver)
+        ActivityLifecycleBroadcaster.unregister(this, lifecycleEventReceiver)
         latestLifecycleActivityEvent = null
 
         if (StorageDelegate.SignalingService.isSignalingServiceEnabled(context = applicationContext)) {


### PR DESCRIPTION
## Summary

`ActivityLifecycleBroadcaster` was registered with `this` in `onCreate` but unregistered with `baseContext` in `onDestroy`. The mismatched context left `lifecycleEventReceiver` registered after service destruction, causing a memory leak and stale callbacks into a dead service.

**Fix:** use `this` for both unregister calls, consistent with `SignalingStatusBroadcaster` and the corresponding register call-sites.

```kotlin
// Before
ActivityLifecycleBroadcaster.unregister(baseContext, lifecycleEventReceiver) // ✗

// After
ActivityLifecycleBroadcaster.unregister(this, lifecycleEventReceiver) // ✓
```

## Test plan

- [ ] `./gradlew :android:compileDebugKotlin` — builds cleanly
- [ ] Manual smoke: start/stop SignalingIsolateService repeatedly, confirm no leaked receiver warnings in logcat