### PR TITLE
fix(android): make terminateWithCause idempotent by always dispatching broadcast

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -1,0 +1,412 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const _options = CallkeepOptions(
+  ios: CallkeepIOSOptions(
+    localizedName: 'Integration Tests',
+    maximumCallGroups: 2,
+    maximumCallsPerCallGroup: 1,
+    supportedHandleTypes: {CallkeepHandleType.number},
+  ),
+  android: CallkeepAndroidOptions(),
+);
+
+const _handle1 = CallkeepHandle.number('380000000000');
+const _handle2 = CallkeepHandle.number('380000000001');
+
+// Each test gets fresh IDs to avoid CALL_ID_ALREADY_TERMINATED from prior runs.
+// Android ConnectionManager keeps terminated connections in its registry until
+// the process restarts, so reusing IDs across setUp/tearDown cycles fails.
+var _idCounter = 0;
+String _nextId() => 'stress-${_idCounter++}';
+
+// ---------------------------------------------------------------------------
+// Recording delegate
+// ---------------------------------------------------------------------------
+
+class _RecordingDelegate implements CallkeepDelegate {
+  final answerCallIds = <String>[];
+  final endCallIds = <String>[];
+  final didPushEvents = <({String callId, CallkeepIncomingCallError? error})>[];
+
+  void Function(String callId)? onPerformAnswerCall;
+  void Function(String callId)? onPerformEndCall;
+
+  @override
+  void continueStartCallIntent(
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+  ) {}
+
+  @override
+  void didPushIncomingCall(
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+    String callId,
+    CallkeepIncomingCallError? error,
+  ) {
+    didPushEvents.add((callId: callId, error: error));
+  }
+
+  @override
+  void didActivateAudioSession() {}
+
+  @override
+  void didDeactivateAudioSession() {}
+
+  @override
+  void didReset() {}
+
+  @override
+  Future<bool> performStartCall(
+    String callId,
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+  ) =>
+      Future.value(true);
+
+  @override
+  Future<bool> performAnswerCall(String callId) {
+    answerCallIds.add(callId);
+    onPerformAnswerCall?.call(callId);
+    return Future.value(true);
+  }
+
+  @override
+  Future<bool> performEndCall(String callId) {
+    endCallIds.add(callId);
+    onPerformEndCall?.call(callId);
+    return Future.value(true);
+  }
+
+  @override
+  Future<bool> performSetHeld(String callId, bool onHold) => Future.value(true);
+
+  @override
+  Future<bool> performSetMuted(String callId, bool muted) => Future.value(true);
+
+  @override
+  Future<bool> performSendDTMF(String callId, String key) => Future.value(true);
+
+  @override
+  Future<bool> performAudioDeviceSet(
+    String callId,
+    CallkeepAudioDevice device,
+  ) =>
+      Future.value(true);
+
+  @override
+  Future<bool> performAudioDevicesUpdate(
+    String callId,
+    List<CallkeepAudioDevice> devices,
+  ) =>
+      Future.value(true);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Callkeep callkeep;
+  late _RecordingDelegate delegate;
+
+  setUp(() async {
+    callkeep = Callkeep();
+    delegate = _RecordingDelegate();
+    callkeep.setDelegate(delegate);
+    await callkeep.setUp(_options);
+  });
+
+  tearDown(() async {
+    callkeep.setDelegate(null);
+    try {
+      await callkeep.tearDown();
+    } catch (_) {
+      // already torn down in a test
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // setUp / tearDown lifecycle
+  // -------------------------------------------------------------------------
+
+  group('setUp / tearDown lifecycle', () {
+    test('isSetUp returns true after setUp', () async {
+      expect(await callkeep.isSetUp(), isTrue);
+    });
+
+    test('tearDown then re-setUp works', () async {
+      await callkeep.tearDown();
+      await callkeep.setUp(_options);
+      expect(await callkeep.isSetUp(), isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reportNewIncomingCall - deduplication
+  // -------------------------------------------------------------------------
+
+  group('reportNewIncomingCall - deduplication', () {
+    test('fresh call ID succeeds', () async {
+      final id = _nextId();
+
+      final err = await callkeep.reportNewIncomingCall(
+        id,
+        _handle1,
+        displayName: 'Call 1',
+      );
+      expect(err, isNull);
+    });
+
+    test('second report with same ID returns callIdAlreadyExists', () async {
+      final id = _nextId();
+
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call');
+      final err = await callkeep.reportNewIncomingCall(
+        id,
+        _handle1,
+        displayName: 'Call',
+      );
+
+      expect(err, CallkeepIncomingCallError.callIdAlreadyExists);
+    });
+
+    test('spam 4x same ID - only first succeeds', () async {
+      final id = _nextId();
+      final results = <CallkeepIncomingCallError?>[];
+
+      for (var i = 0; i < 4; i++) {
+        results.add(
+          await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call'),
+        );
+      }
+
+      expect(results[0], isNull, reason: 'first call must succeed');
+      for (final err in results.sublist(1)) {
+        expect(err, isNotNull, reason: 'subsequent calls must return an error');
+      }
+    });
+
+    test('two different call IDs both succeed', () async {
+      final id1 = _nextId();
+      final id2 = _nextId();
+
+      final err1 = await callkeep.reportNewIncomingCall(
+        id1,
+        _handle1,
+        displayName: 'Call 1',
+      );
+      final err2 = await callkeep.reportNewIncomingCall(
+        id2,
+        _handle2,
+        displayName: 'Call 2',
+      );
+
+      expect(err1, isNull);
+      expect(err2, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Call lifecycle - answer and end via Dart API
+  // -------------------------------------------------------------------------
+
+  group('call lifecycle', () {
+    test('answerCall triggers performAnswerCall callback', () async {
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+      final completer = Completer<String>();
+      delegate.onPerformAnswerCall = completer.complete;
+
+      await callkeep.answerCall(id);
+
+      final answeredId = await completer.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => throw TimeoutException('performAnswerCall not fired'),
+      );
+      expect(answeredId, id);
+    });
+
+    test('endCall on incoming call triggers performEndCall callback', () async {
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+      final completer = Completer<String>();
+      delegate.onPerformEndCall = completer.complete;
+
+      await callkeep.endCall(id);
+
+      final endedId = await completer.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => throw TimeoutException('performEndCall not fired'),
+      );
+      expect(endedId, id);
+    });
+
+    test('endCall after answerCall triggers performEndCall', () async {
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+      final answerCompleter = Completer<String>();
+      delegate.onPerformAnswerCall = answerCompleter.complete;
+      await callkeep.answerCall(id);
+      await answerCompleter.future.timeout(const Duration(seconds: 5));
+
+      final endCompleter = Completer<String>();
+      delegate.onPerformEndCall = endCompleter.complete;
+      await callkeep.endCall(id);
+
+      final endedId = await endCompleter.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => throw TimeoutException('performEndCall not fired'),
+      );
+      expect(endedId, id);
+    });
+
+    test('endCall twice - second call returns error, delegate fires once', () async {
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+      final completer = Completer<String>();
+      delegate.onPerformEndCall = completer.complete;
+      await callkeep.endCall(id);
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      // Second endCall on an already-ended call must not throw
+      final secondErr = await callkeep.endCall(id);
+      expect(delegate.endCallIds.length, 1);
+      expect(secondErr, isNotNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stress - rapid succession
+  // -------------------------------------------------------------------------
+
+  group('stress - rapid succession', () {
+    test('report two calls then end both - each performEndCall fires once', () async {
+      final id1 = _nextId();
+      final id2 = _nextId();
+
+      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
+      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+
+      final endedIds = <String>[];
+      final latch = Completer<void>();
+      var count = 0;
+      delegate.onPerformEndCall = (id) {
+        endedIds.add(id);
+        count++;
+        if (count == 2) latch.complete();
+      };
+
+      await callkeep.endCall(id1);
+      await callkeep.endCall(id2);
+
+      await latch.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw TimeoutException('not all performEndCall fired: $endedIds'),
+      );
+
+      expect(endedIds, containsAll([id1, id2]));
+      expect(endedIds.length, 2);
+    });
+
+    test('spam same ID concurrently - exactly one succeeds', () async {
+      final id = _nextId();
+      final futures = List.generate(
+        4,
+        (_) => callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Call'),
+      );
+      final results = await Future.wait(futures);
+
+      final successes = results.where((e) => e == null).length;
+      expect(successes, 1, reason: 'exactly one concurrent report must succeed');
+    });
+
+    test('tearDown while calls are active triggers performEndCall for each', () async {
+      final id1 = _nextId();
+      final id2 = _nextId();
+
+      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
+      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+
+      await callkeep.tearDown();
+
+      // Give callbacks time to arrive after tearDown
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(delegate.endCallIds, containsAll([id1, id2]));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stress - push + direct (Android only)
+  // -------------------------------------------------------------------------
+
+  group('stress - push + direct (Android only)', () {
+    test('push then direct same ID - direct returns callIdAlreadyExists', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+
+      AndroidCallkeepServices.backgroundPushNotificationBootstrapService
+          .reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+      // Give the push path time to register the connection
+      await Future.delayed(const Duration(milliseconds: 300));
+
+      final err = await callkeep.reportNewIncomingCall(
+        id,
+        _handle1,
+        displayName: 'Call',
+      );
+
+      expect(err, CallkeepIncomingCallError.callIdAlreadyExists);
+    });
+
+    test('mixed push + direct spam 3x same ID - system stays stable', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+
+      for (var i = 0; i < 3; i++) {
+        AndroidCallkeepServices.backgroundPushNotificationBootstrapService
+            .reportNewIncomingCall(id, _handle1, displayName: 'Call');
+
+        final err = await callkeep.reportNewIncomingCall(
+          id,
+          _handle1,
+          displayName: 'Call',
+        );
+
+        expect(err, isNotNull);
+      }
+
+      // tearDown must not throw even after spam
+      await callkeep.tearDown();
+      expect(await callkeep.isSetUp(), isFalse);
+    });
+  });
+}

--- a/webtrit_callkeep/example/pubspec.yaml
+++ b/webtrit_callkeep/example/pubspec.yaml
@@ -26,6 +26,10 @@ dev_dependencies:
   build_runner: ^2.10.1
   freezed: ^3.2.3
   flutter_lints: ^6.0.0
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -3,6 +3,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group 'com.webtrit.callkeep'
 version '1.0-SNAPSHOT'
 
+// Read flutter.sdk from local.properties when present (e.g. standalone test runs).
+def flutterSdkPath = null
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    def localProperties = new Properties()
+    localPropertiesFile.withInputStream { localProperties.load(it) }
+    flutterSdkPath = localProperties.getProperty("flutter.sdk")
+}
+
 buildscript {
     ext.kotlin_version = '2.2.21'
     repositories {
@@ -57,7 +66,16 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
     implementation "androidx.work:work-runtime-ktx:2.11.0"
+    implementation "androidx.core:core-ktx:1.16.0"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
+
+    // Flutter engine jar — required for io.flutter.* references in main sources.
+    // Provided by the Flutter tools Gradle plugin when building inside a Flutter app;
+    // added explicitly here so standalone `./gradlew testDebugUnitTest` works too.
+    if (flutterSdkPath) {
+        compileOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")
+        testRuntimeOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")
+    }
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -128,6 +128,12 @@ class ConnectionManager {
             val manager = PhoneConnectionService.connectionManager
 
             when {
+                // A call with this ID was already sent to Telecom but onCreateIncomingConnection
+                // has not fired yet. Block the duplicate before it reaches Telecom.
+                PhoneConnectionService.pendingCallIds.contains(metadata.callId) -> {
+                    onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS))
+                }
+
                 manager.isConnectionDisconnected(metadata.callId) -> {
                     onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED))
                 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -14,15 +14,42 @@ class ConnectionManager {
     // Guards the async gap between addNewIncomingCall() and connection creation.
     private val pendingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
-    fun addPending(callId: String) {
-        pendingCallIds.add(callId)
+    /**
+     * Atomically validates that a call ID can be added and reserves it as pending.
+     *
+     * Returns null on success (call ID was free and is now reserved).
+     * Returns an error enum if the call ID is already pending, disconnected, or active.
+     *
+     * Using a single lock for check+reserve prevents a race where two concurrent
+     * reportNewIncomingCall calls both see isPending=false and both proceed.
+     */
+    fun checkAndReservePending(callId: String): PIncomingCallErrorEnum? {
+        synchronized(connectionResourceLock) {
+            return when {
+                pendingCallIds.contains(callId) ->
+                    PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS
+
+                connections[callId]?.state == Connection.STATE_DISCONNECTED ->
+                    PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED
+
+                connections.containsKey(callId) ->
+                    if (connections[callId]?.hasAnswered == true) {
+                        PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS_AND_ANSWERED
+                    } else {
+                        PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS
+                    }
+
+                else -> {
+                    pendingCallIds.add(callId)
+                    null
+                }
+            }
+        }
     }
 
     fun removePending(callId: String) {
         pendingCallIds.remove(callId)
     }
-
-    fun isPending(callId: String): Boolean = pendingCallIds.contains(callId)
 
     // TODO(Serdun): The current modifier is incorrect; this method is public but should be restricted.
     // Consider limiting its accessibility to the connection service only.
@@ -101,7 +128,6 @@ class ConnectionManager {
         }
     }
 
-
     fun cleanConnections() {
         synchronized(connectionResourceLock) {
             connections.values.forEach { it.destroy() }
@@ -139,32 +165,11 @@ class ConnectionManager {
         fun validateConnectionAddition(
             metadata: CallMetadata, onSuccess: () -> Unit, onError: (PIncomingCallError) -> Unit
         ) {
-            val manager = PhoneConnectionService.connectionManager
+            val errorEnum = PhoneConnectionService.connectionManager
+                .checkAndReservePending(metadata.callId)
 
-            when {
-                // A call with this ID was already sent to Telecom but onCreateIncomingConnection
-                // has not fired yet. Block the duplicate before it reaches Telecom.
-                manager.isPending(metadata.callId) -> {
-                    onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS))
-                }
-
-                manager.isConnectionDisconnected(metadata.callId) -> {
-                    onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED))
-                }
-
-                manager.isConnectionAlreadyExists(metadata.callId) -> {
-                    val errorEnum = if (manager.isConnectionAnswered(metadata.callId)) {
-                        PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS_AND_ANSWERED
-                    } else {
-                        PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS
-                    }
-                    onError(PIncomingCallError(errorEnum))
-                }
-
-                else -> {
-                    onSuccess()
-                }
-            }
+            if (errorEnum == null) onSuccess()
+            else onError(PIncomingCallError(errorEnum))
         }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -10,6 +10,20 @@ class ConnectionManager {
     private val connections: ConcurrentHashMap<String, PhoneConnection> = ConcurrentHashMap()
     private val connectionResourceLock = Any()
 
+    // Call IDs sent to Telecom but not yet registered via onCreateIncomingConnection.
+    // Guards the async gap between addNewIncomingCall() and connection creation.
+    private val pendingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    fun addPending(callId: String) {
+        pendingCallIds.add(callId)
+    }
+
+    fun removePending(callId: String) {
+        pendingCallIds.remove(callId)
+    }
+
+    fun isPending(callId: String): Boolean = pendingCallIds.contains(callId)
+
     // TODO(Serdun): The current modifier is incorrect; this method is public but should be restricted.
     // Consider limiting its accessibility to the connection service only.
     @Synchronized
@@ -130,7 +144,7 @@ class ConnectionManager {
             when {
                 // A call with this ID was already sent to Telecom but onCreateIncomingConnection
                 // has not fired yet. Block the duplicate before it reaches Telecom.
-                PhoneConnectionService.pendingCallIds.contains(metadata.callId) -> {
+                manager.isPending(metadata.callId) -> {
                     onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS))
                 }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -653,8 +653,8 @@ class PhoneConnection internal constructor(
     /**
      * Maps a [DisconnectCause] to the corresponding [ConnectionPerform] broadcast event.
      *
-     * [DisconnectCause.REMOTE] indicates the remote party ended the call → [ConnectionPerform.DeclineCall].
-     * All other causes (local hang-up, rejection, timeout, etc.) → [ConnectionPerform.HungUp].
+     * [DisconnectCause.REMOTE] maps to [ConnectionPerform.DeclineCall].
+     * All other causes (local hang-up, rejection, timeout, etc.) map to [ConnectionPerform.HungUp].
      */
     private fun eventForDisconnectCause(cause: DisconnectCause?): ConnectionPerform =
         if (cause?.code == DisconnectCause.REMOTE) ConnectionPerform.DeclineCall
@@ -663,21 +663,13 @@ class PhoneConnection internal constructor(
     /**
      * Terminates the connection with the given [disconnectCause].
      *
-     * Uses the Telecom framework's own [state] as the single source of truth to guard
-     * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
-     * This removes the need for a separate `disconnected` flag that would duplicate
-     * state already tracked by the framework.
+     * Uses [state] as the guard: if the connection is not yet [STATE_DISCONNECTED], runs
+     * the full cleanup via [setDisconnected] and [onDisconnect]. If already disconnected,
+     * skips cleanup and re-dispatches the broadcast using the stored [disconnectCause] so
+     * late-arriving consumers (e.g. a one-shot endCall confirmation receiver) still receive
+     * teardown confirmation without waiting for a timeout.
      *
-     * The confirmation broadcast ([ConnectionPerform.HungUp] /
-     * [ConnectionPerform.DeclineCall]) is **always dispatched**, even when the connection
-     * was already in [STATE_DISCONNECTED] by the time this method is called. This covers
-     * the race where the remote party hangs up just before the local side initiates
-     * teardown: the original broadcast fires before any listener registers, so re-sending
-     * it ensures late-arriving consumers (e.g. a one-shot endCall confirmation receiver)
-     * still receive teardown confirmation.
-     *
-     * All broadcast consumers are expected to be idempotent — they receive the event and
-     * decide themselves whether it is still relevant.
+     * All broadcast consumers are expected to be idempotent.
      *
      * @param disconnectCause The reason for disconnection.
      */

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -157,12 +157,7 @@ class PhoneConnection internal constructor(
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
 
-        val event = if (disconnectCause?.code == DisconnectCause.REMOTE) {
-            ConnectionPerform.DeclineCall
-        } else {
-            ConnectionPerform.HungUp
-        }
-        dispatcher(event, metadata)
+        dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
     }
@@ -656,11 +651,21 @@ class PhoneConnection internal constructor(
     }
 
     /**
+     * Maps a [DisconnectCause] to the corresponding [ConnectionPerform] broadcast event.
+     *
+     * [DisconnectCause.REMOTE] indicates the remote party ended the call → [ConnectionPerform.DeclineCall].
+     * All other causes (local hang-up, rejection, timeout, etc.) → [ConnectionPerform.HungUp].
+     */
+    private fun eventForDisconnectCause(cause: DisconnectCause?): ConnectionPerform =
+        if (cause?.code == DisconnectCause.REMOTE) ConnectionPerform.DeclineCall
+        else ConnectionPerform.HungUp
+
+    /**
      * Terminates the connection with the given [disconnectCause].
      *
      * Uses the Telecom framework's own [state] as the single source of truth to guard
      * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
-     * This removes the need for a separate [disconnected] flag that would duplicate
+     * This removes the need for a separate `disconnected` flag that would duplicate
      * state already tracked by the framework.
      *
      * The confirmation broadcast ([ConnectionPerform.HungUp] /
@@ -684,12 +689,7 @@ class PhoneConnection internal constructor(
             logger.v("terminateWithCause: already disconnected for callId: $callId")
             // Re-dispatch using the original stored cause so consumers receive the same
             // event that was fired during the first disconnect.
-            val event = if (this.disconnectCause?.code == DisconnectCause.REMOTE) {
-                ConnectionPerform.DeclineCall
-            } else {
-                ConnectionPerform.HungUp
-            }
-            dispatcher(event, metadata)
+            dispatcher(eventForDisconnectCause(this.disconnectCause), metadata)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -39,7 +39,6 @@ class PhoneConnection internal constructor(
 ) : Connection() {
     private var isMute = false
     private var isHasSpeaker = false
-    private var disconnected = false
 
     /**
      * Tracks whether the speaker was manually disabled by the user.
@@ -657,15 +656,40 @@ class PhoneConnection internal constructor(
     }
 
     /**
-     * Safely terminates the connection with a reason and prevents double-termination.
+     * Terminates the connection with the given [disconnectCause].
+     *
+     * Uses the Telecom framework's own [state] as the single source of truth to guard
+     * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
+     * This removes the need for a separate [disconnected] flag that would duplicate
+     * state already tracked by the framework.
+     *
+     * The confirmation broadcast ([ConnectionPerform.HungUp] /
+     * [ConnectionPerform.DeclineCall]) is **always dispatched**, even when the connection
+     * was already in [STATE_DISCONNECTED] by the time this method is called. This covers
+     * the race where the remote party hangs up just before the local side initiates
+     * teardown: the original broadcast fires before any listener registers, so re-sending
+     * it ensures late-arriving consumers (e.g. a one-shot endCall confirmation receiver)
+     * still receive teardown confirmation.
+     *
+     * All broadcast consumers are expected to be idempotent — they receive the event and
+     * decide themselves whether it is still relevant.
+     *
+     * @param disconnectCause The reason for disconnection.
      */
     fun terminateWithCause(disconnectCause: DisconnectCause) {
-        if (!disconnected) {
-            disconnected = true
+        if (state != STATE_DISCONNECTED) {
             setDisconnected(disconnectCause)
             onDisconnect()
         } else {
             logger.v("terminateWithCause: already disconnected for callId: $callId")
+            // Re-dispatch using the original stored cause so consumers receive the same
+            // event that was fired during the first disconnect.
+            val event = if (this.disconnectCause?.code == DisconnectCause.REMOTE) {
+                ConnectionPerform.DeclineCall
+            } else {
+                ConnectionPerform.HungUp
+            }
+            dispatcher(event, metadata)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import java.util.concurrent.ConcurrentHashMap
 import android.telecom.Connection
 import android.telecom.ConnectionRequest
 import android.telecom.ConnectionService
@@ -164,8 +163,8 @@ class PhoneConnectionService : ConnectionService() {
     ): Connection {
         val metadata = CallMetadata.fromBundle(request.extras)
 
-        // Remove from pending set: connection is now being handled by Telecom.
-        pendingCallIds.remove(metadata.callId)
+        // Remove from pending: connection is now being handled by Telecom.
+        connectionManager.removePending(metadata.callId)
 
         // Check if a connection with the same ID already exists.
         // This can occur if receivers from both the activity and the service
@@ -209,7 +208,7 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?
     ) {
         val callMetadata = CallMetadata.fromBundleOrNull(request?.extras ?: Bundle.EMPTY)
-        callMetadata?.callId?.let { pendingCallIds.remove(it) }
+        callMetadata?.callId?.let { connectionManager.removePending(it) }
 
         val failureContext = "onCreateIncomingConnectionFailed"
         val failureMessage = "$failureContext: $connectionManagerPhoneAccount $request"
@@ -277,11 +276,6 @@ class PhoneConnectionService : ConnectionService() {
             }
 
         var connectionManager: ConnectionManager = ConnectionManager()
-
-        // Call IDs that have been sent to Telecom but not yet registered in connectionManager.
-        // Prevents rapid duplicate reportNewIncomingCall calls from bypassing validation
-        // during the async gap between addNewIncomingCall() and onCreateIncomingConnection().
-        val pendingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
         fun startAnswerCall(context: Context, metadata: CallMetadata) {
             communicate(context, ServiceAction.AnswerCall, metadata)
@@ -380,7 +374,7 @@ class PhoneConnectionService : ConnectionService() {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
-                pendingCallIds.add(metadata.callId)
+                connectionManager.addPending(metadata.callId)
                 TelephonyUtils(context).addNewIncomingCall(metadata)
                 onSuccess()
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -374,7 +374,6 @@ class PhoneConnectionService : ConnectionService() {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
-                connectionManager.addPending(metadata.callId)
                 TelephonyUtils(context).addNewIncomingCall(metadata)
                 onSuccess()
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import java.util.concurrent.ConcurrentHashMap
 import android.telecom.Connection
 import android.telecom.ConnectionRequest
 import android.telecom.ConnectionService
@@ -163,6 +164,9 @@ class PhoneConnectionService : ConnectionService() {
     ): Connection {
         val metadata = CallMetadata.fromBundle(request.extras)
 
+        // Remove from pending set: connection is now being handled by Telecom.
+        pendingCallIds.remove(metadata.callId)
+
         // Check if a connection with the same ID already exists.
         // This can occur if receivers from both the activity and the service
         // trigger the incoming call flow simultaneously.
@@ -205,6 +209,7 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?
     ) {
         val callMetadata = CallMetadata.fromBundleOrNull(request?.extras ?: Bundle.EMPTY)
+        callMetadata?.callId?.let { pendingCallIds.remove(it) }
 
         val failureContext = "onCreateIncomingConnectionFailed"
         val failureMessage = "$failureContext: $connectionManagerPhoneAccount $request"
@@ -272,6 +277,11 @@ class PhoneConnectionService : ConnectionService() {
             }
 
         var connectionManager: ConnectionManager = ConnectionManager()
+
+        // Call IDs that have been sent to Telecom but not yet registered in connectionManager.
+        // Prevents rapid duplicate reportNewIncomingCall calls from bypassing validation
+        // during the async gap between addNewIncomingCall() and onCreateIncomingConnection().
+        val pendingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
         fun startAnswerCall(context: Context, metadata: CallMetadata) {
             communicate(context, ServiceAction.AnswerCall, metadata)
@@ -370,6 +380,7 @@ class PhoneConnectionService : ConnectionService() {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
+                pendingCallIds.add(metadata.callId)
                 TelephonyUtils(context).addNewIncomingCall(metadata)
                 onSuccess()
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
@@ -48,9 +48,9 @@ class ConnectionManagerTest {
     @Before
     fun setUp() {
         ContextHolder.init(context)
-        // Reset the global manager and pending set used by validateConnectionAddition
+        // Reset the global manager used by validateConnectionAddition.
+        // A fresh ConnectionManager also clears the pending set.
         PhoneConnectionService.connectionManager = createManager()
-        PhoneConnectionService.pendingCallIds.clear()
     }
 
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
@@ -48,8 +48,9 @@ class ConnectionManagerTest {
     @Before
     fun setUp() {
         ContextHolder.init(context)
-        // Reset the global manager used by validateConnectionAddition
+        // Reset the global manager and pending set used by validateConnectionAddition
         PhoneConnectionService.connectionManager = createManager()
+        PhoneConnectionService.pendingCallIds.clear()
     }
 
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
@@ -1,0 +1,279 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Context
+import android.os.Build
+import android.telecom.Connection
+import android.telecom.DisconnectCause
+import com.webtrit.callkeep.PIncomingCallErrorEnum
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [ConnectionManager].
+ *
+ * Covers connection storage, state-based queries, duplicate guards,
+ * and the [ConnectionManager.validateConnectionAddition] factory logic.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class ConnectionManagerTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+    private val noop: PerformDispatchHandle = { _, _ -> }
+    private val noopCallback: (PhoneConnection) -> Unit = {}
+
+    private fun createManager() = ConnectionManager()
+
+    private fun createRingingConnection(callId: String = "call-1"): PhoneConnection =
+        PhoneConnection.createIncomingPhoneConnection(
+            context = context,
+            dispatcher = noop,
+            metadata = CallMetadata(callId = callId),
+            onDisconnect = noopCallback,
+        )
+
+    @Before
+    fun setUp() {
+        ContextHolder.init(context)
+        // Reset the global manager used by validateConnectionAddition
+        PhoneConnectionService.connectionManager = createManager()
+    }
+
+    // -------------------------------------------------------------------------
+    // addConnection / getConnection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `addConnection stores connection retrievable by callId`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+
+        manager.addConnection("call-1", conn)
+
+        assertSame(conn, manager.getConnection("call-1"))
+    }
+
+    @Test
+    fun `getConnection returns null for unknown callId`() {
+        assertNull(createManager().getConnection("missing"))
+    }
+
+    @Test
+    fun `addConnection does not overwrite an existing entry for the same callId`() {
+        val manager = createManager()
+        val first = createRingingConnection()
+        val second = createRingingConnection()
+
+        manager.addConnection("call-1", first)
+        manager.addConnection("call-1", second)
+
+        assertSame("first connection must be preserved", first, manager.getConnection("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // isConnectionAlreadyExists
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isConnectionAlreadyExists returns true after add`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertTrue(manager.isConnectionAlreadyExists("call-1"))
+    }
+
+    @Test
+    fun `isConnectionAlreadyExists returns false for unknown callId`() {
+        assertFalse(createManager().isConnectionAlreadyExists("unknown"))
+    }
+
+    // -------------------------------------------------------------------------
+    // isExistsIncomingConnection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isExistsIncomingConnection returns true when a ringing connection is present`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertTrue(manager.isExistsIncomingConnection())
+    }
+
+    @Test
+    fun `isExistsIncomingConnection returns false when manager is empty`() {
+        assertFalse(createManager().isExistsIncomingConnection())
+    }
+
+    @Test
+    fun `isExistsIncomingConnection returns false when all connections are disconnected`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        manager.addConnection("call-1", conn)
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertFalse(manager.isExistsIncomingConnection())
+    }
+
+    // -------------------------------------------------------------------------
+    // isConnectionDisconnected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isConnectionDisconnected returns false for a ringing connection`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertFalse(manager.isConnectionDisconnected("call-1"))
+    }
+
+    @Test
+    fun `isConnectionDisconnected returns true after setDisconnected`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        manager.addConnection("call-1", conn)
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+        assertTrue(manager.isConnectionDisconnected("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // getConnections (active only)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getConnections excludes disconnected connections`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        manager.addConnection("call-1", conn)
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertTrue("disconnected connection must not appear in active list", manager.getConnections().isEmpty())
+    }
+
+    @Test
+    fun `getConnections includes ringing connection`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        manager.addConnection("call-1", conn)
+
+        assertEquals(1, manager.getConnections().size)
+        assertSame(conn, manager.getConnections().first())
+    }
+
+    // -------------------------------------------------------------------------
+    // getActiveConnection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getActiveConnection returns null when no connection is in STATE_ACTIVE`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertNull(manager.getActiveConnection())
+    }
+
+    // -------------------------------------------------------------------------
+    // isConnectionAnswered
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isConnectionAnswered returns false for a freshly created connection`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertFalse(manager.isConnectionAnswered("call-1"))
+    }
+
+    @Test
+    fun `isConnectionAnswered returns false for unknown callId`() {
+        assertFalse(createManager().isConnectionAnswered("unknown"))
+    }
+
+    // -------------------------------------------------------------------------
+    // cleanConnections
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `cleanConnections empties the manager`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection("call-1"))
+        manager.addConnection("call-2", createRingingConnection("call-2"))
+
+        manager.cleanConnections()
+
+        assertFalse(manager.isConnectionAlreadyExists("call-1"))
+        assertFalse(manager.isConnectionAlreadyExists("call-2"))
+    }
+
+    // -------------------------------------------------------------------------
+    // validateConnectionAddition
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `validateConnectionAddition calls onSuccess for a brand-new callId`() {
+        var success = false
+        ConnectionManager.validateConnectionAddition(
+            metadata = CallMetadata(callId = "new-call"),
+            onSuccess = { success = true },
+            onError = { },
+        )
+        assertTrue(success)
+    }
+
+    @Test
+    fun `validateConnectionAddition calls onError TERMINATED for a disconnected callId`() {
+        val manager = createManager()
+        val conn = createRingingConnection("call-1")
+        manager.addConnection("call-1", conn)
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+        PhoneConnectionService.connectionManager = manager
+
+        var errorEnum: PIncomingCallErrorEnum? = null
+        ConnectionManager.validateConnectionAddition(
+            metadata = CallMetadata(callId = "call-1"),
+            onSuccess = { },
+            onError = { errorEnum = it.value },
+        )
+
+        assertEquals(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED, errorEnum)
+    }
+
+    @Test
+    fun `validateConnectionAddition calls onError ALREADY_EXISTS for an active ringing callId`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection("call-1"))
+        PhoneConnectionService.connectionManager = manager
+
+        var errorEnum: PIncomingCallErrorEnum? = null
+        ConnectionManager.validateConnectionAddition(
+            metadata = CallMetadata(callId = "call-1"),
+            onSuccess = { },
+            onError = { errorEnum = it.value },
+        )
+
+        assertEquals(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS, errorEnum)
+    }
+
+    @Test
+    fun `validateConnectionAddition error result is non-null`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection("call-1"))
+        PhoneConnectionService.connectionManager = manager
+
+        var errorResult: com.webtrit.callkeep.PIncomingCallError? = null
+        ConnectionManager.validateConnectionAddition(
+            metadata = CallMetadata(callId = "call-1"),
+            onSuccess = { },
+            onError = { errorResult = it },
+        )
+
+        assertNotNull(errorResult)
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionServiceDispatcherTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionServiceDispatcherTest.kt
@@ -1,0 +1,230 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Context
+import android.os.Build
+import android.telecom.DisconnectCause
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.ConnectionPerform
+import com.webtrit.callkeep.services.services.connection.dispatchers.ConnectionLifecycleAction
+import com.webtrit.callkeep.services.services.connection.dispatchers.PhoneConnectionServiceDispatcher
+import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [PhoneConnectionServiceDispatcher].
+ *
+ * Verifies that each [ServiceAction] is routed to the correct [PhoneConnection] method,
+ * that missing connections produce a [ConnectionPerform.ConnectionNotFound] fallback,
+ * and that lifecycle events (TearDown, ServiceDestroyed) clean up all active connections.
+ *
+ * [ActivityWakelockManager] and [ProximitySensorManager] are mocked so tests run without
+ * a real Activity or proximity sensor hardware.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class PhoneConnectionServiceDispatcherTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    private val capturedEvents = mutableListOf<ConnectionPerform>()
+    private val captureDispatcher: PerformDispatchHandle = { event, _ -> capturedEvents.add(event) }
+
+    private val wakelockManager: ActivityWakelockManager = mock()
+    private val proximitySensorManager: ProximitySensorManager = mock()
+
+    private lateinit var connectionManager: ConnectionManager
+    private lateinit var dispatcher: PhoneConnectionServiceDispatcher
+
+    @Before
+    fun setUp() {
+        ContextHolder.init(context)
+        capturedEvents.clear()
+        connectionManager = ConnectionManager()
+        dispatcher = PhoneConnectionServiceDispatcher(
+            connectionManager,
+            captureDispatcher,
+            wakelockManager,
+            proximitySensorManager,
+        )
+    }
+
+    private fun createRingingConnection(callId: String = "call-1"): PhoneConnection =
+        PhoneConnection.createIncomingPhoneConnection(
+            context = context,
+            dispatcher = captureDispatcher,
+            metadata = CallMetadata(callId = callId),
+            onDisconnect = {},
+        )
+
+    // -------------------------------------------------------------------------
+    // HungUpCall
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch HungUpCall calls hungUp on the matching connection`() {
+        val conn = spy(createRingingConnection())
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatch(ServiceAction.HungUpCall, CallMetadata(callId = "call-1"))
+
+        verify(conn).hungUp()
+    }
+
+    @Test
+    fun `dispatch HungUpCall for unknown callId dispatches ConnectionNotFound`() {
+        dispatcher.dispatch(ServiceAction.HungUpCall, CallMetadata(callId = "unknown"))
+
+        assertTrue(capturedEvents.contains(ConnectionPerform.ConnectionNotFound))
+    }
+
+    // -------------------------------------------------------------------------
+    // DeclineCall
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch DeclineCall calls declineCall on the matching connection`() {
+        val conn = spy(createRingingConnection())
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatch(ServiceAction.DeclineCall, CallMetadata(callId = "call-1"))
+
+        verify(conn).declineCall()
+    }
+
+    @Test
+    fun `dispatch DeclineCall for unknown callId dispatches ConnectionNotFound`() {
+        dispatcher.dispatch(ServiceAction.DeclineCall, CallMetadata(callId = "ghost"))
+
+        assertTrue(capturedEvents.contains(ConnectionPerform.ConnectionNotFound))
+    }
+
+    // -------------------------------------------------------------------------
+    // AnswerCall
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch AnswerCall calls onAnswer on the matching connection`() {
+        val conn = spy(createRingingConnection())
+        // onAnswer() calls ActivityHolder.start() which tries context.startActivity(null) in
+        // Robolectric because no launch activity is registered -- stub it to avoid the NPE.
+        doNothing().`when`(conn).onAnswer()
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatch(ServiceAction.AnswerCall, CallMetadata(callId = "call-1"))
+
+        verify(conn).onAnswer()
+    }
+
+    @Test
+    fun `dispatch AnswerCall for unknown callId dispatches ConnectionNotFound`() {
+        dispatcher.dispatch(ServiceAction.AnswerCall, CallMetadata(callId = "ghost"))
+
+        assertTrue(capturedEvents.contains(ConnectionPerform.ConnectionNotFound))
+    }
+
+    // -------------------------------------------------------------------------
+    // Muting
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch Muting true calls changeMuteState with true`() {
+        val conn = spy(createRingingConnection())
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatch(ServiceAction.Muting, CallMetadata(callId = "call-1", hasMute = true))
+
+        verify(conn).changeMuteState(true)
+    }
+
+    @Test
+    fun `dispatch Muting false calls changeMuteState with false`() {
+        val conn = spy(createRingingConnection())
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatch(ServiceAction.Muting, CallMetadata(callId = "call-1", hasMute = false))
+
+        verify(conn).changeMuteState(false)
+    }
+
+    // -------------------------------------------------------------------------
+    // TearDown
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch TearDown calls hungUp on every active connection`() {
+        val conn1 = spy(createRingingConnection("call-1"))
+        val conn2 = spy(createRingingConnection("call-2"))
+        connectionManager.addConnection("call-1", conn1)
+        connectionManager.addConnection("call-2", conn2)
+
+        dispatcher.dispatch(ServiceAction.TearDown, null)
+
+        verify(conn1).hungUp()
+        verify(conn2).hungUp()
+    }
+
+    @Test
+    fun `dispatch TearDown with no connections does not throw`() {
+        dispatcher.dispatch(ServiceAction.TearDown, null)
+        // no assertion needed -- must not throw
+    }
+
+    // -------------------------------------------------------------------------
+    // TearDown skips already-disconnected connections
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatch TearDown skips connections that are already disconnected`() {
+        val conn = spy(createRingingConnection())
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+        connectionManager.addConnection("call-1", conn)
+
+        // getConnections() filters out STATE_DISCONNECTED -- hungUp must not be called again
+        dispatcher.dispatch(ServiceAction.TearDown, null)
+
+        verify(conn, org.mockito.Mockito.never()).hungUp()
+    }
+
+    // -------------------------------------------------------------------------
+    // ConnectionNotFound fallback -- same callId, connection missing from manager
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ConnectionNotFound is dispatched exactly once for a single missing-connection action`() {
+        dispatcher.dispatch(ServiceAction.HungUpCall, CallMetadata(callId = "no-such-call"))
+
+        assertEquals(1, capturedEvents.count { it == ConnectionPerform.ConnectionNotFound })
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle: ServiceDestroyed
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `dispatchLifecycle ServiceDestroyed calls hungUp on all active connections`() {
+        val conn = spy(createRingingConnection())
+        connectionManager.addConnection("call-1", conn)
+
+        dispatcher.dispatchLifecycle(ConnectionLifecycleAction.ServiceDestroyed)
+
+        verify(conn).hungUp()
+    }
+
+    @Test
+    fun `dispatchLifecycle ServiceDestroyed with no connections does not throw`() {
+        dispatcher.dispatchLifecycle(ConnectionLifecycleAction.ServiceDestroyed)
+        // must not throw
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
@@ -1,0 +1,243 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Context
+import android.os.Build
+import android.telecom.Connection
+import android.telecom.DisconnectCause
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.ConnectionPerform
+import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [PhoneConnection.terminateWithCause] idempotency.
+ *
+ * Covers three scenarios:
+ * 1. Normal disconnect — first call triggers full cleanup and dispatches the correct event.
+ * 2. Already-disconnected (idempotent) — second call re-dispatches the original event without
+ *    repeating cleanup, using the stored [DisconnectCause] as the source of truth.
+ * 3. Race condition — remote hangup sets state to [Connection.STATE_DISCONNECTED] before
+ *    [terminateWithCause] is invoked; the re-dispatch prevents the 5-second endCall timeout.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class PhoneConnectionTerminateTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    // Captured dispatcher events — order matters for multi-call assertions.
+    private val dispatchedEvents = mutableListOf<ConnectionPerform>()
+    private val dispatcher: PerformDispatchHandle = { event, _ -> dispatchedEvents.add(event) }
+
+    // Count of onDisconnectCallback invocations.
+    private var disconnectCallbackCount = 0
+    private val onDisconnectCallback: (PhoneConnection) -> Unit = { disconnectCallbackCount++ }
+
+    @Before
+    fun setUp() {
+        // NotificationManager internally accesses ContextHolder; initialize before each test.
+        ContextHolder.init(context)
+        dispatchedEvents.clear()
+        disconnectCallbackCount = 0
+    }
+
+    /**
+     * Factory that mirrors [PhoneConnectionService] incoming-call setup:
+     * state starts as [Connection.STATE_RINGING].
+     */
+    private fun createRingingConnection(callId: String = "test-call"): PhoneConnection =
+        PhoneConnection.createIncomingPhoneConnection(
+            context = context,
+            dispatcher = dispatcher,
+            metadata = CallMetadata(callId = callId),
+            onDisconnect = onDisconnectCallback,
+        )
+
+    // -------------------------------------------------------------------------
+    // Group 1: Normal disconnect (state != STATE_DISCONNECTED)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `terminateWithCause LOCAL dispatches HungUp`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause REMOTE dispatches DeclineCall`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE))
+
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause REJECTED dispatches HungUp not DeclineCall`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REJECTED))
+
+        // REJECTED code != REMOTE → falls into the HungUp branch
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause transitions state to DISCONNECTED`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(Connection.STATE_DISCONNECTED, connection.state)
+    }
+
+    @Test
+    fun `terminateWithCause invokes onDisconnectCallback exactly once`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(1, disconnectCallbackCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 2: Already-disconnected path (idempotency)
+    //
+    // Uses setDisconnected() to force STATE_DISCONNECTED without going through
+    // the full onDisconnect() cleanup.  This isolates the else-branch behaviour.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `terminateWithCause when already DISCONNECTED with LOCAL stored — re-dispatches HungUp`() {
+        val connection = createRingingConnection()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause when already DISCONNECTED with REMOTE stored — re-dispatches DeclineCall`() {
+        val connection = createRingingConnection()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+
+        // Incoming cause is LOCAL, but stored cause is REMOTE — stored cause wins
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `double terminate — dispatcher called twice, onDisconnectCallback called once`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL)) // full path
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL)) // else branch
+
+        assertEquals(2, dispatchedEvents.size)
+        assertTrue(dispatchedEvents.all { it == ConnectionPerform.HungUp })
+        assertEquals("onDisconnectCallback must fire only once", 1, disconnectCallbackCount)
+    }
+
+    @Test
+    fun `stored REMOTE cause wins when second call arrives with LOCAL`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE)) // stores REMOTE
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))  // else branch
+
+        assertEquals(
+            "Both dispatches must use the original REMOTE cause",
+            listOf(ConnectionPerform.DeclineCall, ConnectionPerform.DeclineCall),
+            dispatchedEvents
+        )
+    }
+
+    @Test
+    fun `stored LOCAL cause wins when second call arrives with REMOTE`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))  // stores LOCAL
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE)) // else branch
+
+        assertEquals(
+            "Both dispatches must use the original LOCAL cause",
+            listOf(ConnectionPerform.HungUp, ConnectionPerform.HungUp),
+            dispatchedEvents
+        )
+    }
+
+    @Test
+    fun `already-disconnected else branch does NOT invoke onDisconnectCallback`() {
+        val connection = createRingingConnection()
+        // Force state without going through onDisconnect()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals("onDisconnect cleanup must not repeat", 0, disconnectCallbackCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 3: Race condition — the core bug
+    //
+    // Scenario: remote party hangs up → Telecom sets state to STATE_DISCONNECTED
+    // (stores the cause) before Flutter's endCall registers its BroadcastReceiver.
+    // Old code: terminateWithCause saw disconnected==true → no broadcast → 5 s timeout.
+    // New code: else branch re-dispatches using stored cause → instant confirmation.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `race — remote hangup before endCall — broadcast dispatched immediately`() {
+        val connection = createRingingConnection()
+
+        // TIME 0: Telecom notifies remote hangup, sets state to DISCONNECTED with REMOTE cause.
+        //         The HungUp/DeclineCall broadcast fired here, but Flutter's endCall receiver
+        //         was not registered yet (it registers later during endCall processing).
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+
+        // TIME 1: Flutter's endCall arrives and calls terminateWithCause.
+        //         Receiver is now registered, but the original broadcast was already missed.
+        //         terminateWithCause must re-dispatch so the receiver fires immediately.
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        // Broadcast fired — no 5-second timeout, endCall resolves immediately.
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `race — remote hangup before endCall — onDisconnectCallback not re-triggered`() {
+        val connection = createRingingConnection()
+
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        // onDisconnect() was never called (we used setDisconnected directly above),
+        // and the else branch must not call it either.
+        assertEquals(0, disconnectCallbackCount)
+    }
+
+    @Test
+    fun `race — local-hang-up stored before endCall arrives — HungUp dispatched`() {
+        val connection = createRingingConnection()
+
+        // Remote side hung up, but we model it as LOCAL this time (e.g. timeout-triggered)
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+}


### PR DESCRIPTION
## Pull request overview

Updates `PhoneConnection.terminateWithCause()` to make termination idempotent by using Telecom `Connection.state` as the guard for cleanup and by re-dispatching the disconnect broadcast when invoked after the connection is already disconnected (to address a race with late receiver registration).

**Changes:**
- Replace the custom “disconnected” guard with `state != STATE_DISCONNECTED` and factor disconnect-cause → broadcast mapping into a helper.
- Re-dispatch `HungUp`/`DeclineCall` when `terminateWithCause()` is called on an already-disconnected connection (using stored `disconnectCause`).
- Add Robolectric unit tests for normal disconnect, idempotent re-invocation, and the reported race; adjust Gradle to support standalone unit test runs.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated no comments.

| File | Description |
| ---- | ----------- |
| webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt | Makes `terminateWithCause()` idempotent and always broadcasts teardown confirmation; refactors event mapping. |
| webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt | Adds unit coverage for idempotency and race scenario behavior. |
| webtrit_callkeep_android/android/build.gradle | Adds dependencies/Flutter jar wiring intended to allow `testDebugUnitTest` outside a full Flutter build. |


<details>
<summary>Comments suppressed due to low confidence (1)</summary>

**webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt:692**
* `terminateWithCause` now skips `onDisconnect()` whenever `state == STATE_DISCONNECTED`. In this class there are code paths that set the state to DISCONNECTED without running the cleanup/destroy logic (e.g. `onReject()` calls `setDisconnected(...)` but does not call `onDisconnect()`), so a later `terminateWithCause()` call would no longer perform cleanup and could leave notifications/ringtone/resources around. Consider ensuring any path that calls `setDisconnected` also runs the cleanup exactly once (e.g. call `onDisconnect()`/`destroy()` from `onReject`, or introduce a dedicated `cleanupPerformed` flag set in `onDisconnect()` and use that to guard cleanup rather than `state`).
```
        }
    }

    /**
     * Implementation of [OutcomeReceiver] for monitoring endpoint switches.
     */
    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
    private inner class EndpointChangeReceiver(private val endpoint: CallEndpoint) :
```
</details>

