### PR TITLE
feat(android): add AssetHolder.initForIsolatedProcess for isolated process support

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/AssetHolder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/AssetHolder.kt
@@ -24,4 +24,24 @@ object AssetHolder {
             Log.i("AssetHolder", "AssetManagerHolder is already initialized.")
         }
     }
+
+    /**
+     * Initializes the asset manager for isolated processes (e.g. :callkeep_core) that have no
+     * Flutter engine attached. Uses a minimal FlutterAssets implementation that replicates the
+     * standard Flutter asset path convention ("flutter_assets/<name>"), allowing
+     * FlutterAssetManager to read assets from the APK and cache them to disk without a live engine.
+     */
+    @Synchronized
+    fun initForIsolatedProcess(context: Context) {
+        if (_flutterAssetManager != null) return
+        val isolatedAssets = object : FlutterAssets {
+            override fun getAssetFilePathByName(asset: String) = "flutter_assets/$asset"
+            override fun getAssetFilePathByName(asset: String, packageName: String) =
+                "flutter_assets/packages/$packageName/$asset"
+            override fun getAssetFilePathBySubpath(subpath: String) = "flutter_assets/$subpath"
+            override fun getAssetFilePathBySubpath(subpath: String, packageName: String) =
+                "flutter_assets/packages/$packageName/$subpath"
+        }
+        _flutterAssetManager = FlutterAssetManager(context, isolatedAssets)
+    }
 }


### PR DESCRIPTION
## What

Adds `AssetHolder.initForIsolatedProcess(context)` — a static method that provides a minimal `FlutterAssets` implementation for OS processes that run without a live `FlutterEngine`.

The implementation uses the standard Flutter asset path convention (`flutter_assets/<name>`) so `FlutterAssetManager` can resolve assets (e.g. custom ringtone paths) without requiring a full engine initialisation.

## Why

When `PhoneConnectionService` moves to the `:callkeep_core` process (upcoming PR), no `FlutterEngine` will be available in that process. This method will be called from `PhoneConnectionService.onCreate()` at that point.

Adding the method now is safe — it is unused until the process isolation PR lands.

## Test plan

- [ ] Existing `AssetHolder` usage compiles and behaves identically
- [ ] `flutter analyze` passes in `webtrit_callkeep_android`