### PR TITLE
fix(android): remove remaining direct connectionManager calls from main process

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/CallDiagnostics.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/CallDiagnostics.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.PowerManager
 import androidx.core.content.ContextCompat
 import com.webtrit.callkeep.managers.NotificationChannelManager
+import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
 import com.webtrit.callkeep.services.services.foreground.ForegroundService
 import java.util.Locale
@@ -50,8 +51,8 @@ object CallDiagnostics {
             // via ActivityManager to correctly detect it regardless of process boundaries.
             "isPhoneConnectionServiceRunning" to isServiceRunning(context, PhoneConnectionService::class.java),
             "isLockScreen" to Platform.isLockScreen(context),
-            "connectionManagerState" to runCatching {
-                PhoneConnectionService.connectionManager.toString()
+            "trackerState" to runCatching {
+                CallkeepCore.instance.getAll().toString()
             }.getOrElse { "Error: ${it.message}" })
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -114,6 +114,14 @@ interface CallkeepCore {
      */
     fun sendCleanConnections()
 
+    /**
+     * Sends [ServiceAction.SyncAudioState] to [PhoneConnectionService].
+     * The service re-emits audio device and mute state for all active connections back to the
+     * main process via broadcasts. Called from [ForegroundService.onDelegateSet] to restore
+     * Flutter audio UI after hot restart.
+     */
+    fun sendSyncAudioState()
+
     companion object {
         /**
          * Process-wide singleton. Swap the implementation here to change IPC strategy

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -74,7 +74,15 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
         metadata: CallMetadata,
         onSuccess: () -> Unit,
         onError: (PIncomingCallError?) -> Unit,
-    ) = PhoneConnectionService.startIncomingCall(context, metadata, onSuccess, onError)
+    ) {
+        // Register as pending before handing off to Telecom so that answerCall() can
+        // find the call via core.isPending() during the broadcast-lag window, regardless
+        // of which entry point initiated the incoming call (ForegroundService,
+        // SignalingIsolateService, BackgroundPushNotificationIsolateBootstrapApi, etc.).
+        // addPending() is idempotent — safe to call even if the caller already did so.
+        tracker.addPending(metadata.callId)
+        PhoneConnectionService.startIncomingCall(context, metadata, onSuccess, onError)
+    }
 
     override fun startAnswerCall(metadata: CallMetadata) =
         PhoneConnectionService.startAnswerCall(context, metadata)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -116,6 +116,8 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
 
     override fun sendCleanConnections() = PhoneConnectionService.sendCleanConnections(context)
 
+    override fun sendSyncAudioState() = PhoneConnectionService.sendSyncAudioState(context)
+
     companion object {
         val instance: CallkeepCore = InProcessCallkeepCore()
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
@@ -3,7 +3,7 @@ package com.webtrit.callkeep.services.services.connection
 import com.webtrit.callkeep.common.ContextHolder
 
 enum class ServiceAction {
-    HungUpCall, DeclineCall, AnswerCall, EstablishCall, Muting, Speaker, AudioDeviceSet, Holding, UpdateCall, SendDTMF, TearDown, TearDownConnections, ReserveAnswer, CleanConnections;
+    HungUpCall, DeclineCall, AnswerCall, EstablishCall, Muting, Speaker, AudioDeviceSet, Holding, UpdateCall, SendDTMF, TearDown, TearDownConnections, ReserveAnswer, CleanConnections, SyncAudioState;
 
     companion object {
         fun from(action: String?): ServiceAction {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -97,6 +97,7 @@ class PhoneConnectionService : ConnectionService() {
                 ServiceAction.ReserveAnswer -> metadata?.callId?.let { handleReserveAnswer(it) }
                     ?: Log.w(TAG, "onStartCommand: ReserveAnswer missing callId")
                 ServiceAction.CleanConnections -> handleCleanConnections()
+                ServiceAction.SyncAudioState -> handleSyncAudioState()
                 else -> phoneConnectionServiceDispatcher.dispatch(action, metadata)
             }
         } catch (e: Exception) {
@@ -305,6 +306,11 @@ class PhoneConnectionService : ConnectionService() {
         connectionManager.cleanConnections()
     }
 
+    private fun handleSyncAudioState() {
+        Log.i(TAG, "handleSyncAudioState: re-emitting audio state for all active connections")
+        connectionManager.getConnections().forEach { it.forceUpdateAudioState() }
+    }
+
     override fun onDestroy() {
         Log.i(TAG, "onDestroy")
         cleanupResources()
@@ -445,6 +451,20 @@ class PhoneConnectionService : ConnectionService() {
             }
             runCatching { context.startService(intent) }
                 .onFailure { e -> Log.w(TAG, "sendCleanConnections: startService failed: $e") }
+        }
+
+        /**
+         * Sends [ServiceAction.SyncAudioState] to [PhoneConnectionService].
+         * The service will call [PhoneConnection.forceUpdateAudioState] on all active connections,
+         * which re-emits audio device and mute state broadcasts back to the main process.
+         * Used by [ForegroundService.onDelegateSet] to restore Flutter UI after hot restart.
+         */
+        fun sendSyncAudioState(context: Context) {
+            val intent = Intent(context, PhoneConnectionService::class.java).apply {
+                action = ServiceAction.SyncAudioState.action
+            }
+            runCatching { context.startService(intent) }
+                .onFailure { e -> Log.w(TAG, "sendSyncAudioState: startService failed: $e") }
         }
 
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
@@ -65,7 +65,8 @@ class PhoneConnectionServiceDispatcher(
             // before reaching the dispatcher, so they should never arrive here.
             ServiceAction.TearDownConnections,
             ServiceAction.ReserveAnswer,
-            ServiceAction.CleanConnections -> logger.w("dispatch: unexpected IPC command action: $action")
+            ServiceAction.CleanConnections,
+            ServiceAction.SyncAudioState -> logger.w("dispatch: unexpected IPC command action: $action")
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -45,7 +45,6 @@ import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.core.CallkeepCore
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
 
 /**
  * ForegroundService is an Android bound Service that maintains a connection with the main Flutter isolate
@@ -523,23 +522,13 @@ class ForegroundService : Service(), PHostApi {
         // DidPushIncomingCall is delivered via sendBroadcast() which is async. Between the
         // moment CS creates the PhoneConnection and the moment the broadcast reaches
         // ForegroundService, core.exists() is false even though the call is live on the
-        // CS side. This window hits both the main-process signaling path (addPending called
-        // in reportNewIncomingCall, but broadcast not yet delivered) and the push-path (no
-        // addPending at all). Resolution order:
-        //   1. core.exists()                         -> promoted, answer immediately.
-        //   2. CS connectionManager has the connection  -> broadcast lag, answer via CS.
-        //   3. core.isPending() && CS has no conn.  -> PhoneConnection not yet created, defer.
-        //   4. none of the above                        -> unknown call, return error.
-        // TODO(PR-9b): collapse steps 2-3 into a single IPC lookup when :callkeep_core splits.
-        val csConnection = PhoneConnectionService.connectionManager.getConnection(callId)
+        // CS side. Resolution order:
+        //   1. core.exists()     -> promoted, answer immediately.
+        //   2. core.isPending()  -> PhoneConnection not yet created, defer via ReserveAnswer.
+        //   3. none of the above -> unknown call, return error.
         when {
             core.exists(callId) -> {
                 logger.i("answerCall $callId: connection exists in core shadow, answering immediately.")
-                core.startAnswerCall(metadata)
-                callback.invoke(Result.success(null))
-            }
-            csConnection != null -> {
-                logger.i("answerCall $callId: CS has connection (core shadow broadcast lag), answering via CS.")
                 core.startAnswerCall(metadata)
                 callback.invoke(Result.success(null))
             }
@@ -741,25 +730,17 @@ class ForegroundService : Service(), PHostApi {
      */
     override fun onDelegateSet() {
         logger.d("onDelegateSet: Flutter delegate attached. Checking for active connections to restore...")
-        val connections = PhoneConnectionService.connectionManager.getConnections()
+        val connections = core.getAll()
 
         if (connections.isEmpty()) {
             Log.d(TAG, "onDelegateSet: No active connections found.")
             return
         }
 
-        Handler(Looper.getMainLooper()).post {
-            connections.forEach { connection ->
-                val handle = connection.handle
-
-                if (handle == null) {
-                    Log.w(TAG, "onDelegateSet: Skipping connection with null handle")
-                    return@forEach
-                }
-
-                connection.forceUpdateAudioState()
-            }
-        }
+        // Ask :callkeep_core to re-emit audio state (device + mute) for all active connections.
+        // PhoneConnection.forceUpdateAudioState() runs in the :callkeep_core process and sends
+        // CallMediaEvent broadcasts back to the main process, which updates the Flutter UI.
+        core.sendSyncAudioState()
     }
 
 


### PR DESCRIPTION
## Summary

Removes the last direct `PhoneConnectionService.connectionManager.*` accesses from the main process, completing the `:callkeep_core` process isolation started in #179-#186.

- **`answerCall()`** -- remove broadcast-lag fallback (step 2) that read `connectionManager.getConnection()`. After the process split this always returns null (main-process `connectionManager` is empty). The tracker + pending path (steps 1 and 3) is now authoritative.
- **`onDelegateSet()`** -- replace `connectionManager.getConnections()` with `core.getAll()`. Audio state resync on Flutter hot restart is now handled via a new `SyncAudioState` IPC command sent to `:callkeep_core`, which calls `forceUpdateAudioState()` on each `PhoneConnection` in the correct process.
- **`CallDiagnostics`** -- replace `connectionManager.toString()` with `CallkeepCore.instance.getAll()`; rename key to `trackerState`.

## New: SyncAudioState IPC command

Wired the same way as existing commands (TearDownConnections, ReserveAnswer, CleanConnections):

| Layer | Change |
|---|---|
| `PhoneConnectionEnums` | Add `SyncAudioState` to `ServiceAction` |
| `PhoneConnectionService` | `handleSyncAudioState()` handler + `sendSyncAudioState()` companion |
| `PhoneConnectionServiceDispatcher` | Add to exhaustive `when` as unexpected IPC action |
| `CallkeepCore` | Add `sendSyncAudioState()` to interface |
| `InProcessCallkeepCore` | Delegate to `PhoneConnectionService.sendSyncAudioState()` |

## Test plan

- [ ] Incoming call: answer works without broadcast-lag fallback
- [ ] Hot restart with active call: audio device + mute state restored in Flutter UI
- [ ] `getDiagnosticReport()` returns `trackerState` with active connection list
- [ ] All existing unit tests pass