### PR TITLE
ci(android): add Firebase Test Lab workflow for integration tests

### DIFF
--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -1,0 +1,77 @@
+name: Integration Tests (Firebase Test Lab)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - "webtrit_callkeep/**"
+      - "webtrit_callkeep_android/**"
+      - "webtrit_callkeep_platform_interface/**"
+      - ".github/workflows/integration-tests-firebase.yml"
+
+jobs:
+  integration-tests:
+    name: Integration Tests (Firebase Test Lab)
+    runs-on: ubuntu-latest
+    # Skip fork PRs: secrets are not available for forks, so auth steps would fail.
+    # workflow_dispatch always runs (no fork context).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.0"
+          channel: stable
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: webtrit_callkeep/example
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build debug APK
+        run: flutter build apk --debug
+        working-directory: webtrit_callkeep/example
+
+      - name: Build instrumented test APK
+        run: ./gradlew :app:assembleAndroidTest
+        working-directory: webtrit_callkeep/example/android
+
+      - name: Run tests on Firebase Test Lab
+        run: |
+          gcloud firebase test android run \
+            --type instrumentation \
+            --app webtrit_callkeep/example/build/app/outputs/apk/debug/app-debug.apk \
+            --test webtrit_callkeep/example/build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+            --device model=Pixel6,version=33,locale=en,orientation=portrait \
+            --timeout 10m \
+            --project ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Upload build artifacts and test APKs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: firebase-test-apks-${{ github.run_number }}
+          path: |
+            webtrit_callkeep/example/build/app/outputs/apk/debug/app-debug.apk
+            webtrit_callkeep/example/build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -482,6 +482,39 @@ Feel free to explore it, fork it, and use it as a starting point for your own ap
 
 ---
 
+## Integration Tests (Android)
+
+Integration tests live in
+[`webtrit_callkeep/example/integration_test/`](webtrit_callkeep/example/integration_test/)
+and cover lifecycle, call scenarios, state machine, foreground service timing, background service
+paths, and stress/concurrency scenarios.
+
+Android emulators cannot run these tests reliably — `ConnectionService`, foreground service
+lifecycle, and dual-process (`main` + `:callkeep_core`) teardown require real hardware behaviour.
+
+### Run locally
+
+```bash
+cd webtrit_callkeep/example
+./run_integration_tests.sh                 # auto-detect connected device
+./run_integration_tests.sh -d <device-id>  # explicit device
+```
+
+### Run on Firebase Test Lab (CI)
+
+The workflow `.github/workflows/integration-tests-firebase.yml` runs the full suite on real
+hardware. It triggers on PRs to `develop`/`main` (same-repo only) and can be started manually
+from the Actions tab via `workflow_dispatch`.
+
+Required secrets (configure in GitHub repo settings):
+
+| Secret | Description |
+| --- | --- |
+| `FIREBASE_SERVICE_ACCOUNT` | JSON key for a GCP service account with Firebase Test Lab permissions |
+| `FIREBASE_PROJECT_ID` | GCP project ID linked to your Firebase project |
+
+---
+
 ## 📃 More Resources
 
 - [CallKit Documentation (Apple)](https://developer.apple.com/documentation/callkit)


### PR DESCRIPTION
## Why

Android emulators cannot reliably run the callkeep integration tests.
The `ConnectionService` API, foreground service lifecycle, and the
dual-process teardown (`main` + `:callkeep_core`) depend on real OS
scheduler and Telecom behaviour that emulators do not reproduce.

Firebase Test Lab provides real devices and integrates cleanly with
GitHub Actions, making it the lowest-friction path to running these
tests in CI without managing physical lab hardware.

## What

- Adds `.github/workflows/integration-tests-firebase.yml`
  - Triggers on `pull_request` to `develop`/`main` (same-repo PRs only — fork PRs are skipped because secrets are unavailable for forks) and `workflow_dispatch` for manual runs
  - Sets up JDK 17 + Flutter 3.32.0, authenticates with GCP via `google-github-actions/auth`
  - Builds debug APK via `flutter build apk --debug` (unambiguous output path)
  - Builds instrumented test APK via `./gradlew :app:assembleAndroidTest`
  - Runs the full suite on Pixel 6 / API 33 via `gcloud firebase test android run`
  - Uploads built APKs as GitHub Actions artifacts on every run (`if: always()`), retained 14 days
  - Does not touch any existing workflow files

- Adds an **Integration Tests** section to `README.md`
  - Documents `run_integration_tests.sh` for local runs
  - Explains why emulators are insufficient
  - Documents `workflow_dispatch` trigger and required secrets

## Required setup

A maintainer must add these secrets in GitHub repo settings:

| Secret | Description |
| --- | --- |
| `FIREBASE_SERVICE_ACCOUNT` | JSON key for a GCP service account with Firebase Test Lab permissions |
| `FIREBASE_PROJECT_ID` | GCP project ID linked to your Firebase project |