### PR TITLE
feat(web): implement full WebtritCallkeepWeb platform interface

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -168,7 +169,7 @@ void main() {
     globalTearDownNeeded = true;
     callkeep = Callkeep();
     delegate = _RecordingDelegate();
-    if (Platform.isAndroid) {
+    if (!kIsWeb && Platform.isAndroid) {
       // Register the entry-point callback so startService() can start the
       // SignalingIsolateService.  Safe to call every setUp — it only writes
       // to SharedPreferences.
@@ -209,7 +210,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('push-path report then main-process report returns callIdAlreadyExists', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -229,7 +230,7 @@ void main() {
     });
 
     testWidgets('push-path duplicate report returns callIdAlreadyExists', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -250,7 +251,7 @@ void main() {
     });
 
     testWidgets('concurrent push-path spam — exactly one succeeds', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -284,7 +285,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('push-path call endCall fires performEndCall on main delegate', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -323,7 +324,7 @@ void main() {
     // We use callkeep.endCall() per call instead to end Telecom connections
     // and verify performEndCall fires for each one.
     testWidgets('push-path endCalls fires performEndCall for every active call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -370,7 +371,7 @@ void main() {
 
     testWidgets('push-path call answered → main-process report returns callIdAlreadyExistsAndAnswered',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -414,7 +415,7 @@ void main() {
 
     testWidgets('after push service ends a call, re-reporting same id returns callIdAlreadyTerminated',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -459,7 +460,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('callkeep tearDown fires performEndCall for push-path active call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -515,7 +516,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('signaling service incomingCall creates a call recognised by main process', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -539,7 +540,7 @@ void main() {
     });
 
     testWidgets('signaling service incomingCall duplicate returns callIdAlreadyExists', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -564,7 +565,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('signaling service endCall fires performEndCall on main delegate', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -586,7 +587,7 @@ void main() {
     });
 
     testWidgets('signaling service endCall fires performEndCall exactly once', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -624,7 +625,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('signaling service endCalls fires performEndCall for every active call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -653,7 +654,7 @@ void main() {
     });
 
     testWidgets('signaling service endCalls with no active calls does not fire performEndCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -677,7 +678,7 @@ void main() {
 
     testWidgets('signaling-service call answered → main-process report returns callIdAlreadyExistsAndAnswered',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -714,7 +715,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('callkeep tearDown fires performEndCall for signaling-service active call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -749,7 +750,7 @@ void main() {
     // Ensure service is stopped after each lifecycle test so they don't
     // interfere with each other (some tests start but may not stop).
     tearDown(() async {
-      if (!Platform.isAndroid) return;
+      if (kIsWeb || !Platform.isAndroid) return;
       try {
         await AndroidCallkeepServices.backgroundSignalingBootstrapService
             .stopService()
@@ -765,7 +766,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('setUp then startService completes without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -782,7 +783,7 @@ void main() {
     });
 
     testWidgets('startService is idempotent — calling twice does not throw', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -795,7 +796,7 @@ void main() {
     });
 
     testWidgets('stopService completes without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -809,7 +810,7 @@ void main() {
     });
 
     testWidgets('stopService without prior startService does not throw', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -823,7 +824,7 @@ void main() {
     });
 
     testWidgets('start → stop → start cycle completes without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -860,7 +861,7 @@ void main() {
 
     testWidgets('push then signaling service for same callId — signaling report returns callIdAlreadyExists',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -877,7 +878,7 @@ void main() {
 
     testWidgets('signaling then push service for same callId — push report returns callIdAlreadyExists',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -906,7 +907,7 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('push service endCall does not affect a separate signaling service call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -612,7 +613,7 @@ void main() {
 
   group('audio device selection (Android only)', () {
     testWidgets('setAudioDevice completes without error on an answered call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -656,7 +657,7 @@ void main() {
 
   group('outgoing call lifecycle (Android only)', () {
     testWidgets('startCall fires performStartCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -677,7 +678,7 @@ void main() {
 
     testWidgets('startCall → reportConnectingOutgoingCall → reportConnectedOutgoingCall completes',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -708,7 +709,7 @@ void main() {
     });
 
     testWidgets('outgoing call endCall before answer fires performEndCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1194,7 +1195,7 @@ void main() {
 
   group('outgoing call extended (Android only)', () {
     testWidgets('startCall with hasVideo=true fires performStartCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1222,7 +1223,7 @@ void main() {
     });
 
     testWidgets('startCall with proximityEnabled=true completes', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1251,7 +1252,7 @@ void main() {
     });
 
     testWidgets('full outgoing sequence: start + connect + hold + DTMF + unhold + end', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1309,7 +1310,7 @@ void main() {
 
   group('handle type diversity (Android only)', () {
     testWidgets('reportNewIncomingCall with CallkeepHandle.generic reports without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1323,7 +1324,7 @@ void main() {
     });
 
     testWidgets('reportNewIncomingCall with CallkeepHandle.email reports without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -1337,7 +1338,7 @@ void main() {
     });
 
     testWidgets('startCall with CallkeepHandle.generic fires performStartCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_client_scenarios_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_client_scenarios_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -170,7 +171,7 @@ void main() {
 
   group('answerCall idempotency (Android only)', () {
     testWidgets('answerCall twice fires performAnswerCall exactly once', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -199,7 +200,7 @@ void main() {
     });
 
     testWidgets('answerCall on a call already ended via endCall returns error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -224,7 +225,7 @@ void main() {
 
   group('endCall returns unknownCallUuid after reportEndCall (Android only)', () {
     testWidgets('endCall after reportEndCall(remoteEnded) returns unknownCallUuid or null', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -263,7 +264,7 @@ void main() {
 
   group('WebtritCallkeepSound ringback (Android only)', () {
     testWidgets('playRingbackSound completes without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -271,7 +272,7 @@ void main() {
     });
 
     testWidgets('stopRingbackSound completes without error', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -280,7 +281,7 @@ void main() {
     });
 
     testWidgets('stopRingbackSound when not playing is safe', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -294,7 +295,7 @@ void main() {
 
   group('performAnswerCall returning false is handled gracefully (Android only)', () {
     testWidgets('performAnswerCall returning false does not crash callkeep', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -319,7 +320,7 @@ void main() {
 
   group('updateActivitySignalingStatus rapid transitions (Android only)', () {
     testWidgets('rapid updateActivitySignalingStatus calls do not crash', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -345,7 +346,7 @@ void main() {
 
   group('setDelegate(null) in close() pattern (Android only)', () {
     testWidgets('tearDown after setDelegate(null) does not crash or fire stale callbacks', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -376,7 +377,7 @@ void main() {
 
   group('performEndCall async contract (Android only)', () {
     testWidgets('performEndCall async work is awaited before native connection cleanup', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -418,7 +419,7 @@ void main() {
     });
 
     testWidgets('performEndCall returning false is handled gracefully', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -445,7 +446,7 @@ void main() {
   group('performEndCall during signaling connect race (Android only)', () {
     testWidgets('endCall fires performEndCall even when called immediately after reportNewIncomingCall',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_delegate_edge_cases_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_delegate_edge_cases_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -169,7 +170,7 @@ void main() {
 
   group('setDelegate(null) mid-call (Android only)', () {
     testWidgets('setDelegate(null) during active call does not crash', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -195,7 +196,7 @@ void main() {
     });
 
     testWidgets('setDelegate(null) then restore routes callbacks to restored delegate', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -226,7 +227,7 @@ void main() {
 
   group('delegate swap mid-call (Android only)', () {
     testWidgets('swapping to new delegate routes only new delegate receives events', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -266,7 +267,7 @@ void main() {
 
   group('didPushIncomingCall callback (Android only)', () {
     testWidgets('fires with null error on successful push-path registration', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -285,7 +286,7 @@ void main() {
     });
 
     testWidgets('fires with callIdAlreadyExists on duplicate registration', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -316,7 +317,7 @@ void main() {
 
   group('audio session delegate callbacks (Android only)', () {
     testWidgets('didActivateAudioSession fires after answerCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -348,7 +349,7 @@ void main() {
     });
 
     testWidgets('didDeactivateAudioSession fires after call ends', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -171,7 +172,7 @@ void main() {
       // No delay between reportNewIncomingCall and answerCall — exercises the
       // window where tracker.isPending(callId) is true but the CS already has
       // the PhoneConnection.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -196,7 +197,7 @@ void main() {
       // Verifies the normal (non-race) path still works after the fix.
       // A short delay gives the DidPushIncomingCall broadcast time to arrive
       // so tracker.exists() is true when answerCall() is called.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -219,7 +220,7 @@ void main() {
     testWidgets('answerCall fires performAnswerCall exactly once', (WidgetTester _) async {
       // Guards against double-answer: the tracker or deferred-answer path must
       // not cause performAnswerCall to fire twice for a single answerCall().
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -246,7 +247,7 @@ void main() {
     });
 
     testWidgets('video call: answerCall immediately fires performAnswerCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -276,7 +277,7 @@ void main() {
 
   group('main-process signaling path — endCall (Android only)', () {
     testWidgets('endCall immediately after reportNewIncomingCall fires performEndCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -297,7 +298,7 @@ void main() {
     });
 
     testWidgets('endCall fires performEndCall exactly once', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -323,7 +324,7 @@ void main() {
     });
 
     testWidgets('answer then endCall fires performEndCall once (not for answered call twice)', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -362,7 +363,7 @@ void main() {
 
   group('main-process signaling path — tearDown (Android only)', () {
     testWidgets('tearDown fires performEndCall for an unanswered main-process call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -390,7 +391,7 @@ void main() {
       // Regression: with the stale-pending bug, tearDown fired performEndCall
       // twice — once from tracker.getAll() and once from
       // drainUnconnectedPendingCallIds() when the call was still in pendingCallIds.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -424,7 +425,7 @@ void main() {
     });
 
     testWidgets('tearDown fires performEndCall for every active main-process call', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -461,7 +462,7 @@ void main() {
 
   group('main-process signaling path — deduplication (Android only)', () {
     testWidgets('duplicate reportNewIncomingCall returns callIdAlreadyExists', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -481,7 +482,7 @@ void main() {
     testWidgets('answered call re-report returns callIdAlreadyExistsAndAnswered', (WidgetTester _) async {
       // Regression: before the removePending fix, the stale pendingCallIds entry
       // from the rejected re-report caused tearDown to fire performEndCall twice.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -508,7 +509,7 @@ void main() {
       // Verifies that removePending() is called when CS rejects the re-report,
       // so tearDown does not see the callId in both getAll() and
       // drainUnconnectedPendingCallIds() and fire performEndCall twice.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -569,7 +570,7 @@ void main() {
     testWidgets('re-report of already-answered call fires performAnswerCall', (WidgetTester _) async {
       // Regression: the ALREADY_ANSWERED early-exit returned without firing
       // performAnswerCall, so WebRTC never started after cold-start adoption.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -604,7 +605,7 @@ void main() {
       // Regression: promote() was never called in the ALREADY_ANSWERED branch,
       // so core.exists(callId) was false and endCall() logged
       // "no connection or pending entry" without firing performEndCall.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -639,7 +640,7 @@ void main() {
       // (promote() was called) and fire performEndCall exactly once.
       // drainUnconnectedPendingCallIds() must not also include it (promote()
       // removes it from pendingCallIds), preventing a double-fire.
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -257,7 +258,7 @@ void main() {
 
   group('mute while on hold (Android only)', () {
     testWidgets('setMuted(true) while held fires performSetMuted(true)', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -294,7 +295,7 @@ void main() {
     });
 
     testWidgets('setMuted(false) while held fires performSetMuted(false)', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -345,7 +346,7 @@ void main() {
 
   group('DTMF while on hold (Android only)', () {
     testWidgets("sendDTMF('5') while held fires performSendDTMF", (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -386,7 +387,7 @@ void main() {
 
   group('two-call hold swap (Android only)', () {
     testWidgets('hold call1, answer call2, unhold call1 produces correct holdEvents', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -446,7 +447,7 @@ void main() {
     });
 
     testWidgets('DTMF on call2 while call1 is held routes only to call2', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -502,7 +503,7 @@ void main() {
 
   group('nested controls: mute then hold (Android only)', () {
     testWidgets('mute then hold then end fires each callback exactly once', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -425,7 +425,7 @@ void main() {
     /// performEndCall fires; the absence of performAnswerCall confirms the
     /// correct (decline, not answer) callback sequence ran.
     testWidgets('decline unanswered call fires performEndCall, not performAnswerCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -475,7 +475,7 @@ void main() {
     /// before the BYE was sent. The fix serialises the teardown so BYE
     /// always precedes WebSocket close.
     testWidgets('immediate decline (no delay) still fires performEndCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -507,7 +507,7 @@ void main() {
     /// the full cleanup path (performEndCall → release → releaseResources)
     /// completed and the ConnectionManager's terminated set was updated.
     testWidgets('after decline, re-reporting same ID returns callIdAlreadyTerminated', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -564,7 +564,7 @@ void main() {
     /// as a generic duplicate error.
     testWidgets('answered call - second reportNewIncomingCall returns callIdAlreadyExistsAndAnswered',
         (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -720,7 +720,7 @@ void main() {
 
   group('stress - push + direct (Android only)', () {
     testWidgets('push then direct same ID - direct returns callIdAlreadyExists', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -743,7 +743,7 @@ void main() {
     });
 
     testWidgets('mixed push + direct spam 3x same ID - system stays stable', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -792,7 +792,7 @@ void main() {
     // broadcast from :callkeep_core must NOT reach Flutter as didPushIncomingCall.
     // If it did, CallBloc would add a second ActiveCall for the same callId.
     testWidgets('reportNewIncomingCall via signaling does not fire didPushIncomingCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -816,7 +816,7 @@ void main() {
 
     // Push path must still fire didPushIncomingCall (unchanged behaviour).
     testWidgets('push-path reportNewIncomingCall still fires didPushIncomingCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }
@@ -851,7 +851,7 @@ void main() {
 
   group('performAudioDevicesUpdate callback (Android only)', () {
     testWidgets('performAudioDevicesUpdate fires with non-empty devices after answerCall', (WidgetTester _) async {
-      if (!Platform.isAndroid) {
+      if (kIsWeb || !Platform.isAndroid) {
         markTestSkipped('Android only');
         return;
       }

--- a/webtrit_callkeep/example/test_driver/integration_test.dart
+++ b/webtrit_callkeep/example/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/webtrit_callkeep/lib/src/callkeep_connections.dart
+++ b/webtrit_callkeep/lib/src/callkeep_connections.dart
@@ -20,7 +20,7 @@ class CallkeepConnections {
   ///
   /// Returns a [Future] resolving to a [CallkeepConnection] if found, or null otherwise.
   Future<CallkeepConnection?> getConnection(String callId) {
-    if (kIsWeb || !Platform.isAndroid) {
+    if (!kIsWeb && !Platform.isAndroid) {
       return Future.value();
     }
 
@@ -32,7 +32,7 @@ class CallkeepConnections {
   /// If the platform is web or not Android, it returns immediately.
   /// Otherwise, it performs the platform-specific cleanup of connections.
   Future<void> cleanConnections() {
-    if (kIsWeb || !Platform.isAndroid) {
+    if (!kIsWeb && !Platform.isAndroid) {
       return Future.value();
     }
 
@@ -44,7 +44,7 @@ class CallkeepConnections {
   /// Returns a [Future] that resolves to a list of [CallkeepConnection] objects representing
   /// the active connections.
   Future<List<CallkeepConnection>> getConnections() {
-    if (kIsWeb || !Platform.isAndroid) {
+    if (!kIsWeb && !Platform.isAndroid) {
       return Future.value([]);
     }
 
@@ -56,7 +56,7 @@ class CallkeepConnections {
   /// Set the signaling status for the current activity connection,
   /// represented by the [CallkeepSignalingStatus] enum.
   Future<void> updateActivitySignalingStatus(CallkeepSignalingStatus status) {
-    if (kIsWeb || !Platform.isAndroid) {
+    if (!kIsWeb && !Platform.isAndroid) {
       return Future.value();
     }
 

--- a/webtrit_callkeep_web/README.md
+++ b/webtrit_callkeep_web/README.md
@@ -1,10 +1,33 @@
 # webtrit_callkeep_web
 
-Web stub implementation of [`webtrit_callkeep`](../webtrit_callkeep/README.md).
+Web implementation of [`webtrit_callkeep`](../webtrit_callkeep/README.md).
 
-This package is a no-op placeholder that satisfies the federated plugin requirement for Web.
-No native call UI or background call handling is implemented. All API methods return silently or
-throw `UnimplementedError`.
+Manages call state in memory and forwards all events to the registered
+`CallkeepDelegate`. There is no native call UI on the web — incoming and
+outgoing call screens are rendered entirely by the Flutter application.
+
+## What is implemented
+
+| Feature | Status |
+|---|---|
+| `setUp` / `tearDown` | Supported |
+| `reportNewIncomingCall` | Supported (in-memory, delegate notified) |
+| `startCall` / `answerCall` / `endCall` | Supported (delegate notified) |
+| `setHeld` / `setMuted` / `sendDTMF` | Supported (delegate notified) |
+| `setAudioDevice` | Supported (delegate notified) |
+| `getConnection` / `getConnections` / `cleanConnections` | Supported |
+| `getDiagnosticReport` | Returns basic web diagnostics |
+
+## What is no-op
+
+| Feature | Notes |
+|---|---|
+| Android background/push notification service | Android-only |
+| Android SMS reception | Android-only |
+| Android activity control (lock screen, wake) | Android-only |
+| iOS PushKit / push registry | iOS-only |
+| Native permissions (phone state, etc.) | Returns `granted` for all |
+| Speaker / ringback sound | Handled by the WebRTC layer |
 
 ---
 

--- a/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
+++ b/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
@@ -1,12 +1,362 @@
 import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
 
 /// The Web implementation of [WebtritCallkeepPlatform].
+///
+/// Manages call state in memory and forwards events to the registered
+/// [CallkeepDelegate]. Platform-specific features (Android background
+/// services, SMS, lock-screen control, iOS PushKit) are no-ops.
 class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
-  /// Registers this class as the default instance of [WebtritCallkeepPlatform]
+  /// Registers this class as the default instance of [WebtritCallkeepPlatform].
   static void registerWith([Object? registrar]) {
     WebtritCallkeepPlatform.instance = WebtritCallkeepWeb();
   }
 
+  CallkeepDelegate? _delegate;
+  bool _isSetUp = false;
+  final Map<String, CallkeepConnection> _connections = {};
+
+  // ---------------------------------------------------------------------------
+  // Platform identity
+  // ---------------------------------------------------------------------------
+
   @override
   Future<String?> getPlatformName() async => 'Web';
+
+  // ---------------------------------------------------------------------------
+  // Delegates
+  // ---------------------------------------------------------------------------
+
+  @override
+  void setDelegate(CallkeepDelegate? delegate) {
+    _delegate = delegate;
+  }
+
+  @override
+  void setBackgroundServiceDelegate(CallkeepBackgroundServiceDelegate? delegate) {
+    // No background service on web.
+  }
+
+  @override
+  void setLogsDelegate(CallkeepLogsDelegate? delegate) {
+    // No native logging on web.
+  }
+
+  @override
+  void setPushRegistryDelegate(PushRegistryDelegate? delegate) {
+    // No PushKit on web.
+  }
+
+  // ---------------------------------------------------------------------------
+  // Push token
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<String?> pushTokenForPushTypeVoIP() async => null;
+
+  // ---------------------------------------------------------------------------
+  // Setup / teardown
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<bool> isSetUp() async => _isSetUp;
+
+  @override
+  Future<void> setUp(CallkeepOptions options) async {
+    _isSetUp = true;
+  }
+
+  @override
+  Future<void> tearDown() async {
+    _isSetUp = false;
+    _connections.clear();
+    _delegate?.didReset();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Incoming call reporting
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<CallkeepIncomingCallError?> reportNewIncomingCall(
+    String callId,
+    CallkeepHandle handle,
+    String? displayName,
+    bool hasVideo,
+  ) async {
+    _connections[callId] = CallkeepConnection(
+      callId: callId,
+      state: CallkeepConnectionState.stateRinging,
+      disconnectCause: null,
+    );
+    _delegate?.didPushIncomingCall(handle, displayName, hasVideo, callId, null);
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Outgoing call reporting
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> reportConnectingOutgoingCall(String callId) async {
+    _updateConnectionState(callId, CallkeepConnectionState.stateDialing);
+  }
+
+  @override
+  Future<void> reportConnectedOutgoingCall(String callId) async {
+    _updateConnectionState(callId, CallkeepConnectionState.stateActive);
+    _delegate?.didActivateAudioSession();
+  }
+
+  @override
+  Future<void> reportUpdateCall(
+    String callId,
+    CallkeepHandle? handle,
+    String? displayName,
+    bool? hasVideo,
+    bool? proximityEnabled,
+  ) async {
+    // No native call UI to update on web.
+  }
+
+  @override
+  Future<void> reportEndCall(String callId, String displayName, CallkeepEndCallReason reason) async {
+    _connections.remove(callId);
+    _delegate?.didDeactivateAudioSession();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Call actions (triggered by Flutter UI on web)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<CallkeepCallRequestError?> startCall(
+    String callId,
+    CallkeepHandle handle,
+    String? displayNameOrContactIdentifier,
+    bool video,
+    bool proximityEnabled,
+  ) async {
+    _connections[callId] = CallkeepConnection(
+      callId: callId,
+      state: CallkeepConnectionState.stateDialing,
+      disconnectCause: null,
+    );
+    await _delegate?.performStartCall(callId, handle, displayNameOrContactIdentifier, video);
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> answerCall(String callId) async {
+    _updateConnectionState(callId, CallkeepConnectionState.stateActive);
+    await _delegate?.performAnswerCall(callId);
+    _delegate?.didActivateAudioSession();
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> endCall(String callId) async {
+    await _delegate?.performEndCall(callId);
+    _connections.remove(callId);
+    _delegate?.didDeactivateAudioSession();
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> setHeld(String callId, bool onHold) async {
+    _updateConnectionState(callId, onHold ? CallkeepConnectionState.stateHolding : CallkeepConnectionState.stateActive);
+    await _delegate?.performSetHeld(callId, onHold);
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> setMuted(String callId, bool muted) async {
+    await _delegate?.performSetMuted(callId, muted);
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> sendDTMF(String callId, String key) async {
+    await _delegate?.performSendDTMF(callId, key);
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> setSpeaker(String callId, bool enabled) async {
+    // No native speaker routing on web; handled by WebRTC.
+    return null;
+  }
+
+  @override
+  Future<CallkeepCallRequestError?> setAudioDevice(String callId, CallkeepAudioDevice device) async {
+    await _delegate?.performAudioDeviceSet(callId, device);
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connections
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<CallkeepConnection?> getConnection(String callId) async => _connections[callId];
+
+  @override
+  Future<List<CallkeepConnection>> getConnections() async => _connections.values.toList();
+
+  @override
+  Future<void> cleanConnections() async => _connections.clear();
+
+  // ---------------------------------------------------------------------------
+  // Signaling status
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> updateActivitySignalingStatus(CallkeepSignalingStatus status) async {
+    // No native signaling indicator on web.
+  }
+
+  // ---------------------------------------------------------------------------
+  // Permissions (web grants all by default)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<CallkeepSpecialPermissionStatus> getFullScreenIntentPermissionStatus() async {
+    return CallkeepSpecialPermissionStatus.granted;
+  }
+
+  @override
+  Future<void> openFullScreenIntentSettings() async {}
+
+  @override
+  Future<void> openSettings() async {}
+
+  @override
+  Future<CallkeepAndroidBatteryMode> getBatteryMode() async {
+    return CallkeepAndroidBatteryMode.unknown;
+  }
+
+  @override
+  Future<Map<CallkeepPermission, CallkeepSpecialPermissionStatus>> requestPermissions(
+    List<CallkeepPermission> permissions,
+  ) async {
+    return {for (final p in permissions) p: CallkeepSpecialPermissionStatus.granted};
+  }
+
+  @override
+  Future<Map<CallkeepPermission, CallkeepSpecialPermissionStatus>> checkPermissionsStatus(
+    List<CallkeepPermission> permissions,
+  ) async {
+    return {for (final p in permissions) p: CallkeepSpecialPermissionStatus.granted};
+  }
+
+  // ---------------------------------------------------------------------------
+  // Diagnostics
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<Map<String, dynamic>> getDiagnosticReport() async {
+    return {'platform': 'web', 'isSetUp': _isSetUp, 'activeConnections': _connections.length};
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ringback
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> playRingbackSound() async {
+    // Ringback is handled by the WebRTC layer on web.
+  }
+
+  @override
+  Future<void> stopRingbackSound() async {}
+
+  // ---------------------------------------------------------------------------
+  // Android background signaling service (no-op on web)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> initializeBackgroundSignalingServiceCallback(ForegroundStartServiceHandle onSync) async {}
+
+  @override
+  Future<void> configureBackgroundSignalingService({
+    String? androidNotificationName,
+    String? androidNotificationDescription,
+  }) async {}
+
+  @override
+  void startBackgroundSignalingService() {}
+
+  @override
+  void stopBackgroundSignalingService() {}
+
+  @override
+  Future<dynamic> endCallsBackgroundSignalingService() async {}
+
+  @override
+  Future<dynamic> endCallBackgroundSignalingService(String callId) async {}
+
+  @override
+  Future<dynamic> incomingCallBackgroundSignalingService(
+    String callId,
+    CallkeepHandle handle,
+    String? displayName,
+    bool hasVideo,
+  ) async {}
+
+  // ---------------------------------------------------------------------------
+  // Android background push notification service (no-op on web)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> initializePushNotificationCallback(CallKeepPushNotificationSyncStatusHandle onSync) async {}
+
+  @override
+  Future<void> configurePushNotificationSignalingService({bool launchBackgroundIsolateEvenIfAppIsOpen = false}) async {}
+
+  @override
+  Future<CallkeepIncomingCallError?> incomingCallPushNotificationService(
+    String callId,
+    CallkeepHandle handle,
+    String? displayName,
+    bool hasVideo,
+  ) async => null;
+
+  @override
+  Future<dynamic> endCallsBackgroundPushNotificationService() async {}
+
+  @override
+  Future<dynamic> endCallBackgroundPushNotificationService(String callId) async {}
+
+  // ---------------------------------------------------------------------------
+  // Android SMS reception (no-op on web)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> initializeSmsReception({required String messagePrefix, required String regexPattern}) async {}
+
+  // ---------------------------------------------------------------------------
+  // Android activity control (no-op on web)
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> showOverLockscreen([bool enable = true]) async {}
+
+  @override
+  Future<void> wakeScreenOnShow([bool enable = true]) async {}
+
+  @override
+  Future<bool> sendToBackground() async => false;
+
+  @override
+  Future<bool> isDeviceLocked() async => false;
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  void _updateConnectionState(String callId, CallkeepConnectionState state) {
+    final conn = _connections[callId];
+    if (conn != null) {
+      _connections[callId] = CallkeepConnection(callId: callId, state: state, disconnectCause: conn.disconnectCause);
+    }
+  }
 }

--- a/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
+++ b/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
@@ -13,7 +13,14 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
 
   CallkeepDelegate? _delegate;
   bool _isSetUp = false;
+
+  /// Active connections keyed by callId.
   final Map<String, CallkeepConnection> _connections = {};
+
+  /// Call IDs that have been terminated (ended or torn down).
+  /// Used to return [CallkeepIncomingCallError.callIdAlreadyTerminated]
+  /// on a re-report of the same ID.
+  final Set<String> _terminatedCallIds = {};
 
   // ---------------------------------------------------------------------------
   // Platform identity
@@ -32,19 +39,13 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   }
 
   @override
-  void setBackgroundServiceDelegate(CallkeepBackgroundServiceDelegate? delegate) {
-    // No background service on web.
-  }
+  void setBackgroundServiceDelegate(CallkeepBackgroundServiceDelegate? delegate) {}
 
   @override
-  void setLogsDelegate(CallkeepLogsDelegate? delegate) {
-    // No native logging on web.
-  }
+  void setLogsDelegate(CallkeepLogsDelegate? delegate) {}
 
   @override
-  void setPushRegistryDelegate(PushRegistryDelegate? delegate) {
-    // No PushKit on web.
-  }
+  void setPushRegistryDelegate(PushRegistryDelegate? delegate) {}
 
   // ---------------------------------------------------------------------------
   // Push token
@@ -68,7 +69,14 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   @override
   Future<void> tearDown() async {
     _isSetUp = false;
+    // Notify Flutter for every still-active call before clearing state.
+    final activeIds = _connections.keys.toList();
+    for (final callId in activeIds) {
+      _terminatedCallIds.add(callId);
+      await _delegate?.performEndCall(callId);
+    }
     _connections.clear();
+    _terminatedCallIds.clear();
     _delegate?.didReset();
   }
 
@@ -83,6 +91,16 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
     String? displayName,
     bool hasVideo,
   ) async {
+    if (_connections.containsKey(callId)) {
+      final state = _connections[callId]!.state;
+      if (state == CallkeepConnectionState.stateActive) {
+        return CallkeepIncomingCallError.callIdAlreadyExistsAndAnswered;
+      }
+      return CallkeepIncomingCallError.callIdAlreadyExists;
+    }
+    if (_terminatedCallIds.contains(callId)) {
+      return CallkeepIncomingCallError.callIdAlreadyTerminated;
+    }
     _connections[callId] = CallkeepConnection(
       callId: callId,
       state: CallkeepConnectionState.stateRinging,
@@ -114,18 +132,17 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
     String? displayName,
     bool? hasVideo,
     bool? proximityEnabled,
-  ) async {
-    // No native call UI to update on web.
-  }
+  ) async {}
 
   @override
   Future<void> reportEndCall(String callId, String displayName, CallkeepEndCallReason reason) async {
     _connections.remove(callId);
+    _terminatedCallIds.add(callId);
     _delegate?.didDeactivateAudioSession();
   }
 
   // ---------------------------------------------------------------------------
-  // Call actions (triggered by Flutter UI on web)
+  // Call actions
   // ---------------------------------------------------------------------------
 
   @override
@@ -147,6 +164,9 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
 
   @override
   Future<CallkeepCallRequestError?> answerCall(String callId) async {
+    if (!_connections.containsKey(callId)) {
+      return CallkeepCallRequestError.unknownCallUuid;
+    }
     _updateConnectionState(callId, CallkeepConnectionState.stateActive);
     await _delegate?.performAnswerCall(callId);
     _delegate?.didActivateAudioSession();
@@ -155,6 +175,10 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
 
   @override
   Future<CallkeepCallRequestError?> endCall(String callId) async {
+    if (!_connections.containsKey(callId)) {
+      return CallkeepCallRequestError.unknownCallUuid;
+    }
+    _terminatedCallIds.add(callId);
     await _delegate?.performEndCall(callId);
     _connections.remove(callId);
     _delegate?.didDeactivateAudioSession();
@@ -163,6 +187,9 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
 
   @override
   Future<CallkeepCallRequestError?> setHeld(String callId, bool onHold) async {
+    if (!_connections.containsKey(callId)) {
+      return CallkeepCallRequestError.unknownCallUuid;
+    }
     _updateConnectionState(callId, onHold ? CallkeepConnectionState.stateHolding : CallkeepConnectionState.stateActive);
     await _delegate?.performSetHeld(callId, onHold);
     return null;
@@ -181,10 +208,7 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   }
 
   @override
-  Future<CallkeepCallRequestError?> setSpeaker(String callId, bool enabled) async {
-    // No native speaker routing on web; handled by WebRTC.
-    return null;
-  }
+  Future<CallkeepCallRequestError?> setSpeaker(String callId, bool enabled) async => null;
 
   @override
   Future<CallkeepCallRequestError?> setAudioDevice(String callId, CallkeepAudioDevice device) async {
@@ -203,16 +227,17 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   Future<List<CallkeepConnection>> getConnections() async => _connections.values.toList();
 
   @override
-  Future<void> cleanConnections() async => _connections.clear();
+  Future<void> cleanConnections() async {
+    _connections.clear();
+    _terminatedCallIds.clear();
+  }
 
   // ---------------------------------------------------------------------------
   // Signaling status
   // ---------------------------------------------------------------------------
 
   @override
-  Future<void> updateActivitySignalingStatus(CallkeepSignalingStatus status) async {
-    // No native signaling indicator on web.
-  }
+  Future<void> updateActivitySignalingStatus(CallkeepSignalingStatus status) async {}
 
   // ---------------------------------------------------------------------------
   // Permissions (web grants all by default)
@@ -230,9 +255,7 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   Future<void> openSettings() async {}
 
   @override
-  Future<CallkeepAndroidBatteryMode> getBatteryMode() async {
-    return CallkeepAndroidBatteryMode.unknown;
-  }
+  Future<CallkeepAndroidBatteryMode> getBatteryMode() async => CallkeepAndroidBatteryMode.unknown;
 
   @override
   Future<Map<CallkeepPermission, CallkeepSpecialPermissionStatus>> requestPermissions(
@@ -262,9 +285,7 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   // ---------------------------------------------------------------------------
 
   @override
-  Future<void> playRingbackSound() async {
-    // Ringback is handled by the WebRTC layer on web.
-  }
+  Future<void> playRingbackSound() async {}
 
   @override
   Future<void> stopRingbackSound() async {}


### PR DESCRIPTION
## Summary

- Replace the empty no-op stub with a complete in-memory implementation of `WebtritCallkeepPlatform` for the web target
- Call state is managed via a `Map<String, CallkeepConnection>`; all call lifecycle events are forwarded to the registered `CallkeepDelegate`
- Android-only (background service, SMS reception, activity/lock-screen control) and iOS-only (PushKit, push registry) features are silent no-ops
- Permissions return `granted` on web; speaker/ringback are no-ops (handled by the WebRTC layer)
- Update `webtrit_callkeep_web/README.md` to reflect the new implementation status

## Implemented methods

| Method | Behaviour |
|---|---|
| `setUp` / `tearDown` | Sets flag, clears connections, notifies `didReset` |
| `reportNewIncomingCall` | Creates ringing connection, calls `didPushIncomingCall` |
| `startCall` | Creates dialing connection, calls `performStartCall` |
| `answerCall` | Moves to active, calls `performAnswerCall` + `didActivateAudioSession` |
| `endCall` | Calls `performEndCall`, removes connection, `didDeactivateAudioSession` |
| `setHeld` / `setMuted` / `sendDTMF` / `setAudioDevice` | Delegate forwarded |
| `getConnection` / `getConnections` / `cleanConnections` | In-memory map |
| `getDiagnosticReport` | Returns `{platform, isSetUp, activeConnections}` |

## Test plan

- [ ] `flutter analyze` in `webtrit_callkeep_web` passes with no issues
- [ ] Call lifecycle integration test on Chrome (start, answer, end)
- [ ] Hold / mute / DTMF delegate callbacks fire as expected
- [ ] `tearDown` clears all connections and calls `didReset`