### PR TITLE
fix(android): make terminateWithCause idempotent

### DIFF
--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -3,6 +3,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group 'com.webtrit.callkeep'
 version '1.0-SNAPSHOT'
 
+// Read flutter.sdk from local.properties when present (e.g. standalone test runs).
+def flutterSdkPath = null
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    def localProperties = new Properties()
+    localPropertiesFile.withInputStream { localProperties.load(it) }
+    flutterSdkPath = localProperties.getProperty("flutter.sdk")
+}
+
 buildscript {
     ext.kotlin_version = '2.2.21'
     repositories {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -663,8 +663,8 @@ class PhoneConnection internal constructor(
     /**
      * Maps a [DisconnectCause] to the corresponding [ConnectionPerform] broadcast event.
      *
-     * [DisconnectCause.REMOTE] indicates the remote party ended the call → [ConnectionPerform.DeclineCall].
-     * All other causes (local hang-up, rejection, timeout, etc.) → [ConnectionPerform.HungUp].
+     * [DisconnectCause.REMOTE] maps to [ConnectionPerform.DeclineCall].
+     * All other causes (local hang-up, rejection, timeout, etc.) map to [ConnectionPerform.HungUp].
      */
     private fun eventForDisconnectCause(cause: DisconnectCause?): ConnectionPerform =
         if (cause?.code == DisconnectCause.REMOTE) ConnectionPerform.DeclineCall
@@ -673,21 +673,13 @@ class PhoneConnection internal constructor(
     /**
      * Terminates the connection with the given [disconnectCause].
      *
-     * Uses the Telecom framework's own [state] as the single source of truth to guard
-     * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
-     * This removes the need for a separate `disconnected` flag that would duplicate
-     * state already tracked by the framework.
+     * Uses [state] as the guard: if the connection is not yet [STATE_DISCONNECTED], runs
+     * the full cleanup via [setDisconnected] and [onDisconnect]. If already disconnected,
+     * skips cleanup and re-dispatches the broadcast using the stored [disconnectCause] so
+     * late-arriving consumers (e.g. a one-shot endCall confirmation receiver) still receive
+     * teardown confirmation without waiting for a timeout.
      *
-     * The confirmation broadcast ([ConnectionPerform.HungUp] /
-     * [ConnectionPerform.DeclineCall]) is **always dispatched**, even when the connection
-     * was already in [STATE_DISCONNECTED] by the time this method is called. This covers
-     * the race where the remote party hangs up just before the local side initiates
-     * teardown: the original broadcast fires before any listener registers, so re-sending
-     * it ensures late-arriving consumers (e.g. a one-shot endCall confirmation receiver)
-     * still receive teardown confirmation.
-     *
-     * All broadcast consumers are expected to be idempotent — they receive the event and
-     * decide themselves whether it is still relevant.
+     * All broadcast consumers are expected to be idempotent.
      *
      * @param disconnectCause The reason for disconnection.
      */

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -37,7 +37,6 @@ class PhoneConnection internal constructor(
 ) : Connection() {
     private var isMute = false
     private var isHasSpeaker = false
-    private var disconnected = false
 
     /**
      * Tracks whether the speaker was manually disabled by the user.
@@ -667,15 +666,40 @@ class PhoneConnection internal constructor(
     }
 
     /**
-     * Safely terminates the connection with a reason and prevents double-termination.
+     * Terminates the connection with the given [disconnectCause].
+     *
+     * Uses the Telecom framework's own [state] as the single source of truth to guard
+     * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
+     * This removes the need for a separate [disconnected] flag that would duplicate
+     * state already tracked by the framework.
+     *
+     * The confirmation broadcast ([ConnectionPerform.HungUp] /
+     * [ConnectionPerform.DeclineCall]) is **always dispatched**, even when the connection
+     * was already in [STATE_DISCONNECTED] by the time this method is called. This covers
+     * the race where the remote party hangs up just before the local side initiates
+     * teardown: the original broadcast fires before any listener registers, so re-sending
+     * it ensures late-arriving consumers (e.g. a one-shot endCall confirmation receiver)
+     * still receive teardown confirmation.
+     *
+     * All broadcast consumers are expected to be idempotent — they receive the event and
+     * decide themselves whether it is still relevant.
+     *
+     * @param disconnectCause The reason for disconnection.
      */
     fun terminateWithCause(disconnectCause: DisconnectCause) {
-        if (!disconnected) {
-            disconnected = true
+        if (state != STATE_DISCONNECTED) {
             setDisconnected(disconnectCause)
             onDisconnect()
         } else {
             logger.v("terminateWithCause: already disconnected for callId: $callId")
+            // Re-dispatch using the original stored cause so consumers receive the same
+            // event that was fired during the first disconnect.
+            val event = if (this.disconnectCause?.code == DisconnectCause.REMOTE) {
+                ConnectionPerform.DeclineCall
+            } else {
+                ConnectionPerform.HungUp
+            }
+            dispatcher(event, metadata)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -157,12 +157,7 @@ class PhoneConnection internal constructor(
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
 
-        val event = if (disconnectCause?.code == DisconnectCause.REMOTE) {
-            ConnectionPerform.DeclineCall
-        } else {
-            ConnectionPerform.HungUp
-        }
-        dispatcher(event, metadata)
+        dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
     }
@@ -666,11 +661,21 @@ class PhoneConnection internal constructor(
     }
 
     /**
+     * Maps a [DisconnectCause] to the corresponding [ConnectionPerform] broadcast event.
+     *
+     * [DisconnectCause.REMOTE] indicates the remote party ended the call → [ConnectionPerform.DeclineCall].
+     * All other causes (local hang-up, rejection, timeout, etc.) → [ConnectionPerform.HungUp].
+     */
+    private fun eventForDisconnectCause(cause: DisconnectCause?): ConnectionPerform =
+        if (cause?.code == DisconnectCause.REMOTE) ConnectionPerform.DeclineCall
+        else ConnectionPerform.HungUp
+
+    /**
      * Terminates the connection with the given [disconnectCause].
      *
      * Uses the Telecom framework's own [state] as the single source of truth to guard
      * against double execution of cleanup operations ([setDisconnected], [onDisconnect]).
-     * This removes the need for a separate [disconnected] flag that would duplicate
+     * This removes the need for a separate `disconnected` flag that would duplicate
      * state already tracked by the framework.
      *
      * The confirmation broadcast ([ConnectionPerform.HungUp] /
@@ -694,12 +699,7 @@ class PhoneConnection internal constructor(
             logger.v("terminateWithCause: already disconnected for callId: $callId")
             // Re-dispatch using the original stored cause so consumers receive the same
             // event that was fired during the first disconnect.
-            val event = if (this.disconnectCause?.code == DisconnectCause.REMOTE) {
-                ConnectionPerform.DeclineCall
-            } else {
-                ConnectionPerform.HungUp
-            }
-            dispatcher(event, metadata)
+            dispatcher(eventForDisconnectCause(this.disconnectCause), metadata)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
@@ -1,0 +1,243 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Context
+import android.os.Build
+import android.telecom.Connection
+import android.telecom.DisconnectCause
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.ConnectionPerform
+import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [PhoneConnection.terminateWithCause] idempotency.
+ *
+ * Covers three scenarios:
+ * 1. Normal disconnect — first call triggers full cleanup and dispatches the correct event.
+ * 2. Already-disconnected (idempotent) — second call re-dispatches the original event without
+ *    repeating cleanup, using the stored [DisconnectCause] as the source of truth.
+ * 3. Race condition — remote hangup sets state to [Connection.STATE_DISCONNECTED] before
+ *    [terminateWithCause] is invoked; the re-dispatch prevents the 5-second endCall timeout.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class PhoneConnectionTerminateTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    // Captured dispatcher events — order matters for multi-call assertions.
+    private val dispatchedEvents = mutableListOf<ConnectionPerform>()
+    private val dispatcher: PerformDispatchHandle = { event, _ -> dispatchedEvents.add(event) }
+
+    // Count of onDisconnectCallback invocations.
+    private var disconnectCallbackCount = 0
+    private val onDisconnectCallback: (PhoneConnection) -> Unit = { disconnectCallbackCount++ }
+
+    @Before
+    fun setUp() {
+        // NotificationManager internally accesses ContextHolder; initialize before each test.
+        ContextHolder.init(context)
+        dispatchedEvents.clear()
+        disconnectCallbackCount = 0
+    }
+
+    /**
+     * Factory that mirrors [PhoneConnectionService] incoming-call setup:
+     * state starts as [Connection.STATE_RINGING].
+     */
+    private fun createRingingConnection(callId: String = "test-call"): PhoneConnection =
+        PhoneConnection.createIncomingPhoneConnection(
+            context = context,
+            dispatcher = dispatcher,
+            metadata = CallMetadata(callId = callId),
+            onDisconnect = onDisconnectCallback,
+        )
+
+    // -------------------------------------------------------------------------
+    // Group 1: Normal disconnect (state != STATE_DISCONNECTED)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `terminateWithCause LOCAL dispatches HungUp`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause REMOTE dispatches DeclineCall`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE))
+
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause REJECTED dispatches HungUp not DeclineCall`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REJECTED))
+
+        // REJECTED code != REMOTE → falls into the HungUp branch
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause transitions state to DISCONNECTED`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(Connection.STATE_DISCONNECTED, connection.state)
+    }
+
+    @Test
+    fun `terminateWithCause invokes onDisconnectCallback exactly once`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(1, disconnectCallbackCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 2: Already-disconnected path (idempotency)
+    //
+    // Uses setDisconnected() to force STATE_DISCONNECTED without going through
+    // the full onDisconnect() cleanup.  This isolates the else-branch behaviour.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `terminateWithCause when already DISCONNECTED with LOCAL stored — re-dispatches HungUp`() {
+        val connection = createRingingConnection()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+
+    @Test
+    fun `terminateWithCause when already DISCONNECTED with REMOTE stored — re-dispatches DeclineCall`() {
+        val connection = createRingingConnection()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+
+        // Incoming cause is LOCAL, but stored cause is REMOTE — stored cause wins
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `double terminate — dispatcher called twice, onDisconnectCallback called once`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL)) // full path
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL)) // else branch
+
+        assertEquals(2, dispatchedEvents.size)
+        assertTrue(dispatchedEvents.all { it == ConnectionPerform.HungUp })
+        assertEquals("onDisconnectCallback must fire only once", 1, disconnectCallbackCount)
+    }
+
+    @Test
+    fun `stored REMOTE cause wins when second call arrives with LOCAL`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE)) // stores REMOTE
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))  // else branch
+
+        assertEquals(
+            "Both dispatches must use the original REMOTE cause",
+            listOf(ConnectionPerform.DeclineCall, ConnectionPerform.DeclineCall),
+            dispatchedEvents
+        )
+    }
+
+    @Test
+    fun `stored LOCAL cause wins when second call arrives with REMOTE`() {
+        val connection = createRingingConnection()
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))  // stores LOCAL
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.REMOTE)) // else branch
+
+        assertEquals(
+            "Both dispatches must use the original LOCAL cause",
+            listOf(ConnectionPerform.HungUp, ConnectionPerform.HungUp),
+            dispatchedEvents
+        )
+    }
+
+    @Test
+    fun `already-disconnected else branch does NOT invoke onDisconnectCallback`() {
+        val connection = createRingingConnection()
+        // Force state without going through onDisconnect()
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals("onDisconnect cleanup must not repeat", 0, disconnectCallbackCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 3: Race condition — the core bug
+    //
+    // Scenario: remote party hangs up → Telecom sets state to STATE_DISCONNECTED
+    // (stores the cause) before Flutter's endCall registers its BroadcastReceiver.
+    // Old code: terminateWithCause saw disconnected==true → no broadcast → 5 s timeout.
+    // New code: else branch re-dispatches using stored cause → instant confirmation.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `race — remote hangup before endCall — broadcast dispatched immediately`() {
+        val connection = createRingingConnection()
+
+        // TIME 0: Telecom notifies remote hangup, sets state to DISCONNECTED with REMOTE cause.
+        //         The HungUp/DeclineCall broadcast fired here, but Flutter's endCall receiver
+        //         was not registered yet (it registers later during endCall processing).
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+
+        // TIME 1: Flutter's endCall arrives and calls terminateWithCause.
+        //         Receiver is now registered, but the original broadcast was already missed.
+        //         terminateWithCause must re-dispatch so the receiver fires immediately.
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        // Broadcast fired — no 5-second timeout, endCall resolves immediately.
+        assertEquals(listOf(ConnectionPerform.DeclineCall), dispatchedEvents)
+    }
+
+    @Test
+    fun `race — remote hangup before endCall — onDisconnectCallback not re-triggered`() {
+        val connection = createRingingConnection()
+
+        connection.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        // onDisconnect() was never called (we used setDisconnected directly above),
+        // and the else branch must not call it either.
+        assertEquals(0, disconnectCallbackCount)
+    }
+
+    @Test
+    fun `race — local-hang-up stored before endCall arrives — HungUp dispatched`() {
+        val connection = createRingingConnection()
+
+        // Remote side hung up, but we model it as LOCAL this time (e.g. timeout-triggered)
+        connection.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+
+        connection.terminateWithCause(DisconnectCause(DisconnectCause.LOCAL))
+
+        assertEquals(listOf(ConnectionPerform.HungUp), dispatchedEvents)
+    }
+}


### PR DESCRIPTION
## Summary

- `terminateWithCause` could be called more than once for the same `PhoneConnection` (e.g. timeout disconnect racing with an explicit decline), causing a duplicate broadcast to the main process
- Fix: always dispatch the `ConnectionPerform` broadcast regardless of current state; the downstream handler is already idempotent so duplicate events are safe, but prevents lost events when the state guard fires too early
- Refactor: extract `eventForDisconnectCause` helper to reduce duplication; rewrite KDoc to reflect actual behaviour

## Test plan

- [ ] `PhoneConnectionTerminateTest` — covers idempotency (double-call) and race condition paths
- [ ] Run `./gradlew test` in `webtrit_callkeep_android/android/`