### PR TITLE
fix(android): guard full-screen intent behind isIncomingCallFullScreen option

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -23,7 +23,6 @@ object StorageDelegate {
     object Sound {
         private const val RINGTONE_PATH = "RINGTONE_PATH_KEY"
         private const val RINGBACK_PATH = "RINGBACK_PATH_KEY"
-        private const val INCOMING_CALL_FULL_SCREEN = "INCOMING_CALL_FULL_SCREEN"
 
         /** Persists [path] as the ringtone asset path. Passing `null` clears the stored value. */
         fun initRingtonePath(context: Context, path: String?) {
@@ -48,17 +47,21 @@ object StorageDelegate {
         fun getRingbackPath(context: Context): String? {
             return getSharedPreferences(context)?.getString(RINGBACK_PATH, null)
         }
+    }
+
+    object IncomingCall {
+        private const val FULL_SCREEN = "INCOMING_CALL_FULL_SCREEN"
 
         /** Persists whether incoming calls should launch in full-screen mode. Defaults to `true`. */
-        fun setIncomingCallFullScreen(context: Context, enabled: Boolean) {
+        fun setFullScreen(context: Context, enabled: Boolean) {
             getSharedPreferences(context)?.edit()?.apply {
-                putBoolean(INCOMING_CALL_FULL_SCREEN, enabled)
+                putBoolean(FULL_SCREEN, enabled)
                 apply()
             }
         }
 
-        fun isIncomingCallFullScreen(context: Context): Boolean {
-            return getSharedPreferences(context)?.getBoolean(INCOMING_CALL_FULL_SCREEN, true) ?: true
+        fun isFullScreen(context: Context): Boolean {
+            return getSharedPreferences(context)?.getBoolean(FULL_SCREEN, true) ?: true
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -72,7 +72,9 @@ class IncomingCallNotificationBuilder() : NotificationBuilder() {
 
         val builder = baseNotificationBuilder(title, description).apply {
             setOngoing(true)
-            setFullScreenIntent(buildOpenAppIntent(context), true)
+            if (StorageDelegate.Sound.isIncomingCallFullScreen(context)) {
+                setFullScreenIntent(buildOpenAppIntent(context), true)
+            }
         }
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -72,7 +72,7 @@ class IncomingCallNotificationBuilder() : NotificationBuilder() {
 
         val builder = baseNotificationBuilder(title, description).apply {
             setOngoing(true)
-            if (StorageDelegate.Sound.isIncomingCallFullScreen(context)) {
+            if (StorageDelegate.IncomingCall.isFullScreen(context)) {
                 setFullScreenIntent(buildOpenAppIntent(context), true)
             }
         }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateIncomingCallTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateIncomingCallTest.kt
@@ -1,0 +1,65 @@
+package com.webtrit.callkeep.common
+
+import android.content.Context
+import android.os.Build
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class StorageDelegateIncomingCallTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("COMMON_PREFERENCES", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    // -------------------------------------------------------------------------
+    // isFullScreen — default / set / get / toggle
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isFullScreen returns true by default when key is absent`() {
+        assertTrue(StorageDelegate.IncomingCall.isFullScreen(context))
+    }
+
+    @Test
+    fun `setFullScreen false is returned by isFullScreen`() {
+        StorageDelegate.IncomingCall.setFullScreen(context, false)
+        assertFalse(StorageDelegate.IncomingCall.isFullScreen(context))
+    }
+
+    @Test
+    fun `setFullScreen true is returned by isFullScreen`() {
+        StorageDelegate.IncomingCall.setFullScreen(context, true)
+        assertTrue(StorageDelegate.IncomingCall.isFullScreen(context))
+    }
+
+    @Test
+    fun `setFullScreen can be toggled from false to true`() {
+        StorageDelegate.IncomingCall.setFullScreen(context, false)
+        assertFalse(StorageDelegate.IncomingCall.isFullScreen(context))
+
+        StorageDelegate.IncomingCall.setFullScreen(context, true)
+        assertTrue(StorageDelegate.IncomingCall.isFullScreen(context))
+    }
+
+    @Test
+    fun `setFullScreen can be toggled from true to false`() {
+        StorageDelegate.IncomingCall.setFullScreen(context, true)
+        assertTrue(StorageDelegate.IncomingCall.isFullScreen(context))
+
+        StorageDelegate.IncomingCall.setFullScreen(context, false)
+        assertFalse(StorageDelegate.IncomingCall.isFullScreen(context))
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateSoundTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateSoundTest.kt
@@ -3,9 +3,7 @@ package com.webtrit.callkeep.common
 import android.content.Context
 import android.os.Build
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,46 +24,6 @@ class StorageDelegateSoundTest {
         // and do not inherit state written by a previously executed test.
         context.getSharedPreferences("COMMON_PREFERENCES", Context.MODE_PRIVATE)
             .edit().clear().commit()
-    }
-
-    // -------------------------------------------------------------------------
-    // incomingCallFullScreen — default / set / get / toggle
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `isIncomingCallFullScreen returns true by default when key is absent`() {
-        // Fresh preferences (cleared in @Before) — key is not present.
-        assertTrue(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-    }
-
-    @Test
-    fun `setIncomingCallFullScreen false is returned by isIncomingCallFullScreen`() {
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, false)
-        assertFalse(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-    }
-
-    @Test
-    fun `setIncomingCallFullScreen true is returned by isIncomingCallFullScreen`() {
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, true)
-        assertTrue(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-    }
-
-    @Test
-    fun `setIncomingCallFullScreen can be toggled from false to true`() {
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, false)
-        assertFalse(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, true)
-        assertTrue(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-    }
-
-    @Test
-    fun `setIncomingCallFullScreen can be toggled from true to false`() {
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, true)
-        assertTrue(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, false)
-        assertFalse(StorageDelegate.Sound.isIncomingCallFullScreen(context))
     }
 
     // -------------------------------------------------------------------------
@@ -100,27 +58,5 @@ class StorageDelegateSoundTest {
         StorageDelegate.Sound.initRingbackPath(context, "/assets/ringback.mp3")
         StorageDelegate.Sound.initRingbackPath(context, null)
         assertNull(StorageDelegate.Sound.getRingbackPath(context))
-    }
-
-    // -------------------------------------------------------------------------
-    // Independence between keys
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `isIncomingCallFullScreen is independent from ringtone path`() {
-        StorageDelegate.Sound.initRingtonePath(context, "/path/to/ringtone.mp3")
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, false)
-
-        assertFalse(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-        assertEquals("/path/to/ringtone.mp3", StorageDelegate.Sound.getRingtonePath(context))
-    }
-
-    @Test
-    fun `isIncomingCallFullScreen is independent from ringback path`() {
-        StorageDelegate.Sound.initRingbackPath(context, "/path/to/ringback.mp3")
-        StorageDelegate.Sound.setIncomingCallFullScreen(context, false)
-
-        assertFalse(StorageDelegate.Sound.isIncomingCallFullScreen(context))
-        assertEquals("/path/to/ringback.mp3", StorageDelegate.Sound.getRingbackPath(context))
     }
 }


### PR DESCRIPTION
## Summary

- `setFullScreenIntent` in `IncomingCallNotificationBuilder.build()` was unconditional — the full-screen incoming-call UI always launched regardless of app configuration
- Wrap it in `StorageDelegate.Sound.isIncomingCallFullScreen(context)` so the flag stored by `setIncomingCallFullScreen()` (added in #157) actually controls the behaviour
- Default remains `true` — no behaviour change for existing apps that never set the flag

## Test plan

- [ ] Default (flag not set): incoming call shows full-screen UI as before
- [ ] `setIncomingCallFullScreen(false)`: incoming call shows notification only, no full-screen intent
- [ ] `setIncomingCallFullScreen(true)`: full-screen UI launches correctly