### PR TITLE
feat(android): introduce MainProcessConnectionTracker as connection state mirror

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
@@ -1,0 +1,555 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webtrit_callkeep/webtrit_callkeep.dart';
+
+// ---------------------------------------------------------------------------
+// ForegroundService / main-process signaling path — integration tests
+//
+// These tests cover the scenario where an incoming call arrives via the
+// main-process signaling path (ForegroundService.reportNewIncomingCall),
+// not via a push notification.
+//
+// Real-world flow (CallBloc._onCallSignalingEventIncoming):
+//   WebSocket incoming_call event received
+//   → CallBloc calls callkeep.reportNewIncomingCall()
+//   → ForegroundService.reportNewIncomingCall()
+//       calls tracker.addPending(callId)                   -- synchronous
+//       calls PhoneConnectionService.startIncomingCall()   -- async Telecom call
+//   → Telecom calls onCreateIncomingConnection()
+//       PhoneConnection is created                         -- synchronous on CS side
+//       DidPushIncomingCall broadcast sent via sendBroadcast() -- ASYNC delivery
+//   → CallBloc receives the SDP offer, calls callkeep.answerCall()
+//
+// The race condition:
+//   answerCall() may be called BEFORE the DidPushIncomingCall broadcast is
+//   delivered to ForegroundService. At that moment:
+//     tracker.exists(callId)   = false   (broadcast not yet processed)
+//     tracker.isPending(callId)= true    (addPending was called)
+//     connectionManager.getConnection() != null  (CS has the PhoneConnection)
+//
+//   The fix: check the CS connectionManager before falling back to the deferred
+//   answer path, so that answerCall works regardless of broadcast delivery timing.
+// ---------------------------------------------------------------------------
+
+const _options = CallkeepOptions(
+  ios: CallkeepIOSOptions(
+    localizedName: 'ForegroundService Tests',
+    maximumCallGroups: 2,
+    maximumCallsPerCallGroup: 1,
+    supportedHandleTypes: {CallkeepHandleType.number},
+  ),
+  android: CallkeepAndroidOptions(),
+);
+
+const _handle1 = CallkeepHandle.number('380002000000');
+const _handle2 = CallkeepHandle.number('380002000001');
+
+var _idCounter = 0;
+String _nextId() => 'fs-${_idCounter++}';
+
+// ---------------------------------------------------------------------------
+// Recording delegate
+// ---------------------------------------------------------------------------
+
+class _RecordingDelegate implements CallkeepDelegate {
+  final List<String> answerCallIds = [];
+  final List<String> endCallIds = [];
+
+  void Function(String callId)? onPerformAnswerCall;
+  void Function(String callId)? onPerformEndCall;
+
+  @override
+  void continueStartCallIntent(CallkeepHandle handle, String? displayName, bool video) {}
+
+  @override
+  void didPushIncomingCall(
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+    String callId,
+    CallkeepIncomingCallError? error,
+  ) {}
+
+  @override
+  void didActivateAudioSession() {}
+
+  @override
+  void didDeactivateAudioSession() {}
+
+  @override
+  void didReset() {}
+
+  @override
+  Future<bool> performStartCall(String callId, CallkeepHandle handle, String? displayName, bool video) =>
+      Future.value(true);
+
+  @override
+  Future<bool> performAnswerCall(String callId) {
+    answerCallIds.add(callId);
+    onPerformAnswerCall?.call(callId);
+    return Future.value(true);
+  }
+
+  @override
+  Future<bool> performEndCall(String callId) {
+    endCallIds.add(callId);
+    onPerformEndCall?.call(callId);
+    return Future.value(true);
+  }
+
+  @override
+  Future<bool> performSetHeld(String callId, bool onHold) => Future.value(true);
+
+  @override
+  Future<bool> performSetMuted(String callId, bool muted) => Future.value(true);
+
+  @override
+  Future<bool> performSendDTMF(String callId, String key) => Future.value(true);
+
+  @override
+  Future<bool> performAudioDeviceSet(String callId, CallkeepAudioDevice device) => Future.value(true);
+
+  @override
+  Future<bool> performAudioDevicesUpdate(String callId, List<CallkeepAudioDevice> devices) => Future.value(true);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Future<T> _waitFor<T>(Future<T> future, {String label = 'callback'}) {
+  return future.timeout(
+    const Duration(seconds: 10),
+    onTimeout: () => throw TimeoutException('$label did not fire within timeout'),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Callkeep callkeep;
+  late _RecordingDelegate delegate;
+  var globalTearDownNeeded = true;
+
+  setUp(() async {
+    globalTearDownNeeded = true;
+    callkeep = Callkeep();
+    delegate = _RecordingDelegate();
+    for (var attempt = 0; attempt < 10; attempt++) {
+      try {
+        await callkeep.setUp(_options);
+        break;
+      } catch (_) {
+        if (attempt == 9) rethrow;
+        await Future.delayed(const Duration(milliseconds: 300));
+      }
+    }
+    callkeep.setDelegate(delegate);
+  });
+
+  tearDown(() async {
+    callkeep.setDelegate(null);
+    if (globalTearDownNeeded) {
+      try {
+        await callkeep.tearDown().timeout(const Duration(seconds: 15));
+      } catch (_) {}
+    }
+    await Future.delayed(const Duration(milliseconds: 300));
+  });
+
+  // =========================================================================
+  // answerCall — broadcast-lag race condition
+  //
+  // answerCall() is called immediately after reportNewIncomingCall() returns,
+  // before the DidPushIncomingCall broadcast has been delivered to
+  // ForegroundService. The ForegroundService must fall back to the CS
+  // connectionManager to detect the PhoneConnection and answer immediately.
+  // =========================================================================
+
+  group('main-process signaling path — answerCall timing (Android only)', () {
+    test('answerCall immediately after reportNewIncomingCall fires performAnswerCall', () async {
+      // This is the primary regression test for the broadcast-lag bug.
+      // No delay between reportNewIncomingCall and answerCall — exercises the
+      // window where tracker.isPending(callId) is true but the CS already has
+      // the PhoneConnection.
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Alice');
+
+      final latch = Completer<String>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete(cid);
+      };
+
+      // No delay: answerCall is called before DidPushIncomingCall broadcast
+      // arrives — this is the race condition the fix addresses.
+      await callkeep.answerCall(id);
+
+      final answered = await _waitFor(latch.future, label: 'performAnswerCall (immediate)');
+      expect(answered, id);
+    });
+
+    test('answerCall after broadcast settles also fires performAnswerCall', () async {
+      // Verifies the normal (non-race) path still works after the fix.
+      // A short delay gives the DidPushIncomingCall broadcast time to arrive
+      // so tracker.exists() is true when answerCall() is called.
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Bob');
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      final latch = Completer<String>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete(cid);
+      };
+
+      await callkeep.answerCall(id);
+
+      final answered = await _waitFor(latch.future, label: 'performAnswerCall (after broadcast)');
+      expect(answered, id);
+    });
+
+    test('answerCall fires performAnswerCall exactly once', () async {
+      // Guards against double-answer: the tracker or deferred-answer path must
+      // not cause performAnswerCall to fire twice for a single answerCall().
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Charlie');
+
+      final latch = Completer<void>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete();
+      };
+
+      await callkeep.answerCall(id);
+      await _waitFor(latch.future, label: 'performAnswerCall');
+
+      // Wait briefly to allow any spurious second callback to arrive.
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(
+        delegate.answerCallIds.where((c) => c == id).length,
+        1,
+        reason: 'performAnswerCall must fire exactly once per answerCall()',
+      );
+    });
+
+    test('video call: answerCall immediately fires performAnswerCall', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Dave', hasVideo: true);
+
+      final latch = Completer<String>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete(cid);
+      };
+
+      await callkeep.answerCall(id);
+
+      final answered = await _waitFor(latch.future, label: 'performAnswerCall (video)');
+      expect(answered, id);
+    });
+  });
+
+  // =========================================================================
+  // endCall — main-process path
+  //
+  // Verifies that endCall fires performEndCall for calls registered via the
+  // main-process ForegroundService path, including immediately after
+  // reportNewIncomingCall (before broadcast delivery).
+  // =========================================================================
+
+  group('main-process signaling path — endCall (Android only)', () {
+    test('endCall immediately after reportNewIncomingCall fires performEndCall', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Eve');
+
+      final latch = Completer<String>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete(cid);
+      };
+
+      await callkeep.endCall(id);
+
+      final ended = await _waitFor(latch.future, label: 'performEndCall (immediate decline)');
+      expect(ended, id);
+      expect(delegate.answerCallIds, isEmpty);
+    });
+
+    test('endCall fires performEndCall exactly once', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Frank');
+
+      final latch = Completer<void>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete();
+      };
+
+      await callkeep.endCall(id);
+      await _waitFor(latch.future, label: 'performEndCall');
+
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(
+        delegate.endCallIds.where((c) => c == id).length,
+        1,
+        reason: 'performEndCall must fire exactly once per endCall()',
+      );
+    });
+
+    test('answer then endCall fires performEndCall once (not for answered call twice)', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Grace');
+
+      final answerLatch = Completer<void>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !answerLatch.isCompleted) answerLatch.complete();
+      };
+      await callkeep.answerCall(id);
+      await _waitFor(answerLatch.future, label: 'performAnswerCall');
+
+      final endLatch = Completer<String>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !endLatch.isCompleted) endLatch.complete(cid);
+      };
+      await callkeep.endCall(id);
+      await _waitFor(endLatch.future, label: 'performEndCall');
+
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(delegate.answerCallIds.where((c) => c == id).length, 1);
+      expect(delegate.endCallIds.where((c) => c == id).length, 1);
+    });
+  });
+
+  // =========================================================================
+  // tearDown — main-process path
+  //
+  // tearDown() must fire performEndCall for every active main-process call,
+  // including calls that were answered before the DidPushIncomingCall
+  // broadcast was delivered to ForegroundService.
+  // =========================================================================
+
+  group('main-process signaling path — tearDown (Android only)', () {
+    test('tearDown fires performEndCall for an unanswered main-process call', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      globalTearDownNeeded = false;
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Hank');
+
+      final latch = Completer<void>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !latch.isCompleted) latch.complete();
+      };
+
+      await callkeep.tearDown();
+      await _waitFor(latch.future, label: 'performEndCall on tearDown');
+
+      expect(
+        delegate.endCallIds.where((c) => c == id).length,
+        1,
+        reason: 'tearDown must fire performEndCall exactly once for the unanswered call',
+      );
+    });
+
+    test('tearDown fires performEndCall exactly once for an answered call', () async {
+      // Regression: with the stale-pending bug, tearDown fired performEndCall
+      // twice — once from tracker.getAll() and once from
+      // drainUnconnectedPendingCallIds() when the call was still in pendingCallIds.
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      globalTearDownNeeded = false;
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Irene');
+
+      final answerLatch = Completer<void>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !answerLatch.isCompleted) answerLatch.complete();
+      };
+      await callkeep.answerCall(id);
+      await _waitFor(answerLatch.future, label: 'performAnswerCall');
+
+      final endLatch = Completer<void>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !endLatch.isCompleted) endLatch.complete();
+      };
+
+      await callkeep.tearDown();
+      await _waitFor(endLatch.future, label: 'performEndCall on tearDown');
+
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(
+        delegate.endCallIds.where((c) => c == id).length,
+        1,
+        reason: 'tearDown must fire performEndCall exactly once, not twice',
+      );
+    });
+
+    test('tearDown fires performEndCall for every active main-process call', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      globalTearDownNeeded = false;
+      final id1 = _nextId();
+      final id2 = _nextId();
+
+      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Jack');
+      await Future.delayed(const Duration(milliseconds: 200));
+      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Kate');
+
+      final endedIds = <String>[];
+      final allDone = Completer<void>();
+      delegate.onPerformEndCall = (cid) {
+        if ({id1, id2}.contains(cid) && !endedIds.contains(cid)) {
+          endedIds.add(cid);
+          if (endedIds.length == 2 && !allDone.isCompleted) allDone.complete();
+        }
+      };
+
+      await callkeep.tearDown();
+      await _waitFor(allDone.future, label: 'both performEndCall on tearDown');
+      expect(endedIds, containsAll([id1, id2]));
+    });
+  });
+
+  // =========================================================================
+  // deduplication — main-process path
+  //
+  // When a call is already active (registered via ForegroundService), a
+  // second reportNewIncomingCall for the same callId must return an error.
+  // =========================================================================
+
+  group('main-process signaling path — deduplication (Android only)', () {
+    test('duplicate reportNewIncomingCall returns callIdAlreadyExists', () async {
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Leo');
+      await Future.delayed(const Duration(milliseconds: 400));
+
+      final err = await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Leo');
+      expect(
+        err,
+        CallkeepIncomingCallError.callIdAlreadyExists,
+        reason: 'second reportNewIncomingCall for the same callId must return callIdAlreadyExists',
+      );
+    });
+
+    test('answered call re-report returns callIdAlreadyExistsAndAnswered', () async {
+      // Regression: before the removePending fix, the stale pendingCallIds entry
+      // from the rejected re-report caused tearDown to fire performEndCall twice.
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Mia');
+
+      final answerLatch = Completer<void>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !answerLatch.isCompleted) answerLatch.complete();
+      };
+      await callkeep.answerCall(id);
+      await _waitFor(answerLatch.future, label: 'performAnswerCall');
+
+      final err = await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Mia');
+      expect(
+        err,
+        CallkeepIncomingCallError.callIdAlreadyExistsAndAnswered,
+        reason: 'reporting an already-answered callId must return callIdAlreadyExistsAndAnswered',
+      );
+    });
+
+    test('re-report after reject does not cause double performEndCall on tearDown', () async {
+      // Verifies that removePending() is called when CS rejects the re-report,
+      // so tearDown does not see the callId in both getAll() and
+      // drainUnconnectedPendingCallIds() and fire performEndCall twice.
+      if (!Platform.isAndroid) {
+        markTestSkipped('Android only');
+        return;
+      }
+
+      globalTearDownNeeded = false;
+      final id = _nextId();
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Nick');
+
+      final answerLatch = Completer<void>();
+      delegate.onPerformAnswerCall = (cid) {
+        if (cid == id && !answerLatch.isCompleted) answerLatch.complete();
+      };
+      await callkeep.answerCall(id);
+      await _waitFor(answerLatch.future, label: 'performAnswerCall');
+
+      // Simulate CallBloc arriving late with its own reportNewIncomingCall.
+      await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Nick');
+
+      final endLatch = Completer<void>();
+      delegate.onPerformEndCall = (cid) {
+        if (cid == id && !endLatch.isCompleted) endLatch.complete();
+      };
+
+      await callkeep.tearDown();
+      await _waitFor(endLatch.future, label: 'performEndCall on tearDown');
+
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      expect(
+        delegate.endCallIds.where((c) => c == id).length,
+        1,
+        reason: 'tearDown must fire performEndCall exactly once even after a rejected re-report',
+      );
+    });
+  });
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/ConnectionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/ConnectionsApi.kt
@@ -2,21 +2,24 @@ package com.webtrit.callkeep
 
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.toSignalingStatus
-import com.webtrit.callkeep.models.toPConnection
 import com.webtrit.callkeep.services.broadcaster.SignalingStatusBroadcaster
 import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.services.foreground.ForegroundService
 
 class ConnectionsApi() : PHostConnectionsApi {
     override fun getConnection(
         callId: String, callback: (Result<PCallkeepConnection?>) -> Unit
     ) {
-        val connection = PhoneConnectionService.connectionManager.getConnection(callId)
-        callback.invoke(Result.success(connection?.toPConnection()))
+        // Read from the main-process tracker instead of crossing to PhoneConnectionService.
+        val connection = ForegroundService.tracker.toPCallkeepConnection(callId)
+        callback.invoke(Result.success(connection))
     }
 
     override fun getConnections(callback: (Result<List<PCallkeepConnection>>) -> Unit) {
-        val connections = PhoneConnectionService.connectionManager.getConnections()
-        callback.invoke(Result.success(connections.mapNotNull { it.toPConnection() }))
+        // Read from the main-process tracker instead of crossing to PhoneConnectionService.
+        val connections = ForegroundService.tracker.getAll()
+            .mapNotNull { ForegroundService.tracker.toPCallkeepConnection(it.callId) }
+        callback.invoke(Result.success(connections))
     }
 
     override fun updateActivitySignalingStatus(
@@ -29,6 +32,8 @@ class ConnectionsApi() : PHostConnectionsApi {
     override fun cleanConnections(
         callback: (Result<Unit>) -> Unit
     ) {
+        // Clear both the tracker and the underlying ConnectionService state.
+        ForegroundService.tracker.clear()
         PhoneConnectionService.connectionManager.cleanConnections()
         callback(Result.success(Unit))
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -667,9 +667,10 @@ class ForegroundService : Service(), PHostApi {
         logger.d("handleCSReportConnectionHolding")
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
-            flutterDelegateApi?.performSetHeld(
-                callMetaData.callId, callMetaData.hasHold ?: false
-            ) {}
+            val onHold = callMetaData.hasHold ?: false
+            // Keep tracker state in sync so getConnections() reflects HOLDING / ACTIVE correctly.
+            tracker.markHeld(callMetaData.callId, onHold)
+            flutterDelegateApi?.performSetHeld(callMetaData.callId, onHold) {}
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -16,6 +16,7 @@ import androidx.annotation.Keep
 import com.webtrit.callkeep.PAudioDevice
 import com.webtrit.callkeep.PCallRequestError
 import com.webtrit.callkeep.PCallRequestErrorEnum
+import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PDelegateFlutterApi
 import com.webtrit.callkeep.PEndCallReason
 import com.webtrit.callkeep.PHandle
@@ -185,6 +186,10 @@ class ForegroundService : Service(), PHostApi {
         // This prevents duplicate receivers/timeouts if startCall() is invoked again with the same callId.
         pendingCallCleanupsByCallId.remove(callId)?.invoke()
 
+        // Register as pending so answerCall/endCall can locate this call via tracker
+        // before the outgoing connection is confirmed by ConnectionService.
+        tracker.addPending(callId, metadata)
+
         // Each outgoing call owns its own receiver + AtomicBoolean so that the callback
         // and performStartCall are invoked exactly once, regardless of whether the
         // ConnectionService responds before or after the timeout fires.
@@ -220,6 +225,8 @@ class ForegroundService : Service(), PHostApi {
                         val callMetaData = CallMetadata.fromBundle(intent.extras ?: return)
                         if (callMetaData.callId != callId) return
                         logger.i("$logContext: ongoing call confirmed by CS")
+                        // Outgoing call is now active in Telecom — promote from pending.
+                        tracker.promote(callMetaData.callId, callMetaData, PCallkeepConnectionState.STATE_DIALING)
                         flutterDelegateApi?.performStartCall(
                             callMetaData.callId,
                             callMetaData.handle!!.toPHandle(),
@@ -317,6 +324,10 @@ class ForegroundService : Service(), PHostApi {
             ringtonePath = ringtonePath
         )
 
+        // Register as pending before sending to Telecom so that answerCall() / endCall()
+        // issued before DidPushIncomingCall fires can locate the call via tracker.isPending().
+        tracker.addPending(callId, metadata)
+
         PhoneConnectionService.startIncomingCall(
             context = baseContext,
             metadata = metadata,
@@ -354,29 +365,39 @@ class ForegroundService : Service(), PHostApi {
         // legitimate broadcasts if callIds are ever reused.
         directNotifiedCallIds.clear()
 
-        val connections = PhoneConnectionService.connectionManager.getConnections()
-        connections.forEach { connection ->
-            val callId = connection.callId
-            // Register BEFORE hungUp() so the async HungUp broadcast is already suppressed
-            // by the time it arrives in handleCSReportDeclineCall.
+        // Step 1: Collect active call IDs from the tracker (promoted connections).
+        val activeCallIds = tracker.getAll().map { it.callId }
+
+        // Step 2: Drain pending calls that were registered with Telecom but whose
+        // PhoneConnection was never created (no DidPushIncomingCall received yet).
+        val unconnectedPending = tracker.drainUnconnectedPendingCallIds()
+
+        // Step 3: Notify Flutter for active connections. Register in directNotifiedCallIds
+        // BEFORE calling connection.hungUp() so the async HungUp broadcast is suppressed.
+        activeCallIds.forEach { callId ->
             directNotifiedCallIds.add(callId)
-            // Notify Flutter synchronously while this session's delegate is still set.
-            flutterDelegateApi?.performEndCall(callId) {}
-            // Trigger native cleanup (cancel notifications, ringtone, etc.).
-            connection.hungUp()
-        }
-
-        // Drain pending calls that never got a PhoneConnection object.
-        val unconnected = PhoneConnectionService.connectionManager.drainUnconnectedPendingCallIds()
-        unconnected.forEach { callId ->
             flutterDelegateApi?.performEndCall(callId) {}
         }
 
-        if (connections.isNotEmpty() || unconnected.isNotEmpty()) {
+        // Step 4: Notify Flutter for pending-only calls (no PhoneConnection to hang up on).
+        unconnectedPending.forEach { callId ->
+            flutterDelegateApi?.performEndCall(callId) {}
+        }
+
+        if (activeCallIds.isNotEmpty() || unconnectedPending.isNotEmpty()) {
             flutterDelegateApi?.didDeactivateAudioSession {}
         }
 
+        // Step 5: Native cleanup — still requires live PhoneConnection objects for hungUp().
+        // TODO(PR-9b): replace direct PhoneConnectionService access with IPC when
+        //   the `:callkeep_core` process split is implemented.
+        val connections = PhoneConnectionService.connectionManager.getConnections()
+        connections.forEach { connection -> connection.hungUp() }
+
         PhoneConnectionService.connectionManager.cleanConnections()
+
+        // Step 6: Reset tracker state for the next session.
+        tracker.clear()
 
         // Send TearDown intent to keep PhoneConnectionService alive for the next session.
         // Telecom unbinds ConnectionService when all connections are destroyed, and without
@@ -439,20 +460,22 @@ class ForegroundService : Service(), PHostApi {
     override fun answerCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit) {
         val metadata = CallMetadata(callId = callId)
         when {
-            PhoneConnectionService.connectionManager.isConnectionAlreadyExists(callId) -> {
-                logger.i("answerCall $callId: connection exists, answering immediately.")
+            tracker.exists(callId) -> {
+                logger.i("answerCall $callId: connection exists in tracker, answering immediately.")
                 PhoneConnectionService.startAnswerCall(baseContext, metadata)
                 callback.invoke(Result.success(null))
             }
-            PhoneConnectionService.connectionManager.isPending(callId) -> {
-                // onCreateIncomingConnection has not fired yet. Reserve the answer so that
-                // PhoneConnectionService applies it as soon as the connection is created.
-                logger.i("answerCall $callId: connection pending, deferring answer.")
+            tracker.isPending(callId) -> {
+                // DidPushIncomingCall has not arrived yet. Reserve the answer in both the
+                // tracker (main-process awareness) and the ConnectionService (so that
+                // onCreateIncomingConnection applies it immediately after creating the connection).
+                logger.i("answerCall $callId: connection pending in tracker, deferring answer.")
+                tracker.reserveAnswer(callId)
                 PhoneConnectionService.connectionManager.reserveAnswer(callId)
                 callback.invoke(Result.success(null))
             }
             else -> {
-                logger.e("answerCall: no connection or pending entry for callId=$callId")
+                logger.e("answerCall: no connection or pending entry for callId=$callId in tracker")
                 callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.INTERNAL)))
             }
         }
@@ -460,8 +483,8 @@ class ForegroundService : Service(), PHostApi {
 
     override fun endCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit) {
         logger.i("endCall $callId.")
-        if (PhoneConnectionService.connectionManager.isConnectionDisconnected(callId)) {
-            logger.w("endCall: connection $callId is already terminated.")
+        if (tracker.isTerminated(callId)) {
+            logger.w("endCall: connection $callId is already terminated (tracker).")
             callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.UNKNOWN_CALL_UUID)))
             return
         }
@@ -526,6 +549,8 @@ class ForegroundService : Service(), PHostApi {
         logger.d("handleCSReportDidPushIncomingCall")
         extras?.let {
             val metadata = CallMetadata.fromBundle(it)
+            // Promote from pending to fully registered incoming connection.
+            tracker.promote(metadata.callId, metadata, PCallkeepConnectionState.STATE_RINGING)
             flutterDelegateApi?.didPushIncomingCall(
                 handleArg = metadata.handle!!.toPHandle(),
                 displayNameArg = metadata.displayName,
@@ -551,6 +576,9 @@ class ForegroundService : Service(), PHostApi {
                 return@let
             }
 
+            // Update tracker: call has ended.
+            tracker.markTerminated(callId)
+
             flutterDelegateApi?.performEndCall(callId) {}
             flutterDelegateApi?.didDeactivateAudioSession {}
 
@@ -564,6 +592,8 @@ class ForegroundService : Service(), PHostApi {
         logger.d("handleCSReportAnswerCall")
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
+            // Update tracker: call has been answered.
+            tracker.markAnswered(callMetaData.callId)
             flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
             flutterDelegateApi?.didActivateAudioSession {}
         }
@@ -690,6 +720,17 @@ class ForegroundService : Service(), PHostApi {
         var isRunning = false
 
         private const val OUTGOING_CALL_TIMEOUT_MS = 5_000L
+
+        /**
+         * Main-process shadow of PhoneConnectionService connection state.
+         *
+         * Updated from [ConnectionServicePerformBroadcaster] events so that
+         * [ForegroundService] and [com.webtrit.callkeep.ConnectionsApi] can read
+         * connection state without crossing a process boundary.
+         *
+         * Must be reset via [MainProcessConnectionTracker.clear] at the end of [tearDown].
+         */
+        val tracker = MainProcessConnectionTracker()
     }
 }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -623,6 +623,9 @@ class ForegroundService : Service(), PHostApi {
         logger.d("handleCSReportAnswerCall")
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
+            // Consume any deferred answer reservation (set by the answerCall deferred path).
+            // This mirrors ConnectionManager.consumeAnswer so pendingAnswers does not leak.
+            tracker.consumeAnswer(callMetaData.callId)
             // Update tracker: call has been answered.
             tracker.markAnswered(callMetaData.callId)
             flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -383,8 +383,13 @@ class ForegroundService : Service(), PHostApi {
             flutterDelegateApi?.performEndCall(callId) {}
         }
 
-        // Step 4: Notify Flutter for pending-only calls (no PhoneConnection to hang up on).
+        // Step 4: Notify Flutter for pending-only calls.
+        // Register in directNotifiedCallIds BEFORE firing performEndCall so that any async
+        // HungUp broadcast from connection.hungUp() (Step 5) is suppressed — this happens
+        // when the deferred-answer path caused CS to create a PhoneConnection via reserveAnswer
+        // even though DidPushIncomingCall had not yet arrived and the callId was still pending.
         unconnectedPending.forEach { callId ->
+            directNotifiedCallIds.add(callId)
             flutterDelegateApi?.performEndCall(callId) {}
         }
 
@@ -463,38 +468,40 @@ class ForegroundService : Service(), PHostApi {
 
     override fun answerCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit) {
         val metadata = CallMetadata(callId = callId)
+        // DidPushIncomingCall is delivered via sendBroadcast() which is async. Between the
+        // moment CS creates the PhoneConnection and the moment the broadcast reaches
+        // ForegroundService, tracker.exists() is false even though the call is live on the
+        // CS side. This window hits both the main-process signaling path (addPending called
+        // in reportNewIncomingCall, but broadcast not yet delivered) and the push-path (no
+        // addPending at all). Resolution order:
+        //   1. tracker.exists()                         → promoted, answer immediately.
+        //   2. CS connectionManager has the connection  → broadcast lag, answer via CS.
+        //   3. tracker.isPending() && CS has no conn.  → PhoneConnection not yet created, defer.
+        //   4. none of the above                        → unknown call, return error.
+        // TODO(PR-9b): collapse steps 2-3 into a single IPC lookup when :callkeep_core splits.
+        val csConnection = PhoneConnectionService.connectionManager.getConnection(callId)
         when {
             tracker.exists(callId) -> {
                 logger.i("answerCall $callId: connection exists in tracker, answering immediately.")
                 PhoneConnectionService.startAnswerCall(baseContext, metadata)
                 callback.invoke(Result.success(null))
             }
+            csConnection != null -> {
+                logger.i("answerCall $callId: CS has connection (tracker broadcast lag), answering via CS.")
+                PhoneConnectionService.startAnswerCall(baseContext, metadata)
+                callback.invoke(Result.success(null))
+            }
             tracker.isPending(callId) -> {
-                // DidPushIncomingCall has not arrived yet. Reserve the answer in both the
-                // tracker (main-process awareness) and the ConnectionService (so that
-                // onCreateIncomingConnection applies it immediately after creating the connection).
-                logger.i("answerCall $callId: connection pending in tracker, deferring answer.")
+                // Telecom accepted the call but CS has not yet created the PhoneConnection.
+                // Reserve the answer so onCreateIncomingConnection can apply it immediately.
+                logger.i("answerCall $callId: pending in tracker, CS has no connection yet, deferring answer.")
                 tracker.reserveAnswer(callId)
                 PhoneConnectionService.connectionManager.reserveAnswer(callId)
                 callback.invoke(Result.success(null))
             }
             else -> {
-                // The tracker may not yet reflect this call if the DidPushIncomingCall
-                // broadcast (sent via sendBroadcast, which is async) has not been
-                // delivered to ForegroundService yet. This window exists for push-path
-                // calls that bypass tracker.addPending(). Fall back to the CS connection
-                // manager as the authoritative source while we are in a single process.
-                // TODO(PR-9b): replace this fallback with an IPC lookup when the
-                //   :callkeep_core process split is implemented.
-                val csHasCall = PhoneConnectionService.connectionManager.getConnection(callId) != null
-                if (csHasCall) {
-                    logger.w("answerCall $callId: not yet in tracker (broadcast lag), falling back to CS.")
-                    PhoneConnectionService.startAnswerCall(baseContext, metadata)
-                    callback.invoke(Result.success(null))
-                } else {
-                    logger.e("answerCall: no connection or pending entry for callId=$callId in tracker or CS")
-                    callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.INTERNAL)))
-                }
+                logger.e("answerCall: no connection or pending entry for callId=$callId in tracker or CS")
+                callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.INTERNAL)))
             }
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -212,6 +212,12 @@ class ForegroundService : Service(), PHostApi {
             if (!resolved.compareAndSet(false, true)) return
             pendingCallCleanupsByCallId.remove(callId)
             cancelResources()
+            // Remove from pending regardless of outcome. On the success path (OngoingCall)
+            // promote() has already removed the callId from pendingCallIds, so this is a
+            // no-op. On failure/timeout paths the pending entry would otherwise linger until
+            // tearDown(), causing drainUnconnectedPendingCallIds() to fire a spurious
+            // performEndCall and routing answerCall() into the deferred-answer path.
+            tracker.removePending(callId)
             callback(result)
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -332,7 +332,10 @@ class ForegroundService : Service(), PHostApi {
 
         // Register as pending before sending to Telecom so that answerCall() / endCall()
         // issued before DidPushIncomingCall fires can locate the call via tracker.isPending().
-        tracker.addPending(callId)
+        // addPending returns true only if this invocation actually inserted the entry, so the
+        // rollback in onError does not remove a concurrent genuine pending registration for the
+        // same callId (e.g. a second reportNewIncomingCall racing against the first).
+        val addedPending = tracker.addPending(callId)
 
         PhoneConnectionService.startIncomingCall(
             context = baseContext,
@@ -343,10 +346,10 @@ class ForegroundService : Service(), PHostApi {
             },
             onError = { error ->
                 logger.e("reportNewIncomingCall: startIncomingCall failed callId=$callId, error=$error")
-                // Roll back the pending entry: Telecom rejected the call, so it was never
-                // registered. Without this, drainUnconnectedPendingCallIds() would fire a
-                // spurious performEndCall during tearDown() for a call that never existed.
-                tracker.removePending(callId)
+                // Roll back the pending entry only if this invocation added it. This avoids
+                // removing a genuine pending entry registered by a concurrent first invocation
+                // when a duplicate call's error arrives.
+                if (addedPending) tracker.removePending(callId)
                 callback(Result.success(error))
             })
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -188,7 +188,7 @@ class ForegroundService : Service(), PHostApi {
 
         // Register as pending so answerCall/endCall can locate this call via tracker
         // before the outgoing connection is confirmed by ConnectionService.
-        tracker.addPending(callId, metadata)
+        tracker.addPending(callId)
 
         // Each outgoing call owns its own receiver + AtomicBoolean so that the callback
         // and performStartCall are invoked exactly once, regardless of whether the
@@ -326,7 +326,7 @@ class ForegroundService : Service(), PHostApi {
 
         // Register as pending before sending to Telecom so that answerCall() / endCall()
         // issued before DidPushIncomingCall fires can locate the call via tracker.isPending().
-        tracker.addPending(callId, metadata)
+        tracker.addPending(callId)
 
         PhoneConnectionService.startIncomingCall(
             context = baseContext,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -337,6 +337,10 @@ class ForegroundService : Service(), PHostApi {
             },
             onError = { error ->
                 logger.e("reportNewIncomingCall: startIncomingCall failed callId=$callId, error=$error")
+                // Roll back the pending entry: Telecom rejected the call, so it was never
+                // registered. Without this, drainUnconnectedPendingCallIds() would fire a
+                // spurious performEndCall during tearDown() for a call that never existed.
+                tracker.removePending(callId)
                 callback(Result.success(error))
             })
     }
@@ -475,8 +479,22 @@ class ForegroundService : Service(), PHostApi {
                 callback.invoke(Result.success(null))
             }
             else -> {
-                logger.e("answerCall: no connection or pending entry for callId=$callId in tracker")
-                callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.INTERNAL)))
+                // The tracker may not yet reflect this call if the DidPushIncomingCall
+                // broadcast (sent via sendBroadcast, which is async) has not been
+                // delivered to ForegroundService yet. This window exists for push-path
+                // calls that bypass tracker.addPending(). Fall back to the CS connection
+                // manager as the authoritative source while we are in a single process.
+                // TODO(PR-9b): replace this fallback with an IPC lookup when the
+                //   :callkeep_core process split is implemented.
+                val csHasCall = PhoneConnectionService.connectionManager.getConnection(callId) != null
+                if (csHasCall) {
+                    logger.w("answerCall $callId: not yet in tracker (broadcast lag), falling back to CS.")
+                    PhoneConnectionService.startAnswerCall(baseContext, metadata)
+                    callback.invoke(Result.success(null))
+                } else {
+                    logger.e("answerCall: no connection or pending entry for callId=$callId in tracker or CS")
+                    callback.invoke(Result.success(PCallRequestError(PCallRequestErrorEnum.INTERNAL)))
+                }
             }
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -52,9 +52,13 @@ class MainProcessConnectionTracker {
      * Register a call that has been sent to Telecom but whose [com.webtrit.callkeep.services.services.connection.PhoneConnection]
      * has not yet been created (i.e., between addNewIncomingCall / startOutgoingCall and
      * onCreateIncoming/OutgoingConnection).
+     *
+     * The call is intentionally NOT added to [connections] here — only to [pendingCallIds].
+     * This keeps [exists] returning false so that [ForegroundService.answerCall] correctly
+     * routes to the deferred-answer path ([reserveAnswer]) rather than attempting to answer
+     * a PhoneConnection that does not yet exist. [connections] is populated only in [promote].
      */
     fun addPending(callId: String, metadata: CallMetadata) {
-        connections[callId] = metadata
         pendingCallIds.add(callId)
     }
 
@@ -136,6 +140,19 @@ class MainProcessConnectionTracker {
     // -------------------------------------------------------------------------
 
     /**
+     * Remove [callId] from the pending set without touching any other state.
+     *
+     * Called when [com.webtrit.callkeep.services.services.foreground.ForegroundService.reportNewIncomingCall]
+     * receives an error from [com.webtrit.callkeep.services.services.connection.PhoneConnectionService]:
+     * the call was never actually registered with Telecom, so the pending entry must be
+     * rolled back to prevent [drainUnconnectedPendingCallIds] from firing a spurious
+     * performEndCall during the next [com.webtrit.callkeep.services.services.foreground.ForegroundService.tearDown].
+     */
+    fun removePending(callId: String) {
+        pendingCallIds.remove(callId)
+    }
+
+    /**
      * Reserve a deferred answer for [callId] before its [com.webtrit.callkeep.services.services.connection.PhoneConnection]
      * is created. Mirrors [com.webtrit.callkeep.services.services.connection.ConnectionManager.reserveAnswer].
      */
@@ -163,7 +180,6 @@ class MainProcessConnectionTracker {
     fun drainUnconnectedPendingCallIds(): Set<String> {
         val unconnected = pendingCallIds.toSet()
         pendingCallIds.clear()
-        unconnected.forEach { connections.remove(it) }
         return unconnected
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -59,6 +59,11 @@ class MainProcessConnectionTracker {
      * a PhoneConnection that does not yet exist. [connections] is populated only in [promote].
      */
     fun addPending(callId: String) {
+        // Reset any stale lifecycle state from a prior use of this callId in the same session.
+        // Without this, isTerminated() / isAnswered() could return true for a genuinely new call.
+        terminatedCallIds.remove(callId)
+        answeredCallIds.remove(callId)
+        pendingAnswers.remove(callId)
         pendingCallIds.add(callId)
     }
 
@@ -70,6 +75,11 @@ class MainProcessConnectionTracker {
      *   Use [PCallkeepConnectionState.STATE_RINGING] for incoming, [PCallkeepConnectionState.STATE_DIALING] for outgoing.
      */
     fun promote(callId: String, metadata: CallMetadata, state: PCallkeepConnectionState) {
+        // Reset stale lifecycle sets in case addPending was not called first (push-path),
+        // or in case this callId was reused without going through addPending.
+        terminatedCallIds.remove(callId)
+        answeredCallIds.remove(callId)
+        pendingAnswers.remove(callId)
         connections[callId] = metadata
         pendingCallIds.remove(callId)
         connectionStates[callId] = state

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -93,6 +93,7 @@ class MainProcessConnectionTracker {
         connections.remove(callId)
         answeredCallIds.remove(callId)
         pendingCallIds.remove(callId)
+        pendingAnswers.remove(callId)
         connectionStates[callId] = PCallkeepConnectionState.STATE_DISCONNECTED
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -94,6 +94,21 @@ class MainProcessConnectionTracker {
     }
 
     /**
+     * Update the hold state for [callId].
+     * Advances its state to [PCallkeepConnectionState.STATE_HOLDING] when [onHold] is true,
+     * or back to [PCallkeepConnectionState.STATE_ACTIVE] when false.
+     * This keeps [getConnections] in sync with the Telecom hold state so that callers never
+     * see a stale ACTIVE state for a held call.
+     */
+    fun markHeld(callId: String, onHold: Boolean) {
+        connectionStates[callId] = if (onHold) {
+            PCallkeepConnectionState.STATE_HOLDING
+        } else {
+            PCallkeepConnectionState.STATE_ACTIVE
+        }
+    }
+
+    /**
      * Mark [callId] as terminated. Removes it from the active connections map so that
      * subsequent [exists] / [getAll] calls exclude it, and records it in [terminatedCallIds]
      * so that [isTerminated] returns true for duplicate endCall guards.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -1,0 +1,182 @@
+package com.webtrit.callkeep.services.services.foreground
+
+import com.webtrit.callkeep.PCallkeepConnection
+import com.webtrit.callkeep.PCallkeepConnectionState
+import com.webtrit.callkeep.PCallkeepDisconnectCause
+import com.webtrit.callkeep.PCallkeepDisconnectCauseType
+import com.webtrit.callkeep.models.CallMetadata
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A lightweight shadow registry that mirrors [com.webtrit.callkeep.services.services.connection.PhoneConnectionService]
+ * connection state in the main process.
+ *
+ * Updated from broadcasts emitted by [com.webtrit.callkeep.services.services.connection.PhoneConnectionService]:
+ * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.DidPushIncomingCall] -> promote incoming
+ * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.AnswerCall]           -> markAnswered
+ * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.HungUp] /
+ *   [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.DeclineCall]          -> markTerminated
+ * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.OngoingCall]          -> promote outgoing
+ *
+ * This allows [ForegroundService] and [com.webtrit.callkeep.ConnectionsApi] to query connection
+ * state without crossing a process boundary. In the current single-process setup the tracker
+ * avoids tightly coupling to [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.connectionManager].
+ * When the `:callkeep_core` process split lands (PR-9b), only the broadcast wiring needs to
+ * change — all callers of this tracker remain unchanged.
+ */
+class MainProcessConnectionTracker {
+
+    // callId -> metadata for all known, non-terminated calls
+    private val connections = ConcurrentHashMap<String, CallMetadata>()
+
+    // callIds registered with Telecom but whose PhoneConnection has not yet been created
+    private val pendingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    // callIds that have been answered by the user
+    private val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    // callIds for which the call has fully terminated (guards duplicate endCall)
+    private val terminatedCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    // callIds for which answerCall was requested before the PhoneConnection was created
+    private val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    // last known Pigeon connection state per callId, kept for getConnections() queries
+    private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
+
+    // -------------------------------------------------------------------------
+    // Write operations — called from ForegroundService broadcast receiver
+    // -------------------------------------------------------------------------
+
+    /**
+     * Register a call that has been sent to Telecom but whose [com.webtrit.callkeep.services.services.connection.PhoneConnection]
+     * has not yet been created (i.e., between addNewIncomingCall / startOutgoingCall and
+     * onCreateIncoming/OutgoingConnection).
+     */
+    fun addPending(callId: String, metadata: CallMetadata) {
+        connections[callId] = metadata
+        pendingCallIds.add(callId)
+    }
+
+    /**
+     * Promote a pending call to a fully registered connection once the
+     * [com.webtrit.callkeep.services.services.connection.PhoneConnection] has been created.
+     *
+     * @param state the initial Telecom state reported for this call.
+     *   Use [PCallkeepConnectionState.STATE_RINGING] for incoming, [PCallkeepConnectionState.STATE_DIALING] for outgoing.
+     */
+    fun promote(callId: String, metadata: CallMetadata, state: PCallkeepConnectionState) {
+        connections[callId] = metadata
+        pendingCallIds.remove(callId)
+        connectionStates[callId] = state
+    }
+
+    /**
+     * Mark [callId] as answered and advance its state to [PCallkeepConnectionState.STATE_ACTIVE].
+     */
+    fun markAnswered(callId: String) {
+        answeredCallIds.add(callId)
+        connectionStates[callId] = PCallkeepConnectionState.STATE_ACTIVE
+    }
+
+    /**
+     * Mark [callId] as terminated. Removes it from the active connections map so that
+     * subsequent [exists] / [getAll] calls exclude it, and records it in [terminatedCallIds]
+     * so that [isTerminated] returns true for duplicate endCall guards.
+     */
+    fun markTerminated(callId: String) {
+        terminatedCallIds.add(callId)
+        connections.remove(callId)
+        answeredCallIds.remove(callId)
+        pendingCallIds.remove(callId)
+        connectionStates[callId] = PCallkeepConnectionState.STATE_DISCONNECTED
+    }
+
+    // -------------------------------------------------------------------------
+    // Read operations — replaces PhoneConnectionService.connectionManager.* reads
+    // -------------------------------------------------------------------------
+
+    /** Returns true if an active connection record exists for [callId]. */
+    fun exists(callId: String): Boolean = connections.containsKey(callId)
+
+    /** Returns true if [callId] is in pending state (Telecom notified, PhoneConnection not yet created). */
+    fun isPending(callId: String): Boolean = pendingCallIds.contains(callId)
+
+    /** Returns true if [callId] has been marked terminated. */
+    fun isTerminated(callId: String): Boolean = terminatedCallIds.contains(callId)
+
+    /** Returns true if [callId] has been answered. */
+    fun isAnswered(callId: String): Boolean = answeredCallIds.contains(callId)
+
+    /** Returns [CallMetadata] for [callId], or null if not tracked. */
+    fun get(callId: String): CallMetadata? = connections[callId]
+
+    /** Returns metadata for all active (non-terminated) calls. */
+    fun getAll(): List<CallMetadata> = connections.values.toList()
+
+    /** Returns the last known Pigeon connection state for [callId], or null if not tracked. */
+    fun getState(callId: String): PCallkeepConnectionState? = connectionStates[callId]
+
+    /**
+     * Constructs a [PCallkeepConnection] for [callId] using stored metadata and state.
+     * Returns null if [callId] is not currently tracked.
+     */
+    fun toPCallkeepConnection(callId: String): PCallkeepConnection? {
+        val metadata = connections[callId] ?: return null
+        val state = connectionStates[callId] ?: PCallkeepConnectionState.STATE_NEW
+        val disconnectCause = PCallkeepDisconnectCause(
+            type = PCallkeepDisconnectCauseType.UNKNOWN,
+            reason = "Unknown reason",
+        )
+        return PCallkeepConnection(callId = metadata.callId, state = state, disconnectCause = disconnectCause)
+    }
+
+    // -------------------------------------------------------------------------
+    // Deferred answer (mirrors ConnectionManager.reserveAnswer / consumeAnswer)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reserve a deferred answer for [callId] before its [com.webtrit.callkeep.services.services.connection.PhoneConnection]
+     * is created. Mirrors [com.webtrit.callkeep.services.services.connection.ConnectionManager.reserveAnswer].
+     */
+    fun reserveAnswer(callId: String) {
+        pendingAnswers.add(callId)
+    }
+
+    /**
+     * Consume and return whether a deferred answer was reserved for [callId].
+     * Returns true and removes the reservation; false if none existed.
+     */
+    fun consumeAnswer(callId: String): Boolean = pendingAnswers.remove(callId)
+
+    // -------------------------------------------------------------------------
+    // tearDown helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Drain all pending call IDs that have not yet been promoted to active connections.
+     * Used by [ForegroundService.tearDown] to fire performEndCall for calls that were
+     * sent to Telecom but whose PhoneConnection was never created.
+     *
+     * The drained IDs are removed from tracking; subsequent [isPending] calls return false.
+     */
+    fun drainUnconnectedPendingCallIds(): Set<String> {
+        val unconnected = pendingCallIds.toSet()
+        pendingCallIds.clear()
+        unconnected.forEach { connections.remove(it) }
+        return unconnected
+    }
+
+    /**
+     * Clear all tracked state. Called at the end of [ForegroundService.tearDown]
+     * after all Flutter notifications and native connection cleanup have been dispatched.
+     */
+    fun clear() {
+        connections.clear()
+        pendingCallIds.clear()
+        answeredCallIds.clear()
+        terminatedCallIds.clear()
+        pendingAnswers.clear()
+        connectionStates.clear()
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -58,7 +58,7 @@ class MainProcessConnectionTracker {
      * routes to the deferred-answer path ([reserveAnswer]) rather than attempting to answer
      * a PhoneConnection that does not yet exist. [connections] is populated only in [promote].
      */
-    fun addPending(callId: String, metadata: CallMetadata) {
+    fun addPending(callId: String) {
         pendingCallIds.add(callId)
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTracker.kt
@@ -58,13 +58,19 @@ class MainProcessConnectionTracker {
      * routes to the deferred-answer path ([reserveAnswer]) rather than attempting to answer
      * a PhoneConnection that does not yet exist. [connections] is populated only in [promote].
      */
-    fun addPending(callId: String) {
+    /**
+     * Returns true if [callId] was newly inserted into the pending set, false if it was already
+     * present. Callers can use this to determine whether they own the pending entry and should
+     * roll it back on error — avoiding a race where a second caller's error removes the first
+     * caller's genuine pending entry.
+     */
+    fun addPending(callId: String): Boolean {
         // Reset any stale lifecycle state from a prior use of this callId in the same session.
         // Without this, isTerminated() / isAnswered() could return true for a genuinely new call.
         terminatedCallIds.remove(callId)
         answeredCallIds.remove(callId)
         pendingAnswers.remove(callId)
-        pendingCallIds.add(callId)
+        return pendingCallIds.add(callId)
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -183,6 +183,15 @@ class MainProcessConnectionTrackerTest {
         assertEquals(PCallkeepConnectionState.STATE_DISCONNECTED, tracker.getState("call-1"))
     }
 
+    @Test
+    fun `markTerminated — clears pending answer reservation`() {
+        tracker.addPending("call-1")
+        tracker.reserveAnswer("call-1")
+        tracker.markTerminated("call-1")
+        // consumeAnswer must return false: reservation was cleared by markTerminated
+        assertFalse(tracker.consumeAnswer("call-1"))
+    }
+
     // -------------------------------------------------------------------------
     // getAll
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -193,6 +193,27 @@ class MainProcessConnectionTrackerTest {
     }
 
     // -------------------------------------------------------------------------
+    // markHeld
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `markHeld true — getState returns STATE_HOLDING`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        tracker.markHeld("call-1", true)
+        assertEquals(PCallkeepConnectionState.STATE_HOLDING, tracker.getState("call-1"))
+    }
+
+    @Test
+    fun `markHeld false — getState returns STATE_ACTIVE`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        tracker.markHeld("call-1", true)
+        tracker.markHeld("call-1", false)
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
     // getAll
     // -------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -44,6 +44,17 @@ class MainProcessConnectionTrackerTest {
     }
 
     @Test
+    fun `addPending — returns true when newly inserted`() {
+        assertTrue(tracker.addPending("call-1"))
+    }
+
+    @Test
+    fun `addPending — returns false when already pending`() {
+        tracker.addPending("call-1")
+        assertFalse(tracker.addPending("call-1"))
+    }
+
+    @Test
     fun `addPending — exists returns false before promote`() {
         // Pending calls are not in connections; only promote() populates connections.
         // This ensures answerCall routes to the deferred-answer path, not startAnswerCall.

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -1,0 +1,322 @@
+package com.webtrit.callkeep.services.services.foreground
+
+import android.os.Build
+import com.webtrit.callkeep.PCallkeepConnectionState
+import com.webtrit.callkeep.models.CallMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [MainProcessConnectionTracker].
+ *
+ * Covers the full call lifecycle: addPending -> promote -> markAnswered -> markTerminated,
+ * deferred-answer reservation, tearDown drain, and clear.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class MainProcessConnectionTrackerTest {
+
+    private lateinit var tracker: MainProcessConnectionTracker
+
+    private fun metadata(callId: String = "call-1") = CallMetadata(callId = callId)
+
+    @Before
+    fun setUp() {
+        tracker = MainProcessConnectionTracker()
+    }
+
+    // -------------------------------------------------------------------------
+    // addPending
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `addPending — isPending returns true`() {
+        tracker.addPending("call-1", metadata())
+        assertTrue(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `addPending — exists returns false before promote`() {
+        // A pending call is also stored in connections so exists() returns true;
+        // isPending() distinguishes it from a promoted connection.
+        tracker.addPending("call-1", metadata())
+        // exists() tracks all known calls including pending
+        assertTrue(tracker.exists("call-1"))
+    }
+
+    @Test
+    fun `addPending — isTerminated returns false`() {
+        tracker.addPending("call-1", metadata())
+        assertFalse(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `addPending — get returns the metadata`() {
+        val meta = metadata("call-1")
+        tracker.addPending("call-1", meta)
+        assertEquals(meta, tracker.get("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // promote
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `promote — isPending becomes false`() {
+        tracker.addPending("call-1", metadata())
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `promote — exists returns true`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        assertTrue(tracker.exists("call-1"))
+    }
+
+    @Test
+    fun `promote — getState returns supplied state`() {
+        tracker.addPending("call-1", metadata())
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        assertEquals(PCallkeepConnectionState.STATE_RINGING, tracker.getState("call-1"))
+    }
+
+    @Test
+    fun `promote outgoing — getState returns STATE_DIALING`() {
+        tracker.addPending("call-out", metadata("call-out"))
+        tracker.promote("call-out", metadata("call-out"), PCallkeepConnectionState.STATE_DIALING)
+        assertEquals(PCallkeepConnectionState.STATE_DIALING, tracker.getState("call-out"))
+    }
+
+    @Test
+    fun `promote without prior addPending — still registers the call`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        assertTrue(tracker.exists("call-1"))
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // markAnswered
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `markAnswered — isAnswered returns true`() {
+        tracker.addPending("call-1", metadata())
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        assertTrue(tracker.isAnswered("call-1"))
+    }
+
+    @Test
+    fun `markAnswered — getState advances to STATE_ACTIVE`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
+    }
+
+    @Test
+    fun `markAnswered — exists remains true`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        assertTrue(tracker.exists("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // markTerminated
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `markTerminated — isTerminated returns true`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertTrue(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `markTerminated — exists returns false`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertFalse(tracker.exists("call-1"))
+    }
+
+    @Test
+    fun `markTerminated — isPending becomes false`() {
+        tracker.addPending("call-1", metadata())
+        tracker.markTerminated("call-1")
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `markTerminated — isAnswered becomes false`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        tracker.markTerminated("call-1")
+        assertFalse(tracker.isAnswered("call-1"))
+    }
+
+    @Test
+    fun `markTerminated — getAll excludes the call`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.promote("call-2", metadata("call-2"), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        val allIds = tracker.getAll().map { it.callId }
+        assertFalse(allIds.contains("call-1"))
+        assertTrue(allIds.contains("call-2"))
+    }
+
+    @Test
+    fun `markTerminated — getState returns STATE_DISCONNECTED`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertEquals(PCallkeepConnectionState.STATE_DISCONNECTED, tracker.getState("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // getAll
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getAll — empty on fresh tracker`() {
+        assertTrue(tracker.getAll().isEmpty())
+    }
+
+    @Test
+    fun `getAll — returns all promoted calls`() {
+        tracker.promote("call-1", metadata("call-1"), PCallkeepConnectionState.STATE_RINGING)
+        tracker.promote("call-2", metadata("call-2"), PCallkeepConnectionState.STATE_DIALING)
+        assertEquals(2, tracker.getAll().size)
+    }
+
+    // -------------------------------------------------------------------------
+    // toPCallkeepConnection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `toPCallkeepConnection — returns null for unknown callId`() {
+        assertNull(tracker.toPCallkeepConnection("unknown"))
+    }
+
+    @Test
+    fun `toPCallkeepConnection — returns connection with correct callId and state`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        val connection = tracker.toPCallkeepConnection("call-1")
+        assertNotNull(connection)
+        assertEquals("call-1", connection!!.callId)
+        assertEquals(PCallkeepConnectionState.STATE_RINGING, connection.state)
+    }
+
+    @Test
+    fun `toPCallkeepConnection — returns null after markTerminated`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertNull(tracker.toPCallkeepConnection("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // reserveAnswer / consumeAnswer
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `reserveAnswer then consumeAnswer returns true and clears`() {
+        tracker.reserveAnswer("call-1")
+        assertTrue(tracker.consumeAnswer("call-1"))
+        assertFalse(tracker.consumeAnswer("call-1"))
+    }
+
+    @Test
+    fun `consumeAnswer without reserveAnswer returns false`() {
+        assertFalse(tracker.consumeAnswer("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // drainUnconnectedPendingCallIds
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `drainUnconnectedPendingCallIds — returns all pending callIds`() {
+        tracker.addPending("call-1", metadata("call-1"))
+        tracker.addPending("call-2", metadata("call-2"))
+        val drained = tracker.drainUnconnectedPendingCallIds()
+        assertEquals(setOf("call-1", "call-2"), drained)
+    }
+
+    @Test
+    fun `drainUnconnectedPendingCallIds — promoted calls are not drained`() {
+        tracker.addPending("call-pending", metadata("call-pending"))
+        tracker.addPending("call-promoted", metadata("call-promoted"))
+        tracker.promote("call-promoted", metadata("call-promoted"), PCallkeepConnectionState.STATE_RINGING)
+        val drained = tracker.drainUnconnectedPendingCallIds()
+        assertFalse(drained.contains("call-promoted"))
+        assertTrue(drained.contains("call-pending"))
+    }
+
+    @Test
+    fun `drainUnconnectedPendingCallIds — subsequent isPending returns false`() {
+        tracker.addPending("call-1", metadata())
+        tracker.drainUnconnectedPendingCallIds()
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `drainUnconnectedPendingCallIds — drained call removed from getAll`() {
+        tracker.addPending("call-1", metadata())
+        tracker.drainUnconnectedPendingCallIds()
+        assertTrue(tracker.getAll().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // clear
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `clear — resets all state`() {
+        tracker.addPending("call-1", metadata("call-1"))
+        tracker.promote("call-2", metadata("call-2"), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-2")
+        tracker.markTerminated("call-1")
+        tracker.reserveAnswer("call-3")
+
+        tracker.clear()
+
+        assertTrue(tracker.getAll().isEmpty())
+        assertFalse(tracker.isPending("call-1"))
+        assertFalse(tracker.exists("call-2"))
+        assertFalse(tracker.isTerminated("call-1"))
+        assertFalse(tracker.consumeAnswer("call-3"))
+    }
+
+    // -------------------------------------------------------------------------
+    // multiple calls lifecycle
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `full lifecycle — incoming call from pending to terminated`() {
+        val id = "call-lifecycle"
+        val meta = metadata(id)
+
+        tracker.addPending(id, meta)
+        assertTrue(tracker.isPending(id))
+        assertTrue(tracker.exists(id))
+
+        tracker.promote(id, meta, PCallkeepConnectionState.STATE_RINGING)
+        assertFalse(tracker.isPending(id))
+        assertEquals(PCallkeepConnectionState.STATE_RINGING, tracker.getState(id))
+
+        tracker.markAnswered(id)
+        assertTrue(tracker.isAnswered(id))
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState(id))
+
+        tracker.markTerminated(id)
+        assertFalse(tracker.exists(id))
+        assertTrue(tracker.isTerminated(id))
+        assertEquals(PCallkeepConnectionState.STATE_DISCONNECTED, tracker.getState(id))
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -39,7 +39,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `addPending — isPending returns true`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertTrue(tracker.isPending("call-1"))
     }
 
@@ -47,25 +47,25 @@ class MainProcessConnectionTrackerTest {
     fun `addPending — exists returns false before promote`() {
         // Pending calls are not in connections; only promote() populates connections.
         // This ensures answerCall routes to the deferred-answer path, not startAnswerCall.
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertFalse(tracker.exists("call-1"))
     }
 
     @Test
     fun `addPending — isTerminated returns false`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertFalse(tracker.isTerminated("call-1"))
     }
 
     @Test
     fun `addPending — get returns null before promote`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertNull(tracker.get("call-1"))
     }
 
     @Test
     fun `addPending — getAll does not include pending calls`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertTrue(tracker.getAll().isEmpty())
     }
 
@@ -75,7 +75,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `promote — isPending becomes false`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
         assertFalse(tracker.isPending("call-1"))
     }
@@ -88,14 +88,14 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `promote — getState returns supplied state`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
         assertEquals(PCallkeepConnectionState.STATE_RINGING, tracker.getState("call-1"))
     }
 
     @Test
     fun `promote outgoing — getState returns STATE_DIALING`() {
-        tracker.addPending("call-out", metadata("call-out"))
+        tracker.addPending("call-out")
         tracker.promote("call-out", metadata("call-out"), PCallkeepConnectionState.STATE_DIALING)
         assertEquals(PCallkeepConnectionState.STATE_DIALING, tracker.getState("call-out"))
     }
@@ -113,7 +113,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `markAnswered — isAnswered returns true`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
         tracker.markAnswered("call-1")
         assertTrue(tracker.isAnswered("call-1"))
@@ -153,7 +153,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `markTerminated — isPending becomes false`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.markTerminated("call-1")
         assertFalse(tracker.isPending("call-1"))
     }
@@ -230,15 +230,15 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `removePending — isPending becomes false`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.removePending("call-1")
         assertFalse(tracker.isPending("call-1"))
     }
 
     @Test
     fun `removePending — drainUnconnectedPendingCallIds excludes removed call`() {
-        tracker.addPending("call-1", metadata("call-1"))
-        tracker.addPending("call-2", metadata("call-2"))
+        tracker.addPending("call-1")
+        tracker.addPending("call-2")
         tracker.removePending("call-1")
         val drained = tracker.drainUnconnectedPendingCallIds()
         assertFalse(drained.contains("call-1"))
@@ -274,16 +274,16 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `drainUnconnectedPendingCallIds — returns all pending callIds`() {
-        tracker.addPending("call-1", metadata("call-1"))
-        tracker.addPending("call-2", metadata("call-2"))
+        tracker.addPending("call-1")
+        tracker.addPending("call-2")
         val drained = tracker.drainUnconnectedPendingCallIds()
         assertEquals(setOf("call-1", "call-2"), drained)
     }
 
     @Test
     fun `drainUnconnectedPendingCallIds — promoted calls are not drained`() {
-        tracker.addPending("call-pending", metadata("call-pending"))
-        tracker.addPending("call-promoted", metadata("call-promoted"))
+        tracker.addPending("call-pending")
+        tracker.addPending("call-promoted")
         tracker.promote("call-promoted", metadata("call-promoted"), PCallkeepConnectionState.STATE_RINGING)
         val drained = tracker.drainUnconnectedPendingCallIds()
         assertFalse(drained.contains("call-promoted"))
@@ -292,7 +292,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `drainUnconnectedPendingCallIds — subsequent isPending returns false`() {
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         tracker.drainUnconnectedPendingCallIds()
         assertFalse(tracker.isPending("call-1"))
     }
@@ -300,7 +300,7 @@ class MainProcessConnectionTrackerTest {
     @Test
     fun `drainUnconnectedPendingCallIds — drained call never appeared in getAll`() {
         // Pending calls are not in connections, so getAll was already empty before drain.
-        tracker.addPending("call-1", metadata())
+        tracker.addPending("call-1")
         assertTrue(tracker.getAll().isEmpty())
         tracker.drainUnconnectedPendingCallIds()
         assertTrue(tracker.getAll().isEmpty())
@@ -312,7 +312,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `clear — resets all state`() {
-        tracker.addPending("call-1", metadata("call-1"))
+        tracker.addPending("call-1")
         tracker.promote("call-2", metadata("call-2"), PCallkeepConnectionState.STATE_RINGING)
         tracker.markAnswered("call-2")
         tracker.markTerminated("call-1")
@@ -336,7 +336,7 @@ class MainProcessConnectionTrackerTest {
         val id = "call-lifecycle"
         val meta = metadata(id)
 
-        tracker.addPending(id, meta)
+        tracker.addPending(id)
         assertTrue(tracker.isPending(id))
         assertFalse(tracker.exists(id))  // not yet promoted, so not in connections
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -45,11 +45,10 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `addPending — exists returns false before promote`() {
-        // A pending call is also stored in connections so exists() returns true;
-        // isPending() distinguishes it from a promoted connection.
+        // Pending calls are not in connections; only promote() populates connections.
+        // This ensures answerCall routes to the deferred-answer path, not startAnswerCall.
         tracker.addPending("call-1", metadata())
-        // exists() tracks all known calls including pending
-        assertTrue(tracker.exists("call-1"))
+        assertFalse(tracker.exists("call-1"))
     }
 
     @Test
@@ -59,10 +58,15 @@ class MainProcessConnectionTrackerTest {
     }
 
     @Test
-    fun `addPending — get returns the metadata`() {
-        val meta = metadata("call-1")
-        tracker.addPending("call-1", meta)
-        assertEquals(meta, tracker.get("call-1"))
+    fun `addPending — get returns null before promote`() {
+        tracker.addPending("call-1", metadata())
+        assertNull(tracker.get("call-1"))
+    }
+
+    @Test
+    fun `addPending — getAll does not include pending calls`() {
+        tracker.addPending("call-1", metadata())
+        assertTrue(tracker.getAll().isEmpty())
     }
 
     // -------------------------------------------------------------------------
@@ -221,6 +225,34 @@ class MainProcessConnectionTrackerTest {
     }
 
     // -------------------------------------------------------------------------
+    // removePending
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `removePending — isPending becomes false`() {
+        tracker.addPending("call-1", metadata())
+        tracker.removePending("call-1")
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `removePending — drainUnconnectedPendingCallIds excludes removed call`() {
+        tracker.addPending("call-1", metadata("call-1"))
+        tracker.addPending("call-2", metadata("call-2"))
+        tracker.removePending("call-1")
+        val drained = tracker.drainUnconnectedPendingCallIds()
+        assertFalse(drained.contains("call-1"))
+        assertTrue(drained.contains("call-2"))
+    }
+
+    @Test
+    fun `removePending — no-op when callId was never pending`() {
+        // Should not throw or affect other state.
+        tracker.removePending("unknown")
+        assertFalse(tracker.isPending("unknown"))
+    }
+
+    // -------------------------------------------------------------------------
     // reserveAnswer / consumeAnswer
     // -------------------------------------------------------------------------
 
@@ -266,8 +298,10 @@ class MainProcessConnectionTrackerTest {
     }
 
     @Test
-    fun `drainUnconnectedPendingCallIds — drained call removed from getAll`() {
+    fun `drainUnconnectedPendingCallIds — drained call never appeared in getAll`() {
+        // Pending calls are not in connections, so getAll was already empty before drain.
         tracker.addPending("call-1", metadata())
+        assertTrue(tracker.getAll().isEmpty())
         tracker.drainUnconnectedPendingCallIds()
         assertTrue(tracker.getAll().isEmpty())
     }
@@ -304,7 +338,7 @@ class MainProcessConnectionTrackerTest {
 
         tracker.addPending(id, meta)
         assertTrue(tracker.isPending(id))
-        assertTrue(tracker.exists(id))
+        assertFalse(tracker.exists(id))  // not yet promoted, so not in connections
 
         tracker.promote(id, meta, PCallkeepConnectionState.STATE_RINGING)
         assertFalse(tracker.isPending(id))

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/foreground/MainProcessConnectionTrackerTest.kt
@@ -362,4 +362,45 @@ class MainProcessConnectionTrackerTest {
         assertTrue(tracker.isTerminated(id))
         assertEquals(PCallkeepConnectionState.STATE_DISCONNECTED, tracker.getState(id))
     }
+
+    // -------------------------------------------------------------------------
+    // callId reuse within the same session
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `addPending after markTerminated — isTerminated resets to false`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertTrue(tracker.isTerminated("call-1"))
+
+        // Same callId reused for a new incoming call
+        tracker.addPending("call-1")
+        assertFalse(tracker.isTerminated("call-1"))
+        assertTrue(tracker.isPending("call-1"))
+    }
+
+    @Test
+    fun `promote after markTerminated — isTerminated resets to false`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markAnswered("call-1")
+        tracker.markTerminated("call-1")
+        assertTrue(tracker.isTerminated("call-1"))
+
+        // Same callId re-promoted (push path — no addPending)
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        assertFalse(tracker.isTerminated("call-1"))
+        assertFalse(tracker.isAnswered("call-1"))
+        assertTrue(tracker.exists("call-1"))
+    }
+
+    @Test
+    fun `addPending after markTerminated — stale pendingAnswer is cleared`() {
+        tracker.addPending("call-1")
+        tracker.reserveAnswer("call-1")
+        tracker.markTerminated("call-1")
+
+        // Reuse the same callId
+        tracker.addPending("call-1")
+        assertFalse(tracker.consumeAnswer("call-1"))
+    }
 }


### PR DESCRIPTION
## Summary

- Add \`MainProcessConnectionTracker\` — a lightweight shadow registry that mirrors \`PhoneConnectionService\` connection state in the main process via existing broadcast events (\`DidPushIncomingCall\`, \`AnswerCall\`, \`HungUp\`/\`DeclineCall\`, \`OngoingCall\`, \`ConnectionHolding\`)
- \`ForegroundService\` and \`ConnectionsApi\` now read the majority of connection state from the tracker instead of calling \`PhoneConnectionService.connectionManager\` directly
- Reduces direct cross-process state reads from the main-process side while the system is still single-process, making the architecture ready for the \`:callkeep_core\` process split (PR-9b)

> **Note on remaining direct CS reads:** Two call-sites still access \`PhoneConnectionService.connectionManager\` directly and are marked \`// TODO(PR-9b)\`:
> - \`answerCall()\` — falls back to \`connectionManager.getConnection()\` to handle broadcast-lag for push-path calls not yet in the tracker
> - \`tearDown()\` — calls \`connectionManager.getConnections()\` to obtain live \`PhoneConnection\` objects needed for \`hungUp()\` cleanup (requires the actual object, not just metadata)
> Both will be replaced with IPC when the process split lands.

## What changed

**\`MainProcessConnectionTracker\`** (new class, companion object on \`ForegroundService\`):
- Tracks \`connections\`, \`pendingCallIds\`, \`answeredCallIds\`, \`terminatedCallIds\`, \`pendingAnswers\`, \`connectionStates\`
- Provides \`addPending\` (returns \`Boolean\` to guard duplicate-call rollback), \`promote\`, \`markAnswered\`, \`markHeld\`, \`markTerminated\` write operations
- Provides \`exists\`, \`isPending\`, \`isTerminated\`, \`isAnswered\`, \`getAll\`, \`toPCallkeepConnection\` read operations
- \`addPending\` and \`promote\` reset stale lifecycle state (\`terminatedCallIds\`, \`answeredCallIds\`, \`pendingAnswers\`) to support callId reuse within the same session
- \`markTerminated\` clears \`pendingAnswers\` to prevent stale deferred-answer reservations
- \`drainUnconnectedPendingCallIds\` for tearDown drain of unconnected pending calls

**\`ForegroundService\`**:
- Wires tracker updates from all relevant broadcasts including \`ConnectionHolding\` (for \`STATE_HOLDING\`)
- \`reportNewIncomingCall\` / \`startCall\`: \`tracker.addPending()\` before sending to Telecom; \`startCall.finish()\` calls \`tracker.removePending()\` on all non-promote paths (failure, timeout, dispatch error)
- \`answerCall\`: checks \`tracker.exists\` → CS connection (broadcast-lag fallback) → \`tracker.isPending\` for routing decisions
- \`handleCSReportAnswerCall\`: calls \`tracker.consumeAnswer()\` before \`markAnswered\` so \`pendingAnswers\` does not leak
- \`endCall\`: \`tracker.isTerminated()\` for duplicate guard
- \`tearDown\`: tracker for Flutter notifications; \`connection.hungUp()\` via CS kept for native cleanup with \`// TODO(PR-9b)\` marking the remaining cross-process access

**\`ConnectionsApi\`**:
- \`getConnection\` / \`getConnections\`: read from \`ForegroundService.tracker\` (now reflects \`STATE_HOLDING\` correctly)
- \`cleanConnections\`: clears tracker then calls CS cleanup

## Test plan

- 32 unit tests in \`MainProcessConnectionTrackerTest\` covering the full call lifecycle: \`addPending\` -> \`promote\` -> \`markAnswered\` -> \`markHeld\` -> \`markTerminated\`, deferred answer reservation, tearDown drain, callId reuse, and \`clear\`
- 13 integration tests in \`callkeep_foreground_service_test.dart\` covering answerCall timing, endCall, tearDown double-fire, and deduplication on a physical Android device
- All pre-existing unit tests pass (pre-existing failures in \`ConnectionManagerTest\` and \`PhoneConnectionTerminateTest\` are unrelated and existed before this PR)