### PR TITLE
ci(android): add Firebase Test Lab workflow for integration tests

### DIFF
--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -1,0 +1,74 @@
+name: Integration Tests (Firebase Test Lab)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - "webtrit_callkeep/**"
+      - "webtrit_callkeep_android/**"
+      - "webtrit_callkeep_platform_interface/**"
+      - ".github/workflows/integration-tests-firebase.yml"
+
+jobs:
+  integration-tests:
+    name: Integration Tests (Firebase Test Lab)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.0"
+          channel: stable
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: webtrit_callkeep/example
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug
+        working-directory: webtrit_callkeep/example/android
+
+      - name: Build instrumented test APK
+        run: ./gradlew :app:assembleAndroidTest
+        working-directory: webtrit_callkeep/example/android
+
+      - name: Run tests on Firebase Test Lab
+        run: |
+          gcloud firebase test android run \
+            --type instrumentation \
+            --app webtrit_callkeep/example/build/app/outputs/apk/debug/app-debug.apk \
+            --test webtrit_callkeep/example/build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+            --device model=Pixel6,version=33,locale=en,orientation=portrait \
+            --timeout 10m \
+            --project ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Upload build artifacts and test APKs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: firebase-test-apks-${{ github.run_number }}
+          path: |
+            webtrit_callkeep/example/build/app/outputs/apk/debug/app-debug.apk
+            webtrit_callkeep/example/build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -295,10 +295,43 @@ Tests cover: lifecycle, incoming/outgoing call scenarios, state machine (hold, m
 foreground service timing, background service paths (push + signaling), connection queries,
 delegate edge cases, and stress/concurrency scenarios.
 
+Android emulators cannot run these tests reliably. The `ConnectionService` API, foreground service
+lifecycle, and dual-process (`main` + `:callkeep_core`) teardown require real hardware behaviour
+that emulators do not reproduce. Tests are designed to run on physical devices only.
+
+### Run locally
+
+Use the helper script, which runs each test file in isolation and waits for both app processes and
+Telecom to drain between files:
+
 ```bash
 cd webtrit_callkeep/example
-flutter test integration_test/<test_file>.dart
+./run_integration_tests.sh                 # auto-detect connected device
+./run_integration_tests.sh -d <device-id>  # explicit device
 ```
+
+To run a single file:
+
+```bash
+cd webtrit_callkeep/example
+flutter test integration_test/<test_file>.dart -d <device-id>
+```
+
+### Run on Firebase Test Lab (CI)
+
+The workflow `.github/workflows/integration-tests-firebase.yml` runs the full suite on real
+hardware via Firebase Test Lab. It triggers automatically on pull requests to `develop` and `main`,
+and can also be started manually from the Actions tab (`workflow_dispatch`).
+
+**Required secrets** (configure in GitHub repo settings):
+
+| Secret | Description |
+| --- | --- |
+| `FIREBASE_SERVICE_ACCOUNT` | JSON key for the GCP service account that has Firebase Test Lab permissions |
+| `FIREBASE_PROJECT_ID` | GCP project ID linked to your Firebase project |
+
+Full results (logcat, video, screenshots) are available in the Firebase console after each run.
+The built APKs are also uploaded as GitHub Actions artifacts for 14 days.
 
 ---
 


### PR DESCRIPTION
## Why

Android emulators cannot reliably run the callkeep integration tests.
The `ConnectionService` API, foreground service lifecycle, and the
dual-process teardown (`main` + `:callkeep_core`) depend on real OS
scheduler and Telecom behaviour that emulators do not reproduce. This
means integration tests must run on physical hardware.

Firebase Test Lab provides real devices (free tier included) and
integrates cleanly with GitHub Actions, making it the lowest-friction
path to running these tests in CI without managing physical lab hardware.

## What

- Adds `.github/workflows/integration-tests-firebase.yml`
  - Triggers on `pull_request` to `develop`/`main` and `workflow_dispatch`
  - Checks out the repo, sets up JDK 17 + Flutter, authenticates with GCP
  - Builds the debug APK and instrumented test APK via Gradle
  - Runs the full instrumented test suite on a Pixel 6 (API 33) via `gcloud firebase test android run`
  - Uploads built APKs as GitHub Actions artifacts on every run (`if: always()`), retained 14 days
  - Does not touch any existing workflow files

- Expands the **Integration tests** section in `README.md`
  - Documents `run_integration_tests.sh` for local runs
  - Documents how to trigger the Firebase workflow manually via `workflow_dispatch`
  - Lists the two required secrets: `FIREBASE_SERVICE_ACCOUNT`, `FIREBASE_PROJECT_ID`

## Required setup

A maintainer must add these secrets in GitHub repo settings before the workflow can authenticate:

| Secret | Description |
| --- | --- |
| `FIREBASE_SERVICE_ACCOUNT` | JSON key for a GCP service account with Firebase Test Lab permissions |
| `FIREBASE_PROJECT_ID` | GCP project ID linked to your Firebase project |