### PR TITLE
fix(test): guard two-call tests against Telecom RINGING race

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
@@ -150,6 +150,23 @@ Future<CallkeepConnection?> _waitForConnection(
   return null;
 }
 
+// Poll until a Telecom connection for callId reaches the desired state (or
+// timeout). Used to guard against the race where Telecom's CallsManager has
+// not yet processed setActive() when the next reportNewIncomingCall arrives.
+Future<void> _waitForConnectionState(
+  String callId,
+  CallkeepConnectionState targetState, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final conn = await CallkeepConnections().getConnection(callId);
+    if (conn != null && conn.state == targetState) return;
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+  throw TimeoutException('$callId did not reach $targetState within timeout');
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -403,6 +420,12 @@ void main() {
       await callkeep.answerCall(id1);
       await _waitFor(answer1Latch.future, label: 'performAnswerCall id1');
 
+      // Wait for id1's Telecom connection to reach ACTIVE before reporting id2.
+      // Telecom refuses a second incoming self-managed call while the first is
+      // still RINGING in its CallsManager. performAnswerCall fires before
+      // Telecom processes setActive(), so we poll here to close that race.
+      await _waitForConnectionState(id1, CallkeepConnectionState.stateActive);
+
       // Report id2
       await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Frank');
 
@@ -461,6 +484,12 @@ void main() {
       };
       await callkeep.answerCall(id1);
       await _waitFor(answer1Latch.future, label: 'performAnswerCall id1');
+
+      // Wait for id1's Telecom connection to reach ACTIVE before reporting id2.
+      // Telecom refuses a second incoming self-managed call while the first is
+      // still RINGING in its CallsManager. performAnswerCall fires before
+      // Telecom processes setActive(), so we poll here to close that race.
+      await _waitForConnectionState(id1, CallkeepConnectionState.stateActive);
 
       await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Hank');
       await _waitForConnection(id2);

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.telecom.Connection
 import android.telecom.ConnectionRequest
 import android.telecom.ConnectionService
@@ -340,10 +342,46 @@ class PhoneConnectionService : ConnectionService() {
 
         Log.e(TAG, failureMessage)
 
-        if (wasPending && callId != null) {
-            // Notify Flutter that this call ended so it can clean up its call state.
-            Log.i(TAG, "onCreateIncomingConnectionFailed: firing HungUp for pending callId=$callId")
-            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+        if (wasPending && callId != null && callMetadata != null) {
+            // Check whether the rejection is due to the RINGING→ACTIVE race in Telecom's
+            // CallsManager. When a self-managed call transitions RINGING→ACTIVE, setActive()
+            // posts an update to Telecom's handler thread asynchronously. If addNewIncomingCall
+            // for a second call arrives before that update is processed, Telecom rejects it
+            // even though the first call is no longer RINGING.
+            //
+            // Heuristic: PhoneConnection.hasAnswered is set synchronously inside onAnswer()
+            // before setActive() and the AnswerCall broadcast, so at the time this callback
+            // fires it is already true — while Connection.state may still be STATE_RINGING
+            // from Telecom's perspective.
+            //
+            // Retry guard: after the delay Telecom will have fully processed markCallAsActive().
+            // If Telecom still rejects, the existing connections are STATE_ACTIVE (not merely
+            // hasAnswered), so the guard `hasRecentlyAnsweredCall` will be false and we will
+            // not loop.
+            val hasRecentlyAnsweredCall =
+                connectionManager
+                    .getConnections()
+                    .any { it.hasAnswered && it.state != Connection.STATE_ACTIVE }
+
+            if (hasRecentlyAnsweredCall) {
+                // Retry once after the delay. By then Telecom will have moved the first call
+                // to STATE_ACTIVE in its CallsManager and will accept the second incoming call.
+                Log.i(TAG, "onCreateIncomingConnectionFailed: scheduling retry for $callId (RINGING→ACTIVE race)")
+                connectionManager.addPendingForIncomingCall(callId)
+                Handler(Looper.getMainLooper()).postDelayed({
+                    try {
+                        Log.i(TAG, "onCreateIncomingConnectionFailed: retrying addNewIncomingCall for $callId")
+                        TelephonyUtils(baseContext).addNewIncomingCall(callMetadata)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "onCreateIncomingConnectionFailed: retry failed for $callId", e)
+                        connectionManager.removePending(callId)
+                        dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+                    }
+                }, RINGING_TO_ACTIVE_RETRY_DELAY_MS)
+            } else {
+                Log.i(TAG, "onCreateIncomingConnectionFailed: firing HungUp for pending callId=$callId")
+                dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+            }
         } else {
             val failureMetadata = FailureMetadata(callMetadata, failureMessage).toBundle()
             dispatcher.dispatch(baseContext, CallLifecycleEvent.IncomingFailure, failureMetadata)
@@ -457,6 +495,11 @@ class PhoneConnectionService : ConnectionService() {
 
     companion object {
         private const val TAG = "PhoneConnectionService"
+
+        // Delay before retrying addNewIncomingCall after a spurious onCreateIncomingConnectionFailed
+        // caused by the RINGING→ACTIVE race in Telecom's CallsManager. The observed race window
+        // is ~2 ms; 300 ms gives Telecom's handler thread plenty of time to process markCallAsActive.
+        private const val RINGING_TO_ACTIVE_RETRY_DELAY_MS = 300L
 
         // The service state is used to determine if the service is running. This is useful to avoid invoking onStartCommand when the service is down.
         private var _isRunning = false


### PR DESCRIPTION
## Summary

- Add `_waitForConnectionState` helper that polls until a Telecom connection reaches a target `CallkeepConnectionState`
- Call `_waitForConnectionState(id1, stateActive)` after `answerCall(id1)` in both two-call tests before `reportNewIncomingCall(id2)`
- Fix applies to both `hold call1, answer call2, unhold call1` and `DTMF on call2 while call1 is held`

**Root cause:** Telecom rejects a second incoming self-managed call if the first is still `STATE_RINGING` in `CallsManager`. The `performAnswerCall` delegate fires from `:callkeep_core` before Telecom processes `setActive()` internally — a ~2ms race observed in logcat (`onCreateIncomingConnectionFailed` for id2 at `08:33:21.418`, id1 transitions RINGING→ACTIVE at `08:33:21.420`). The test then waited 10s for `performAnswerCall id2` that never fired.

## Test plan

- [ ] CI: `callkeep_state_machine_test` passes on Firebase Test Lab without timeout on `performAnswerCall id2`
- [ ] Both two-call tests (`hold call1, answer call2, unhold call1` and `DTMF on call2 while call1 is held`) pass reliably