### PR TITLE
fix(android): defer reportNewIncomingCall callback until Telecom confirms

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -353,7 +353,15 @@ void main() {
 
       await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
           .reportNewIncomingCall(id2, _handle2, displayName: 'Frank');
-      await _waitForConnection(id2);
+
+      // On OEM devices that reject concurrent incoming calls, id2 is never
+      // promoted (no DidPushIncomingCall). Skip rather than waiting the full
+      // _waitForConnection timeout on every run on such devices.
+      final conn2 = await _waitForConnection(id2);
+      if (conn2 == null) {
+        markTestSkipped('device does not support concurrent incoming calls');
+        return;
+      }
 
       await callkeep.endCall(id1);
       await callkeep.endCall(id2);

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -336,10 +336,12 @@ void main() {
       // Wait for id1 to be promoted (DidPushIncomingCall received) before
       // adding id2. This ensures Telecom sees id1 in RINGING state first.
       await _waitForConnection(id1);
-      await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
-          .reportNewIncomingCall(id2, _handle2, displayName: 'Frank');
-      await _waitForConnection(id2);
 
+      // Register the callback before reporting id2. Telecom may call
+      // onCreateIncomingConnectionFailed for id2 (BUSY — id1 is RINGING),
+      // which fires performEndCall immediately via the HungUp broadcast path.
+      // Registering here ensures that early firing is captured even if
+      // _waitForConnection(id2) times out before endCall(id2) is called.
       final endedIds = <String>[];
       final allDone = Completer<void>();
       delegate.onPerformEndCall = (cid) {
@@ -348,6 +350,10 @@ void main() {
           if (endedIds.length == 2 && !allDone.isCompleted) allDone.complete();
         }
       };
+
+      await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
+          .reportNewIncomingCall(id2, _handle2, displayName: 'Frank');
+      await _waitForConnection(id2);
 
       await callkeep.endCall(id1);
       await callkeep.endCall(id2);

--- a/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
@@ -782,7 +782,14 @@ void main() {
       // Now answer id2. Wait for the Telecom connection to exist in
       // :callkeep_core before calling answerCall — the connection is created
       // asynchronously and answerCall fails silently if called too early.
-      await _waitForConnection(id2);
+      // On some OEM devices (e.g. Huawei), Telecom rejects the second incoming
+      // call even when the first is active. Skip if the device does not support
+      // concurrent self-managed calls.
+      final conn2 = await _waitForConnection(id2);
+      if (conn2 == null) {
+        markTestSkipped('device does not support concurrent incoming calls');
+        return;
+      }
       final answer2Latch = Completer<void>();
       delegate.onPerformAnswerCall = (cid) {
         if (cid == id2 && !answer2Latch.isCompleted) answer2Latch.complete();

--- a/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_call_scenarios_test.dart
@@ -805,15 +805,28 @@ void main() {
       final id1 = _nextId();
       final id2 = _nextId();
 
-      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Wendy');
-      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Xavier');
+      final err1 = await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Wendy');
+      final err2 = await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Xavier');
+
+      // On devices that do not support concurrent self-managed calls (standard
+      // Android 11+, Huawei, other OEMs), the second call is rejected by Telecom
+      // and never confirmed to Flutter, so performEndCall will only fire for the
+      // accepted calls.
+      final expectedIds = <String>{};
+      if (err1 == null) expectedIds.add(id1);
+      if (err2 == null) expectedIds.add(id2);
+
+      if (expectedIds.isEmpty) {
+        markTestSkipped('device rejected all incoming calls');
+        return;
+      }
 
       final endedIds = <String>[];
       final allEnded = Completer<void>();
       delegate.onPerformEndCall = (cid) {
-        if ({id1, id2}.contains(cid) && !endedIds.contains(cid)) {
+        if (expectedIds.contains(cid) && !endedIds.contains(cid)) {
           endedIds.add(cid);
-          if (endedIds.length == 2 && !allEnded.isCompleted) allEnded.complete();
+          if (endedIds.length == expectedIds.length && !allEnded.isCompleted) allEnded.complete();
         }
       };
 
@@ -821,7 +834,7 @@ void main() {
       await callkeep.endCall(id2);
 
       await _waitFor(allEnded.future, label: 'both performEndCall');
-      expect(endedIds, containsAll([id1, id2]));
+      expect(endedIds, containsAll(expectedIds.toList()));
     });
   });
 

--- a/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
@@ -435,20 +435,27 @@ void main() {
 
       await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Jack');
       await Future.delayed(const Duration(milliseconds: 200));
-      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Kate');
+      final err2 = await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Kate');
+
+      // On OEM devices that do not support concurrent self-managed calls (e.g.
+      // Huawei), the second reportNewIncomingCall returns callRejectedBySystem.
+      // In that case the call was never confirmed to Flutter, so tearDown will
+      // only fire performEndCall for the calls that were actually accepted.
+      final expectedIds = <String>{id1};
+      if (err2 == null) expectedIds.add(id2);
 
       final endedIds = <String>[];
       final allDone = Completer<void>();
       delegate.onPerformEndCall = (cid) {
-        if ({id1, id2}.contains(cid) && !endedIds.contains(cid)) {
+        if (expectedIds.contains(cid) && !endedIds.contains(cid)) {
           endedIds.add(cid);
-          if (endedIds.length == 2 && !allDone.isCompleted) allDone.complete();
+          if (endedIds.length == expectedIds.length && !allDone.isCompleted) allDone.complete();
         }
       };
 
       await callkeep.tearDown();
-      await _waitFor(allDone.future, label: 'both performEndCall on tearDown');
-      expect(endedIds, containsAll([id1, id2]));
+      await _waitFor(allDone.future, label: 'performEndCall on tearDown for accepted calls');
+      expect(endedIds, containsAll(expectedIds.toList()));
     });
   });
 

--- a/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_state_machine_test.dart
@@ -409,7 +409,15 @@ void main() {
       // Wait for id2's Telecom connection to be created before proceeding.
       // The connection is built asynchronously in :callkeep_core and may not
       // exist yet by the time answerCall is called.
-      await _waitForConnection(id2);
+      // On some OEM devices (e.g. Huawei), Telecom rejects the second incoming
+      // call even when the first is active. If _waitForConnection returns null
+      // the device does not support concurrent self-managed calls and the
+      // remainder of this scenario cannot be exercised.
+      final conn2 = await _waitForConnection(id2);
+      if (conn2 == null) {
+        markTestSkipped('device does not support concurrent incoming calls');
+        return;
+      }
 
       // Hold id1
       final holdLatch = Completer<void>();
@@ -463,7 +471,12 @@ void main() {
       await _waitFor(answer1Latch.future, label: 'performAnswerCall id1');
 
       await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Hank');
-      await _waitForConnection(id2);
+      // Same OEM guard as in the hold-swap test above: skip if Telecom rejects id2.
+      final conn2 = await _waitForConnection(id2);
+      if (conn2 == null) {
+        markTestSkipped('device does not support concurrent incoming calls');
+        return;
+      }
 
       // Hold id1
       final holdLatch = Completer<void>();

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -250,8 +250,15 @@ void main() {
         displayName: 'Call 2',
       );
 
-      expect(err1, isNull);
-      expect(err2, isNull);
+      expect(err1, isNull, reason: 'first call must succeed');
+      // On OEM devices that do not support concurrent self-managed calls (e.g.
+      // Huawei), the second call is rejected by Telecom and returns
+      // callRejectedBySystem. Accept this as a valid outcome.
+      expect(
+        err2 == null || err2 == CallkeepIncomingCallError.callRejectedBySystem,
+        isTrue,
+        reason: 'second call must succeed or be rejected by system (OEM device limitation)',
+      );
     });
   });
 
@@ -378,31 +385,41 @@ void main() {
       final id1 = _nextId();
       final id2 = _nextId();
 
-      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
-      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+      final err1 = await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
+      final err2 = await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+
+      // On OEM devices that do not support concurrent self-managed calls (e.g.
+      // Huawei), the second call is rejected and never confirmed to Flutter, so
+      // tearDown will only fire performEndCall for the accepted calls.
+      final expectedIds = <String>{};
+      if (err1 == null) expectedIds.add(id1);
+      if (err2 == null) expectedIds.add(id2);
+
+      if (expectedIds.isEmpty) {
+        markTestSkipped('device rejected all incoming calls');
+        return;
+      }
 
       final endedIds = <String>[];
       final latch = Completer<void>();
-      var count = 0;
       // Filter by expected IDs so stale callbacks from earlier tests don't
       // prematurely complete the latch.
       delegate.onPerformEndCall = (id) {
-        if (!{id1, id2}.contains(id)) return;
+        if (!expectedIds.contains(id)) return;
         endedIds.add(id);
-        count++;
-        if (count == 2 && !latch.isCompleted) latch.complete();
+        if (endedIds.length == expectedIds.length && !latch.isCompleted) latch.complete();
       };
 
       await callkeep.tearDown();
 
       // Pigeon delivers performEndCall asynchronously from the Dart side even
-      // though Kotlin fires them synchronously. Wait for both callbacks.
+      // though Kotlin fires them synchronously. Wait for all expected callbacks.
       await latch.future.timeout(
         const Duration(seconds: 10),
         onTimeout: () => throw TimeoutException('not all performEndCall fired: $endedIds'),
       );
 
-      expect(endedIds, containsAll([id1, id2]));
+      expect(endedIds, containsAll(expectedIds.toList()));
     });
   });
 

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -344,16 +344,28 @@ void main() {
       final id1 = _nextId();
       final id2 = _nextId();
 
-      await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
-      await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+      final err1 = await callkeep.reportNewIncomingCall(id1, _handle1, displayName: 'Call 1');
+      final err2 = await callkeep.reportNewIncomingCall(id2, _handle2, displayName: 'Call 2');
+
+      // On devices that do not support concurrent self-managed calls (standard
+      // Android 11+, Huawei, other OEMs), the second call is rejected by Telecom
+      // and never confirmed to Flutter, so performEndCall will only fire for the
+      // accepted calls.
+      final expectedIds = <String>{};
+      if (err1 == null) expectedIds.add(id1);
+      if (err2 == null) expectedIds.add(id2);
+
+      if (expectedIds.isEmpty) {
+        markTestSkipped('device rejected all incoming calls');
+        return;
+      }
 
       final endedIds = <String>[];
       final latch = Completer<void>();
-      var count = 0;
       delegate.onPerformEndCall = (id) {
+        if (!expectedIds.contains(id)) return;
         endedIds.add(id);
-        count++;
-        if (count == 2) latch.complete();
+        if (endedIds.length == expectedIds.length && !latch.isCompleted) latch.complete();
       };
 
       await callkeep.endCall(id1);
@@ -364,8 +376,8 @@ void main() {
         onTimeout: () => throw TimeoutException('not all performEndCall fired: $endedIds'),
       );
 
-      expect(endedIds, containsAll([id1, id2]));
-      expect(endedIds.length, 2);
+      expect(endedIds, containsAll(expectedIds.toList()));
+      expect(endedIds.length, expectedIds.length);
     });
 
     testWidgets('spam same ID concurrently - exactly one succeeds', (WidgetTester _) async {

--- a/webtrit_callkeep/example/run_integration_tests.sh
+++ b/webtrit_callkeep/example/run_integration_tests.sh
@@ -90,6 +90,14 @@ cleanup_device() {
 
 run_test_file() {
   local test_file="$1"
+  # Retry once on infrastructure failures (WebSocket drop during loading).
+  # These are not test-logic failures -- they occur when the Flutter test
+  # runner cannot attach to the app after a long previous test file.
+  if flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"; then
+    return 0
+  fi
+  echo "  [retry] $test_file failed, cleaning up and retrying once..."
+  cleanup_device
   flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"
 }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -9,64 +9,64 @@ import io.flutter.plugin.common.BasicMessageChannel
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MessageCodec
-import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.common.StandardMethodCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
+
 private object GeneratedPigeonUtils {
+    fun createConnectionError(channelName: String): FlutterError = FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 
-  fun createConnectionError(channelName: String): FlutterError {
-    return FlutterError("channel-error",  "Unable to establish connection on channel: '$channelName'.", "")  }
+    fun wrapResult(result: Any?): List<Any?> = listOf(result)
 
-  fun wrapResult(result: Any?): List<Any?> {
-    return listOf(result)
-  }
+    fun wrapError(exception: Throwable): List<Any?> =
+        if (exception is FlutterError) {
+            listOf(
+                exception.code,
+                exception.message,
+                exception.details,
+            )
+        } else {
+            listOf(
+                exception.javaClass.simpleName,
+                exception.toString(),
+                "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception),
+            )
+        }
 
-  fun wrapError(exception: Throwable): List<Any?> {
-    return if (exception is FlutterError) {
-      listOf(
-        exception.code,
-        exception.message,
-        exception.details
-      )
-    } else {
-      listOf(
-        exception.javaClass.simpleName,
-        exception.toString(),
-        "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception)
-      )
+    fun deepEquals(
+        a: Any?,
+        b: Any?,
+    ): Boolean {
+        if (a is ByteArray && b is ByteArray) {
+            return a.contentEquals(b)
+        }
+        if (a is IntArray && b is IntArray) {
+            return a.contentEquals(b)
+        }
+        if (a is LongArray && b is LongArray) {
+            return a.contentEquals(b)
+        }
+        if (a is DoubleArray && b is DoubleArray) {
+            return a.contentEquals(b)
+        }
+        if (a is Array<*> && b is Array<*>) {
+            return a.size == b.size &&
+                a.indices.all { deepEquals(a[it], b[it]) }
+        }
+        if (a is List<*> && b is List<*>) {
+            return a.size == b.size &&
+                a.indices.all { deepEquals(a[it], b[it]) }
+        }
+        if (a is Map<*, *> && b is Map<*, *>) {
+            return a.size == b.size &&
+                a.all {
+                    (b as Map<Any?, Any?>).contains(it.key) &&
+                        deepEquals(it.value, b[it.key])
+                }
+        }
+        return a == b
     }
-  }
-  fun deepEquals(a: Any?, b: Any?): Boolean {
-    if (a is ByteArray && b is ByteArray) {
-        return a.contentEquals(b)
-    }
-    if (a is IntArray && b is IntArray) {
-        return a.contentEquals(b)
-    }
-    if (a is LongArray && b is LongArray) {
-        return a.contentEquals(b)
-    }
-    if (a is DoubleArray && b is DoubleArray) {
-        return a.contentEquals(b)
-    }
-    if (a is Array<*> && b is Array<*>) {
-      return a.size == b.size &&
-          a.indices.all{ deepEquals(a[it], b[it]) }
-    }
-    if (a is List<*> && b is List<*>) {
-      return a.size == b.size &&
-          a.indices.all{ deepEquals(a[it], b[it]) }
-    }
-    if (a is Map<*, *> && b is Map<*, *>) {
-      return a.size == b.size && a.all {
-          (b as Map<Any?, Any?>).contains(it.key) &&
-          deepEquals(it.value, b[it.key])
-      }
-    }
-    return a == b
-  }
-      
 }
 
 /**
@@ -75,2575 +75,2997 @@ private object GeneratedPigeonUtils {
  * @property message The error message.
  * @property details The error details. Must be a datatype supported by the api codec.
  */
-class FlutterError (
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
+class FlutterError(
+    val code: String,
+    override val message: String? = null,
+    val details: Any? = null,
 ) : Throwable()
 
-enum class PLogTypeEnum(val raw: Int) {
-  DEBUG(0),
-  ERROR(1),
-  INFO(2),
-  VERBOSE(3),
-  WARN(4);
+enum class PLogTypeEnum(
+    val raw: Int,
+) {
+    DEBUG(0),
+    ERROR(1),
+    INFO(2),
+    VERBOSE(3),
+    WARN(4),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PLogTypeEnum? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PLogTypeEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepPermission(val raw: Int) {
-  READ_PHONE_STATE(0),
-  READ_PHONE_NUMBERS(1);
+enum class PCallkeepPermission(
+    val raw: Int,
+) {
+    READ_PHONE_STATE(0),
+    READ_PHONE_NUMBERS(1),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepPermission? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepPermission? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PSpecialPermissionStatusTypeEnum(val raw: Int) {
-  DENIED(0),
-  GRANTED(1),
-  UNKNOWN(2);
+enum class PSpecialPermissionStatusTypeEnum(
+    val raw: Int,
+) {
+    DENIED(0),
+    GRANTED(1),
+    UNKNOWN(2),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PSpecialPermissionStatusTypeEnum? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PSpecialPermissionStatusTypeEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepAndroidBatteryMode(val raw: Int) {
-  UNRESTRICTED(0),
-  OPTIMIZED(1),
-  RESTRICTED(2),
-  UNKNOWN(3);
+enum class PCallkeepAndroidBatteryMode(
+    val raw: Int,
+) {
+    UNRESTRICTED(0),
+    OPTIMIZED(1),
+    RESTRICTED(2),
+    UNKNOWN(3),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepAndroidBatteryMode? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepAndroidBatteryMode? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PHandleTypeEnum(val raw: Int) {
-  GENERIC(0),
-  NUMBER(1),
-  EMAIL(2);
+enum class PHandleTypeEnum(
+    val raw: Int,
+) {
+    GENERIC(0),
+    NUMBER(1),
+    EMAIL(2),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PHandleTypeEnum? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PHandleTypeEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallInfoConsts(val raw: Int) {
-  UUID(0),
-  DTMF(1),
-  IS_VIDEO(2),
-  NUMBER(3),
-  NAME(4);
+enum class PCallInfoConsts(
+    val raw: Int,
+) {
+    UUID(0),
+    DTMF(1),
+    IS_VIDEO(2),
+    NUMBER(3),
+    NAME(4),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallInfoConsts? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallInfoConsts? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PEndCallReasonEnum(val raw: Int) {
-  FAILED(0),
-  REMOTE_ENDED(1),
-  UNANSWERED(2),
-  ANSWERED_ELSEWHERE(3),
-  DECLINED_ELSEWHERE(4),
-  MISSED(5);
+enum class PEndCallReasonEnum(
+    val raw: Int,
+) {
+    FAILED(0),
+    REMOTE_ENDED(1),
+    UNANSWERED(2),
+    ANSWERED_ELSEWHERE(3),
+    DECLINED_ELSEWHERE(4),
+    MISSED(5),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PEndCallReasonEnum? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PEndCallReasonEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PAudioDeviceType(val raw: Int) {
-  EARPIECE(0),
-  SPEAKER(1),
-  BLUETOOTH(2),
-  WIRED_HEADSET(3),
-  STREAMING(4),
-  UNKNOWN(5);
+enum class PAudioDeviceType(
+    val raw: Int,
+) {
+    EARPIECE(0),
+    SPEAKER(1),
+    BLUETOOTH(2),
+    WIRED_HEADSET(3),
+    STREAMING(4),
+    UNKNOWN(5),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PAudioDeviceType? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PAudioDeviceType? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PIncomingCallErrorEnum(val raw: Int) {
-  UNKNOWN(0),
-  UNENTITLED(1),
-  CALL_ID_ALREADY_EXISTS(2),
-  CALL_ID_ALREADY_EXISTS_AND_ANSWERED(3),
-  CALL_ID_ALREADY_TERMINATED(4),
-  FILTERED_BY_DO_NOT_DISTURB(5),
-  FILTERED_BY_BLOCK_LIST(6),
-  INTERNAL(7);
+enum class PIncomingCallErrorEnum(
+    val raw: Int,
+) {
+    UNKNOWN(0),
+    UNENTITLED(1),
+    CALL_ID_ALREADY_EXISTS(2),
+    CALL_ID_ALREADY_EXISTS_AND_ANSWERED(3),
+    CALL_ID_ALREADY_TERMINATED(4),
+    FILTERED_BY_DO_NOT_DISTURB(5),
+    FILTERED_BY_BLOCK_LIST(6),
+    INTERNAL(7),
+    CALL_REJECTED_BY_SYSTEM(8),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PIncomingCallErrorEnum? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PIncomingCallErrorEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallRequestErrorEnum(val raw: Int) {
-  UNKNOWN(0),
-  UNENTITLED(1),
-  UNKNOWN_CALL_UUID(2),
-  CALL_UUID_ALREADY_EXISTS(3),
-  MAXIMUM_CALL_GROUPS_REACHED(4),
-  INTERNAL(5),
-  EMERGENCY_NUMBER(6),
-  /**
-   * Android only.
-   *
-   * Triggered when the phone is not registered as a self-managed
-   * [PhoneAccount]. As a result, the `ConnectionService` cannot create
-   * a connection, and the system throws an exception such as
-   * `CALL_PHONE permission required to place calls`, because it attempts
-   * to use the GSM dialer instead of VoIP.
-   */
-  SELF_MANAGED_PHONE_ACCOUNT_NOT_REGISTERED(7),
-  /**
-   * Android only.
-   *
-   * Occurs when the outgoing/incoming call request times out because the
-   * system TelecomManager failed to bind to the ConnectionService or provide
-   * a response within the expected timeframe.
-   *
-   * Typical causes:
-   * - Zombie State: After an app crash or OS kill, TelecomManager might
-   *   retain a stale binder connection to the previous (dead) process.
-   * - Stale Binding: The system assumes the PhoneAccount is active but
-   *   fails to trigger `onCreateOutgoingConnection`.
-   * - Cold Start Latency: On certain vendors (e.g., Itel, Android One),
-   *   the OS may deadlock or time out during service binding after a cold start.
-   */
-  TIMEOUT(8);
+enum class PCallRequestErrorEnum(
+    val raw: Int,
+) {
+    UNKNOWN(0),
+    UNENTITLED(1),
+    UNKNOWN_CALL_UUID(2),
+    CALL_UUID_ALREADY_EXISTS(3),
+    MAXIMUM_CALL_GROUPS_REACHED(4),
+    INTERNAL(5),
+    EMERGENCY_NUMBER(6),
 
-  companion object {
-    fun ofRaw(raw: Int): PCallRequestErrorEnum? {
-      return values().firstOrNull { it.raw == raw }
+    /**
+     * Android only.
+     *
+     * Triggered when the phone is not registered as a self-managed
+     * [PhoneAccount]. As a result, the `ConnectionService` cannot create
+     * a connection, and the system throws an exception such as
+     * `CALL_PHONE permission required to place calls`, because it attempts
+     * to use the GSM dialer instead of VoIP.
+     */
+    SELF_MANAGED_PHONE_ACCOUNT_NOT_REGISTERED(7),
+
+    /**
+     * Android only.
+     *
+     * Occurs when the outgoing/incoming call request times out because the
+     * system TelecomManager failed to bind to the ConnectionService or provide
+     * a response within the expected timeframe.
+     *
+     * Typical causes:
+     * - Zombie State: After an app crash or OS kill, TelecomManager might
+     *   retain a stale binder connection to the previous (dead) process.
+     * - Stale Binding: The system assumes the PhoneAccount is active but
+     *   fails to trigger `onCreateOutgoingConnection`.
+     * - Cold Start Latency: On certain vendors (e.g., Itel, Android One),
+     *   the OS may deadlock or time out during service binding after a cold start.
+     */
+    TIMEOUT(8),
+    ;
+
+    companion object {
+        fun ofRaw(raw: Int): PCallRequestErrorEnum? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepLifecycleEvent(val raw: Int) {
-  ON_CREATE(0),
-  ON_START(1),
-  ON_RESUME(2),
-  ON_PAUSE(3),
-  ON_STOP(4),
-  ON_DESTROY(5),
-  ON_ANY(6);
+enum class PCallkeepLifecycleEvent(
+    val raw: Int,
+) {
+    ON_CREATE(0),
+    ON_START(1),
+    ON_RESUME(2),
+    ON_PAUSE(3),
+    ON_STOP(4),
+    ON_DESTROY(5),
+    ON_ANY(6),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepLifecycleEvent? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepLifecycleEvent? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepPushNotificationSyncStatus(val raw: Int) {
-  SYNCHRONIZE_CALL_STATUS(0),
-  RELEASE_RESOURCES(1);
+enum class PCallkeepPushNotificationSyncStatus(
+    val raw: Int,
+) {
+    SYNCHRONIZE_CALL_STATUS(0),
+    RELEASE_RESOURCES(1),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepPushNotificationSyncStatus? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepPushNotificationSyncStatus? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepConnectionState(val raw: Int) {
-  STATE_INITIALIZING(0),
-  STATE_NEW(1),
-  STATE_RINGING(2),
-  STATE_DIALING(3),
-  STATE_ACTIVE(4),
-  STATE_HOLDING(5),
-  STATE_DISCONNECTED(6),
-  STATE_PULLING_CALL(7);
+enum class PCallkeepConnectionState(
+    val raw: Int,
+) {
+    STATE_INITIALIZING(0),
+    STATE_NEW(1),
+    STATE_RINGING(2),
+    STATE_DIALING(3),
+    STATE_ACTIVE(4),
+    STATE_HOLDING(5),
+    STATE_DISCONNECTED(6),
+    STATE_PULLING_CALL(7),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepConnectionState? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepConnectionState? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepDisconnectCauseType(val raw: Int) {
-  UNKNOWN(0),
-  ERROR(1),
-  LOCAL(2),
-  REMOTE(3),
-  CANCELED(4),
-  MISSED(5),
-  REJECTED(6),
-  BUSY(7),
-  RESTRICTED(8),
-  OTHER(9),
-  CONNECTION_MANAGER_NOT_SUPPORTED(10),
-  ANSWERED_ELSEWHERE(11),
-  CALL_PULLED(12);
+enum class PCallkeepDisconnectCauseType(
+    val raw: Int,
+) {
+    UNKNOWN(0),
+    ERROR(1),
+    LOCAL(2),
+    REMOTE(3),
+    CANCELED(4),
+    MISSED(5),
+    REJECTED(6),
+    BUSY(7),
+    RESTRICTED(8),
+    OTHER(9),
+    CONNECTION_MANAGER_NOT_SUPPORTED(10),
+    ANSWERED_ELSEWHERE(11),
+    CALL_PULLED(12),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepDisconnectCauseType? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepDisconnectCauseType? = values().firstOrNull { it.raw == raw }
     }
-  }
 }
 
-enum class PCallkeepSignalingStatus(val raw: Int) {
-  DISCONNECTING(0),
-  DISCONNECT(1),
-  CONNECTING(2),
-  CONNECT(3),
-  FAILURE(4);
+enum class PCallkeepSignalingStatus(
+    val raw: Int,
+) {
+    DISCONNECTING(0),
+    DISCONNECT(1),
+    CONNECTING(2),
+    CONNECT(3),
+    FAILURE(4),
+    ;
 
-  companion object {
-    fun ofRaw(raw: Int): PCallkeepSignalingStatus? {
-      return values().firstOrNull { it.raw == raw }
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepSignalingStatus? = values().firstOrNull { it.raw == raw }
     }
-  }
-}
-
-/** Generated class from Pigeon that represents data sent in messages. */
-data class PIOSOptions (
-  val localizedName: String,
-  val ringtoneSound: String? = null,
-  val ringbackSound: String? = null,
-  val iconTemplateImageAssetName: String? = null,
-  val maximumCallGroups: Long,
-  val maximumCallsPerCallGroup: Long,
-  val supportsHandleTypeGeneric: Boolean? = null,
-  val supportsHandleTypePhoneNumber: Boolean? = null,
-  val supportsHandleTypeEmailAddress: Boolean? = null,
-  val supportsVideo: Boolean,
-  val includesCallsInRecents: Boolean,
-  val driveIdleTimerDisabled: Boolean
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PIOSOptions {
-      val localizedName = pigeonVar_list[0] as String
-      val ringtoneSound = pigeonVar_list[1] as String?
-      val ringbackSound = pigeonVar_list[2] as String?
-      val iconTemplateImageAssetName = pigeonVar_list[3] as String?
-      val maximumCallGroups = pigeonVar_list[4] as Long
-      val maximumCallsPerCallGroup = pigeonVar_list[5] as Long
-      val supportsHandleTypeGeneric = pigeonVar_list[6] as Boolean?
-      val supportsHandleTypePhoneNumber = pigeonVar_list[7] as Boolean?
-      val supportsHandleTypeEmailAddress = pigeonVar_list[8] as Boolean?
-      val supportsVideo = pigeonVar_list[9] as Boolean
-      val includesCallsInRecents = pigeonVar_list[10] as Boolean
-      val driveIdleTimerDisabled = pigeonVar_list[11] as Boolean
-      return PIOSOptions(localizedName, ringtoneSound, ringbackSound, iconTemplateImageAssetName, maximumCallGroups, maximumCallsPerCallGroup, supportsHandleTypeGeneric, supportsHandleTypePhoneNumber, supportsHandleTypeEmailAddress, supportsVideo, includesCallsInRecents, driveIdleTimerDisabled)
-    }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      localizedName,
-      ringtoneSound,
-      ringbackSound,
-      iconTemplateImageAssetName,
-      maximumCallGroups,
-      maximumCallsPerCallGroup,
-      supportsHandleTypeGeneric,
-      supportsHandleTypePhoneNumber,
-      supportsHandleTypeEmailAddress,
-      supportsVideo,
-      includesCallsInRecents,
-      driveIdleTimerDisabled,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PIOSOptions) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
-
-  override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PAndroidOptions (
-  val ringtoneSound: String? = null,
-  val ringbackSound: String? = null,
-  val incomingCallFullScreen: Boolean? = null
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PAndroidOptions {
-      val ringtoneSound = pigeonVar_list[0] as String?
-      val ringbackSound = pigeonVar_list[1] as String?
-      val incomingCallFullScreen = pigeonVar_list[2] as Boolean?
-      return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen)
+data class PIOSOptions(
+    val localizedName: String,
+    val ringtoneSound: String? = null,
+    val ringbackSound: String? = null,
+    val iconTemplateImageAssetName: String? = null,
+    val maximumCallGroups: Long,
+    val maximumCallsPerCallGroup: Long,
+    val supportsHandleTypeGeneric: Boolean? = null,
+    val supportsHandleTypePhoneNumber: Boolean? = null,
+    val supportsHandleTypeEmailAddress: Boolean? = null,
+    val supportsVideo: Boolean,
+    val includesCallsInRecents: Boolean,
+    val driveIdleTimerDisabled: Boolean,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PIOSOptions {
+            val localizedName = pigeonVar_list[0] as String
+            val ringtoneSound = pigeonVar_list[1] as String?
+            val ringbackSound = pigeonVar_list[2] as String?
+            val iconTemplateImageAssetName = pigeonVar_list[3] as String?
+            val maximumCallGroups = pigeonVar_list[4] as Long
+            val maximumCallsPerCallGroup = pigeonVar_list[5] as Long
+            val supportsHandleTypeGeneric = pigeonVar_list[6] as Boolean?
+            val supportsHandleTypePhoneNumber = pigeonVar_list[7] as Boolean?
+            val supportsHandleTypeEmailAddress = pigeonVar_list[8] as Boolean?
+            val supportsVideo = pigeonVar_list[9] as Boolean
+            val includesCallsInRecents = pigeonVar_list[10] as Boolean
+            val driveIdleTimerDisabled = pigeonVar_list[11] as Boolean
+            return PIOSOptions(localizedName, ringtoneSound, ringbackSound, iconTemplateImageAssetName, maximumCallGroups, maximumCallsPerCallGroup, supportsHandleTypeGeneric, supportsHandleTypePhoneNumber, supportsHandleTypeEmailAddress, supportsVideo, includesCallsInRecents, driveIdleTimerDisabled)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      ringtoneSound,
-      ringbackSound,
-      incomingCallFullScreen,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PAndroidOptions) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            localizedName,
+            ringtoneSound,
+            ringbackSound,
+            iconTemplateImageAssetName,
+            maximumCallGroups,
+            maximumCallsPerCallGroup,
+            supportsHandleTypeGeneric,
+            supportsHandleTypePhoneNumber,
+            supportsHandleTypeEmailAddress,
+            supportsVideo,
+            includesCallsInRecents,
+            driveIdleTimerDisabled,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PIOSOptions) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class POptions (
-  val ios: PIOSOptions,
-  val android: PAndroidOptions
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): POptions {
-      val ios = pigeonVar_list[0] as PIOSOptions
-      val android = pigeonVar_list[1] as PAndroidOptions
-      return POptions(ios, android)
+data class PAndroidOptions(
+    val ringtoneSound: String? = null,
+    val ringbackSound: String? = null,
+    val incomingCallFullScreen: Boolean? = null,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PAndroidOptions {
+            val ringtoneSound = pigeonVar_list[0] as String?
+            val ringbackSound = pigeonVar_list[1] as String?
+            val incomingCallFullScreen = pigeonVar_list[2] as Boolean?
+            return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      ios,
-      android,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is POptions) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            ringtoneSound,
+            ringbackSound,
+            incomingCallFullScreen,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PAndroidOptions) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PAudioDevice (
-  val type: PAudioDeviceType,
-  val id: String? = null,
-  val name: String? = null
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PAudioDevice {
-      val type = pigeonVar_list[0] as PAudioDeviceType
-      val id = pigeonVar_list[1] as String?
-      val name = pigeonVar_list[2] as String?
-      return PAudioDevice(type, id, name)
+data class POptions(
+    val ios: PIOSOptions,
+    val android: PAndroidOptions,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): POptions {
+            val ios = pigeonVar_list[0] as PIOSOptions
+            val android = pigeonVar_list[1] as PAndroidOptions
+            return POptions(ios, android)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      type,
-      id,
-      name,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PAudioDevice) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            ios,
+            android,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is POptions) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PPermissionResult (
-  val permission: PCallkeepPermission,
-  val status: PSpecialPermissionStatusTypeEnum
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PPermissionResult {
-      val permission = pigeonVar_list[0] as PCallkeepPermission
-      val status = pigeonVar_list[1] as PSpecialPermissionStatusTypeEnum
-      return PPermissionResult(permission, status)
+data class PAudioDevice(
+    val type: PAudioDeviceType,
+    val id: String? = null,
+    val name: String? = null,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PAudioDevice {
+            val type = pigeonVar_list[0] as PAudioDeviceType
+            val id = pigeonVar_list[1] as String?
+            val name = pigeonVar_list[2] as String?
+            return PAudioDevice(type, id, name)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      permission,
-      status,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PPermissionResult) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            type,
+            id,
+            name,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PAudioDevice) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PHandle (
-  val type: PHandleTypeEnum,
-  val value: String
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PHandle {
-      val type = pigeonVar_list[0] as PHandleTypeEnum
-      val value = pigeonVar_list[1] as String
-      return PHandle(type, value)
+data class PPermissionResult(
+    val permission: PCallkeepPermission,
+    val status: PSpecialPermissionStatusTypeEnum,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PPermissionResult {
+            val permission = pigeonVar_list[0] as PCallkeepPermission
+            val status = pigeonVar_list[1] as PSpecialPermissionStatusTypeEnum
+            return PPermissionResult(permission, status)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      type,
-      value,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PHandle) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            permission,
+            status,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PPermissionResult) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PEndCallReason (
-  val value: PEndCallReasonEnum
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PEndCallReason {
-      val value = pigeonVar_list[0] as PEndCallReasonEnum
-      return PEndCallReason(value)
+data class PHandle(
+    val type: PHandleTypeEnum,
+    val value: String,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PHandle {
+            val type = pigeonVar_list[0] as PHandleTypeEnum
+            val value = pigeonVar_list[1] as String
+            return PHandle(type, value)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      value,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PEndCallReason) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            type,
+            value,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PHandle) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PIncomingCallError (
-  val value: PIncomingCallErrorEnum
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PIncomingCallError {
-      val value = pigeonVar_list[0] as PIncomingCallErrorEnum
-      return PIncomingCallError(value)
+data class PEndCallReason(
+    val value: PEndCallReasonEnum,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PEndCallReason {
+            val value = pigeonVar_list[0] as PEndCallReasonEnum
+            return PEndCallReason(value)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      value,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PIncomingCallError) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            value,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PEndCallReason) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PCallRequestError (
-  val value: PCallRequestErrorEnum
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PCallRequestError {
-      val value = pigeonVar_list[0] as PCallRequestErrorEnum
-      return PCallRequestError(value)
+data class PIncomingCallError(
+    val value: PIncomingCallErrorEnum,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PIncomingCallError {
+            val value = pigeonVar_list[0] as PIncomingCallErrorEnum
+            return PIncomingCallError(value)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      value,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PCallRequestError) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            value,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PIncomingCallError) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PCallkeepIncomingCallData (
-  val callId: String,
-  val handle: PHandle? = null,
-  val displayName: String? = null,
-  val hasVideo: Boolean
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PCallkeepIncomingCallData {
-      val callId = pigeonVar_list[0] as String
-      val handle = pigeonVar_list[1] as PHandle?
-      val displayName = pigeonVar_list[2] as String?
-      val hasVideo = pigeonVar_list[3] as Boolean
-      return PCallkeepIncomingCallData(callId, handle, displayName, hasVideo)
+data class PCallRequestError(
+    val value: PCallRequestErrorEnum,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PCallRequestError {
+            val value = pigeonVar_list[0] as PCallRequestErrorEnum
+            return PCallRequestError(value)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      callId,
-      handle,
-      displayName,
-      hasVideo,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PCallkeepIncomingCallData) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            value,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PCallRequestError) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PCallkeepServiceStatus (
-  val lifecycleEvent: PCallkeepLifecycleEvent,
-  val mainSignalingStatus: PCallkeepSignalingStatus? = null
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PCallkeepServiceStatus {
-      val lifecycleEvent = pigeonVar_list[0] as PCallkeepLifecycleEvent
-      val mainSignalingStatus = pigeonVar_list[1] as PCallkeepSignalingStatus?
-      return PCallkeepServiceStatus(lifecycleEvent, mainSignalingStatus)
+data class PCallkeepIncomingCallData(
+    val callId: String,
+    val handle: PHandle? = null,
+    val displayName: String? = null,
+    val hasVideo: Boolean,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PCallkeepIncomingCallData {
+            val callId = pigeonVar_list[0] as String
+            val handle = pigeonVar_list[1] as PHandle?
+            val displayName = pigeonVar_list[2] as String?
+            val hasVideo = pigeonVar_list[3] as Boolean
+            return PCallkeepIncomingCallData(callId, handle, displayName, hasVideo)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      lifecycleEvent,
-      mainSignalingStatus,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PCallkeepServiceStatus) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            callId,
+            handle,
+            displayName,
+            hasVideo,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PCallkeepIncomingCallData) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PCallkeepDisconnectCause (
-  val type: PCallkeepDisconnectCauseType,
-  val reason: String? = null
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PCallkeepDisconnectCause {
-      val type = pigeonVar_list[0] as PCallkeepDisconnectCauseType
-      val reason = pigeonVar_list[1] as String?
-      return PCallkeepDisconnectCause(type, reason)
+data class PCallkeepServiceStatus(
+    val lifecycleEvent: PCallkeepLifecycleEvent,
+    val mainSignalingStatus: PCallkeepSignalingStatus? = null,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PCallkeepServiceStatus {
+            val lifecycleEvent = pigeonVar_list[0] as PCallkeepLifecycleEvent
+            val mainSignalingStatus = pigeonVar_list[1] as PCallkeepSignalingStatus?
+            return PCallkeepServiceStatus(lifecycleEvent, mainSignalingStatus)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      type,
-      reason,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PCallkeepDisconnectCause) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            lifecycleEvent,
+            mainSignalingStatus,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PCallkeepServiceStatus) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
-data class PCallkeepConnection (
-  val callId: String,
-  val state: PCallkeepConnectionState,
-  val disconnectCause: PCallkeepDisconnectCause
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): PCallkeepConnection {
-      val callId = pigeonVar_list[0] as String
-      val state = pigeonVar_list[1] as PCallkeepConnectionState
-      val disconnectCause = pigeonVar_list[2] as PCallkeepDisconnectCause
-      return PCallkeepConnection(callId, state, disconnectCause)
+data class PCallkeepDisconnectCause(
+    val type: PCallkeepDisconnectCauseType,
+    val reason: String? = null,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PCallkeepDisconnectCause {
+            val type = pigeonVar_list[0] as PCallkeepDisconnectCauseType
+            val reason = pigeonVar_list[1] as String?
+            return PCallkeepDisconnectCause(type, reason)
+        }
     }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      callId,
-      state,
-      disconnectCause,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is PCallkeepConnection) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return GeneratedPigeonUtils.deepEquals(toList(), other.toList())  }
 
-  override fun hashCode(): Int = toList().hashCode()
+    fun toList(): List<Any?> =
+        listOf(
+            type,
+            reason,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PCallkeepDisconnectCause) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
 }
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class PCallkeepConnection(
+    val callId: String,
+    val state: PCallkeepConnectionState,
+    val disconnectCause: PCallkeepDisconnectCause,
+) {
+    companion object {
+        fun fromList(pigeonVar_list: List<Any?>): PCallkeepConnection {
+            val callId = pigeonVar_list[0] as String
+            val state = pigeonVar_list[1] as PCallkeepConnectionState
+            val disconnectCause = pigeonVar_list[2] as PCallkeepDisconnectCause
+            return PCallkeepConnection(callId, state, disconnectCause)
+        }
+    }
+
+    fun toList(): List<Any?> =
+        listOf(
+            callId,
+            state,
+            disconnectCause,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is PCallkeepConnection) {
+            return false
+        }
+        if (this === other) {
+            return true
+        }
+        return GeneratedPigeonUtils.deepEquals(toList(), other.toList())
+    }
+
+    override fun hashCode(): Int = toList().hashCode()
+}
+
 private open class GeneratedPigeonCodec : StandardMessageCodec() {
-  override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
-    return when (type) {
-      129.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PLogTypeEnum.ofRaw(it.toInt())
-        }
-      }
-      130.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepPermission.ofRaw(it.toInt())
-        }
-      }
-      131.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PSpecialPermissionStatusTypeEnum.ofRaw(it.toInt())
-        }
-      }
-      132.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepAndroidBatteryMode.ofRaw(it.toInt())
-        }
-      }
-      133.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PHandleTypeEnum.ofRaw(it.toInt())
-        }
-      }
-      134.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallInfoConsts.ofRaw(it.toInt())
-        }
-      }
-      135.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PEndCallReasonEnum.ofRaw(it.toInt())
-        }
-      }
-      136.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PAudioDeviceType.ofRaw(it.toInt())
-        }
-      }
-      137.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PIncomingCallErrorEnum.ofRaw(it.toInt())
-        }
-      }
-      138.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallRequestErrorEnum.ofRaw(it.toInt())
-        }
-      }
-      139.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepLifecycleEvent.ofRaw(it.toInt())
-        }
-      }
-      140.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepPushNotificationSyncStatus.ofRaw(it.toInt())
-        }
-      }
-      141.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepConnectionState.ofRaw(it.toInt())
-        }
-      }
-      142.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepDisconnectCauseType.ofRaw(it.toInt())
-        }
-      }
-      143.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          PCallkeepSignalingStatus.ofRaw(it.toInt())
-        }
-      }
-      144.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PIOSOptions.fromList(it)
-        }
-      }
-      145.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PAndroidOptions.fromList(it)
-        }
-      }
-      146.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          POptions.fromList(it)
-        }
-      }
-      147.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PAudioDevice.fromList(it)
-        }
-      }
-      148.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PPermissionResult.fromList(it)
-        }
-      }
-      149.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PHandle.fromList(it)
-        }
-      }
-      150.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PEndCallReason.fromList(it)
-        }
-      }
-      151.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PIncomingCallError.fromList(it)
-        }
-      }
-      152.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PCallRequestError.fromList(it)
-        }
-      }
-      153.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PCallkeepIncomingCallData.fromList(it)
-        }
-      }
-      154.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PCallkeepServiceStatus.fromList(it)
-        }
-      }
-      155.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PCallkeepDisconnectCause.fromList(it)
-        }
-      }
-      156.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PCallkeepConnection.fromList(it)
-        }
-      }
-      else -> super.readValueOfType(type, buffer)
-    }
-  }
-  override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
-    when (value) {
-      is PLogTypeEnum -> {
-        stream.write(129)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepPermission -> {
-        stream.write(130)
-        writeValue(stream, value.raw)
-      }
-      is PSpecialPermissionStatusTypeEnum -> {
-        stream.write(131)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepAndroidBatteryMode -> {
-        stream.write(132)
-        writeValue(stream, value.raw)
-      }
-      is PHandleTypeEnum -> {
-        stream.write(133)
-        writeValue(stream, value.raw)
-      }
-      is PCallInfoConsts -> {
-        stream.write(134)
-        writeValue(stream, value.raw)
-      }
-      is PEndCallReasonEnum -> {
-        stream.write(135)
-        writeValue(stream, value.raw)
-      }
-      is PAudioDeviceType -> {
-        stream.write(136)
-        writeValue(stream, value.raw)
-      }
-      is PIncomingCallErrorEnum -> {
-        stream.write(137)
-        writeValue(stream, value.raw)
-      }
-      is PCallRequestErrorEnum -> {
-        stream.write(138)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepLifecycleEvent -> {
-        stream.write(139)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepPushNotificationSyncStatus -> {
-        stream.write(140)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepConnectionState -> {
-        stream.write(141)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepDisconnectCauseType -> {
-        stream.write(142)
-        writeValue(stream, value.raw)
-      }
-      is PCallkeepSignalingStatus -> {
-        stream.write(143)
-        writeValue(stream, value.raw)
-      }
-      is PIOSOptions -> {
-        stream.write(144)
-        writeValue(stream, value.toList())
-      }
-      is PAndroidOptions -> {
-        stream.write(145)
-        writeValue(stream, value.toList())
-      }
-      is POptions -> {
-        stream.write(146)
-        writeValue(stream, value.toList())
-      }
-      is PAudioDevice -> {
-        stream.write(147)
-        writeValue(stream, value.toList())
-      }
-      is PPermissionResult -> {
-        stream.write(148)
-        writeValue(stream, value.toList())
-      }
-      is PHandle -> {
-        stream.write(149)
-        writeValue(stream, value.toList())
-      }
-      is PEndCallReason -> {
-        stream.write(150)
-        writeValue(stream, value.toList())
-      }
-      is PIncomingCallError -> {
-        stream.write(151)
-        writeValue(stream, value.toList())
-      }
-      is PCallRequestError -> {
-        stream.write(152)
-        writeValue(stream, value.toList())
-      }
-      is PCallkeepIncomingCallData -> {
-        stream.write(153)
-        writeValue(stream, value.toList())
-      }
-      is PCallkeepServiceStatus -> {
-        stream.write(154)
-        writeValue(stream, value.toList())
-      }
-      is PCallkeepDisconnectCause -> {
-        stream.write(155)
-        writeValue(stream, value.toList())
-      }
-      is PCallkeepConnection -> {
-        stream.write(156)
-        writeValue(stream, value.toList())
-      }
-      else -> super.writeValue(stream, value)
-    }
-  }
-}
+    override fun readValueOfType(
+        type: Byte,
+        buffer: ByteBuffer,
+    ): Any? {
+        return when (type) {
+            129.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PLogTypeEnum.ofRaw(it.toInt())
+                }
+            }
 
+            130.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepPermission.ofRaw(it.toInt())
+                }
+            }
+
+            131.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PSpecialPermissionStatusTypeEnum.ofRaw(it.toInt())
+                }
+            }
+
+            132.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepAndroidBatteryMode.ofRaw(it.toInt())
+                }
+            }
+
+            133.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PHandleTypeEnum.ofRaw(it.toInt())
+                }
+            }
+
+            134.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallInfoConsts.ofRaw(it.toInt())
+                }
+            }
+
+            135.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PEndCallReasonEnum.ofRaw(it.toInt())
+                }
+            }
+
+            136.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PAudioDeviceType.ofRaw(it.toInt())
+                }
+            }
+
+            137.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PIncomingCallErrorEnum.ofRaw(it.toInt())
+                }
+            }
+
+            138.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallRequestErrorEnum.ofRaw(it.toInt())
+                }
+            }
+
+            139.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepLifecycleEvent.ofRaw(it.toInt())
+                }
+            }
+
+            140.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepPushNotificationSyncStatus.ofRaw(it.toInt())
+                }
+            }
+
+            141.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepConnectionState.ofRaw(it.toInt())
+                }
+            }
+
+            142.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepDisconnectCauseType.ofRaw(it.toInt())
+                }
+            }
+
+            143.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepSignalingStatus.ofRaw(it.toInt())
+                }
+            }
+
+            144.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PIOSOptions.fromList(it)
+                }
+            }
+
+            145.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PAndroidOptions.fromList(it)
+                }
+            }
+
+            146.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    POptions.fromList(it)
+                }
+            }
+
+            147.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PAudioDevice.fromList(it)
+                }
+            }
+
+            148.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PPermissionResult.fromList(it)
+                }
+            }
+
+            149.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PHandle.fromList(it)
+                }
+            }
+
+            150.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PEndCallReason.fromList(it)
+                }
+            }
+
+            151.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PIncomingCallError.fromList(it)
+                }
+            }
+
+            152.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PCallRequestError.fromList(it)
+                }
+            }
+
+            153.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PCallkeepIncomingCallData.fromList(it)
+                }
+            }
+
+            154.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PCallkeepServiceStatus.fromList(it)
+                }
+            }
+
+            155.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PCallkeepDisconnectCause.fromList(it)
+                }
+            }
+
+            156.toByte() -> {
+                return (readValue(buffer) as? List<Any?>)?.let {
+                    PCallkeepConnection.fromList(it)
+                }
+            }
+
+            else -> {
+                super.readValueOfType(type, buffer)
+            }
+        }
+    }
+
+    override fun writeValue(
+        stream: ByteArrayOutputStream,
+        value: Any?,
+    ) {
+        when (value) {
+            is PLogTypeEnum -> {
+                stream.write(129)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepPermission -> {
+                stream.write(130)
+                writeValue(stream, value.raw)
+            }
+
+            is PSpecialPermissionStatusTypeEnum -> {
+                stream.write(131)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepAndroidBatteryMode -> {
+                stream.write(132)
+                writeValue(stream, value.raw)
+            }
+
+            is PHandleTypeEnum -> {
+                stream.write(133)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallInfoConsts -> {
+                stream.write(134)
+                writeValue(stream, value.raw)
+            }
+
+            is PEndCallReasonEnum -> {
+                stream.write(135)
+                writeValue(stream, value.raw)
+            }
+
+            is PAudioDeviceType -> {
+                stream.write(136)
+                writeValue(stream, value.raw)
+            }
+
+            is PIncomingCallErrorEnum -> {
+                stream.write(137)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallRequestErrorEnum -> {
+                stream.write(138)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepLifecycleEvent -> {
+                stream.write(139)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepPushNotificationSyncStatus -> {
+                stream.write(140)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepConnectionState -> {
+                stream.write(141)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepDisconnectCauseType -> {
+                stream.write(142)
+                writeValue(stream, value.raw)
+            }
+
+            is PCallkeepSignalingStatus -> {
+                stream.write(143)
+                writeValue(stream, value.raw)
+            }
+
+            is PIOSOptions -> {
+                stream.write(144)
+                writeValue(stream, value.toList())
+            }
+
+            is PAndroidOptions -> {
+                stream.write(145)
+                writeValue(stream, value.toList())
+            }
+
+            is POptions -> {
+                stream.write(146)
+                writeValue(stream, value.toList())
+            }
+
+            is PAudioDevice -> {
+                stream.write(147)
+                writeValue(stream, value.toList())
+            }
+
+            is PPermissionResult -> {
+                stream.write(148)
+                writeValue(stream, value.toList())
+            }
+
+            is PHandle -> {
+                stream.write(149)
+                writeValue(stream, value.toList())
+            }
+
+            is PEndCallReason -> {
+                stream.write(150)
+                writeValue(stream, value.toList())
+            }
+
+            is PIncomingCallError -> {
+                stream.write(151)
+                writeValue(stream, value.toList())
+            }
+
+            is PCallRequestError -> {
+                stream.write(152)
+                writeValue(stream, value.toList())
+            }
+
+            is PCallkeepIncomingCallData -> {
+                stream.write(153)
+                writeValue(stream, value.toList())
+            }
+
+            is PCallkeepServiceStatus -> {
+                stream.write(154)
+                writeValue(stream, value.toList())
+            }
+
+            is PCallkeepDisconnectCause -> {
+                stream.write(155)
+                writeValue(stream, value.toList())
+            }
+
+            is PCallkeepConnection -> {
+                stream.write(156)
+                writeValue(stream, value.toList())
+            }
+
+            else -> {
+                super.writeValue(stream, value)
+            }
+        }
+    }
+}
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostBackgroundSignalingIsolateBootstrapApi {
-  fun initializeSignalingServiceCallback(callbackDispatcher: Long, onSync: Long, callback: (Result<Unit>) -> Unit)
-  fun configureSignalingService(androidNotificationName: String?, androidNotificationDescription: String?, callback: (Result<Unit>) -> Unit)
-  fun startService(callback: (Result<Unit>) -> Unit)
-  fun stopService(callback: (Result<Unit>) -> Unit)
+    fun initializeSignalingServiceCallback(
+        callbackDispatcher: Long,
+        onSync: Long,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostBackgroundSignalingIsolateBootstrapApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun configureSignalingService(
+        androidNotificationName: String?,
+        androidNotificationDescription: String?,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun startService(callback: (Result<Unit>) -> Unit)
+
+    fun stopService(callback: (Result<Unit>) -> Unit)
+
+    companion object {
+        /** The codec used by PHostBackgroundSignalingIsolateBootstrapApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostBackgroundSignalingIsolateBootstrapApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostBackgroundSignalingIsolateBootstrapApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.initializeSignalingServiceCallback$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callbackDispatcherArg = args[0] as Long
+                        val onSyncArg = args[1] as Long
+                        api.initializeSignalingServiceCallback(callbackDispatcherArg, onSyncArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.configureSignalingService$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val androidNotificationNameArg = args[0] as String?
+                        val androidNotificationDescriptionArg = args[1] as String?
+                        api.configureSignalingService(androidNotificationNameArg, androidNotificationDescriptionArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.startService$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.startService { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.stopService$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.stopService { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostBackgroundSignalingIsolateBootstrapApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostBackgroundSignalingIsolateBootstrapApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.initializeSignalingServiceCallback$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callbackDispatcherArg = args[0] as Long
-            val onSyncArg = args[1] as Long
-            api.initializeSignalingServiceCallback(callbackDispatcherArg, onSyncArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.configureSignalingService$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val androidNotificationNameArg = args[0] as String?
-            val androidNotificationDescriptionArg = args[1] as String?
-            api.configureSignalingService(androidNotificationNameArg, androidNotificationDescriptionArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.startService$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.startService{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateBootstrapApi.stopService$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.stopService{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostBackgroundSignalingIsolateApi {
-  fun incomingCall(callId: String, handle: PHandle, displayName: String?, hasVideo: Boolean, callback: (Result<Unit>) -> Unit)
-  fun endCall(callId: String, callback: (Result<Unit>) -> Unit)
-  fun endAllCalls(callback: (Result<Unit>) -> Unit)
+    fun incomingCall(
+        callId: String,
+        handle: PHandle,
+        displayName: String?,
+        hasVideo: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostBackgroundSignalingIsolateApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun endCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun endAllCalls(callback: (Result<Unit>) -> Unit)
+
+    companion object {
+        /** The codec used by PHostBackgroundSignalingIsolateApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostBackgroundSignalingIsolateApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostBackgroundSignalingIsolateApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.incomingCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val handleArg = args[1] as PHandle
+                        val displayNameArg = args[2] as String?
+                        val hasVideoArg = args[3] as Boolean
+                        api.incomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.endCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.endCall(callIdArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.endAllCalls$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.endAllCalls { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostBackgroundSignalingIsolateApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostBackgroundSignalingIsolateApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.incomingCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val handleArg = args[1] as PHandle
-            val displayNameArg = args[2] as String?
-            val hasVideoArg = args[3] as Boolean
-            api.incomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.endCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.endCall(callIdArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundSignalingIsolateApi.endAllCalls$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.endAllCalls{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostBackgroundPushNotificationIsolateBootstrapApi {
-  fun initializePushNotificationCallback(callbackDispatcher: Long, onNotificationSync: Long, callback: (Result<Unit>) -> Unit)
-  fun configureSignalingService(launchBackgroundIsolateEvenIfAppIsOpen: Boolean, callback: (Result<Unit>) -> Unit)
-  fun reportNewIncomingCall(callId: String, handle: PHandle, displayName: String?, hasVideo: Boolean, callback: (Result<PIncomingCallError?>) -> Unit)
+    fun initializePushNotificationCallback(
+        callbackDispatcher: Long,
+        onNotificationSync: Long,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostBackgroundPushNotificationIsolateBootstrapApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun configureSignalingService(
+        launchBackgroundIsolateEvenIfAppIsOpen: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun reportNewIncomingCall(
+        callId: String,
+        handle: PHandle,
+        displayName: String?,
+        hasVideo: Boolean,
+        callback: (Result<PIncomingCallError?>) -> Unit,
+    )
+
+    companion object {
+        /** The codec used by PHostBackgroundPushNotificationIsolateBootstrapApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostBackgroundPushNotificationIsolateBootstrapApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostBackgroundPushNotificationIsolateBootstrapApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.initializePushNotificationCallback$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callbackDispatcherArg = args[0] as Long
+                        val onNotificationSyncArg = args[1] as Long
+                        api.initializePushNotificationCallback(callbackDispatcherArg, onNotificationSyncArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.configureSignalingService$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val launchBackgroundIsolateEvenIfAppIsOpenArg = args[0] as Boolean
+                        api.configureSignalingService(launchBackgroundIsolateEvenIfAppIsOpenArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val handleArg = args[1] as PHandle
+                        val displayNameArg = args[2] as String?
+                        val hasVideoArg = args[3] as Boolean
+                        api.reportNewIncomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<PIncomingCallError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostBackgroundPushNotificationIsolateBootstrapApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostBackgroundPushNotificationIsolateBootstrapApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.initializePushNotificationCallback$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callbackDispatcherArg = args[0] as Long
-            val onNotificationSyncArg = args[1] as Long
-            api.initializePushNotificationCallback(callbackDispatcherArg, onNotificationSyncArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.configureSignalingService$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val launchBackgroundIsolateEvenIfAppIsOpenArg = args[0] as Boolean
-            api.configureSignalingService(launchBackgroundIsolateEvenIfAppIsOpenArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val handleArg = args[1] as PHandle
-            val displayNameArg = args[2] as String?
-            val hasVideoArg = args[3] as Boolean
-            api.reportNewIncomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<PIncomingCallError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostBackgroundPushNotificationIsolateApi {
-  fun endCall(callId: String, callback: (Result<Unit>) -> Unit)
-  fun endAllCalls(callback: (Result<Unit>) -> Unit)
+    fun endCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostBackgroundPushNotificationIsolateApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-    /** Sets up an instance of `PHostBackgroundPushNotificationIsolateApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostBackgroundPushNotificationIsolateApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.endCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.endCall(callIdArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
+    fun endAllCalls(callback: (Result<Unit>) -> Unit)
+
+    companion object {
+        /** The codec used by PHostBackgroundPushNotificationIsolateApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.endAllCalls$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.endAllCalls{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
+
+        /** Sets up an instance of `PHostBackgroundPushNotificationIsolateApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostBackgroundPushNotificationIsolateApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.endCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.endCall(callIdArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
             }
-          }
-        } else {
-          channel.setMessageHandler(null)
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.endAllCalls$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.endAllCalls { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
         }
-      }
     }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostPermissionsApi {
-  fun getFullScreenIntentPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
-  fun openFullScreenIntentSettings(callback: (Result<Unit>) -> Unit)
-  fun openSettings(callback: (Result<Unit>) -> Unit)
-  fun getBatteryMode(callback: (Result<PCallkeepAndroidBatteryMode>) -> Unit)
-  fun requestPermissions(permissions: List<PCallkeepPermission>, callback: (Result<List<PPermissionResult>>) -> Unit)
-  fun checkPermissionsStatus(permissions: List<PCallkeepPermission>, callback: (Result<List<PPermissionResult>>) -> Unit)
+    fun getFullScreenIntentPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
 
-  companion object {
-    /** The codec used by PHostPermissionsApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun openFullScreenIntentSettings(callback: (Result<Unit>) -> Unit)
+
+    fun openSettings(callback: (Result<Unit>) -> Unit)
+
+    fun getBatteryMode(callback: (Result<PCallkeepAndroidBatteryMode>) -> Unit)
+
+    fun requestPermissions(
+        permissions: List<PCallkeepPermission>,
+        callback: (Result<List<PPermissionResult>>) -> Unit,
+    )
+
+    fun checkPermissionsStatus(
+        permissions: List<PCallkeepPermission>,
+        callback: (Result<List<PPermissionResult>>) -> Unit,
+    )
+
+    companion object {
+        /** The codec used by PHostPermissionsApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostPermissionsApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostPermissionsApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getFullScreenIntentPermissionStatus$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.getFullScreenIntentPermissionStatus { result: Result<PSpecialPermissionStatusTypeEnum> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openFullScreenIntentSettings$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.openFullScreenIntentSettings { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openSettings$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.openSettings { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getBatteryMode$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.getBatteryMode { result: Result<PCallkeepAndroidBatteryMode> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.requestPermissions$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val permissionsArg = args[0] as List<PCallkeepPermission>
+                        api.requestPermissions(permissionsArg) { result: Result<List<PPermissionResult>> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.checkPermissionsStatus$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val permissionsArg = args[0] as List<PCallkeepPermission>
+                        api.checkPermissionsStatus(permissionsArg) { result: Result<List<PPermissionResult>> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostPermissionsApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostPermissionsApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getFullScreenIntentPermissionStatus$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.getFullScreenIntentPermissionStatus{ result: Result<PSpecialPermissionStatusTypeEnum> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openFullScreenIntentSettings$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.openFullScreenIntentSettings{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openSettings$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.openSettings{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getBatteryMode$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.getBatteryMode{ result: Result<PCallkeepAndroidBatteryMode> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.requestPermissions$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val permissionsArg = args[0] as List<PCallkeepPermission>
-            api.requestPermissions(permissionsArg) { result: Result<List<PPermissionResult>> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.checkPermissionsStatus$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val permissionsArg = args[0] as List<PCallkeepPermission>
-            api.checkPermissionsStatus(permissionsArg) { result: Result<List<PPermissionResult>> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostDiagnosticsApi {
-  fun getDiagnosticReport(callback: (Result<Map<String, Any?>>) -> Unit)
+    fun getDiagnosticReport(callback: (Result<Map<String, Any?>>) -> Unit)
 
-  companion object {
-    /** The codec used by PHostDiagnosticsApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-    /** Sets up an instance of `PHostDiagnosticsApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostDiagnosticsApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostDiagnosticsApi.getDiagnosticReport$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.getDiagnosticReport{ result: Result<Map<String, Any?>> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
+    companion object {
+        /** The codec used by PHostDiagnosticsApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      }
+
+        /** Sets up an instance of `PHostDiagnosticsApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostDiagnosticsApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostDiagnosticsApi.getDiagnosticReport$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.getDiagnosticReport { result: Result<Map<String, Any?>> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostSoundApi {
-  fun playRingbackSound(callback: (Result<Unit>) -> Unit)
-  fun stopRingbackSound(callback: (Result<Unit>) -> Unit)
+    fun playRingbackSound(callback: (Result<Unit>) -> Unit)
 
-  companion object {
-    /** The codec used by PHostSoundApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-    /** Sets up an instance of `PHostSoundApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostSoundApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playRingbackSound$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.playRingbackSound{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
+    fun stopRingbackSound(callback: (Result<Unit>) -> Unit)
+
+    companion object {
+        /** The codec used by PHostSoundApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopRingbackSound$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.stopRingbackSound{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
+
+        /** Sets up an instance of `PHostSoundApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostSoundApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playRingbackSound$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.playRingbackSound { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
             }
-          }
-        } else {
-          channel.setMessageHandler(null)
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopRingbackSound$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.stopRingbackSound { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
         }
-      }
     }
-  }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PDelegateBackgroundRegisterFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PDelegateBackgroundRegisterFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  fun onWakeUpBackgroundHandler(userCallbackHandleArg: Long, statusArg: PCallkeepServiceStatus, callDataArg: PCallkeepIncomingCallData?, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onWakeUpBackgroundHandler$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(userCallbackHandleArg, statusArg, callDataArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PDelegateBackgroundRegisterFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PDelegateBackgroundRegisterFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun onApplicationStatusChanged(applicationStatusCallbackHandleArg: Long, statusArg: PCallkeepServiceStatus, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(applicationStatusCallbackHandleArg, statusArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun onWakeUpBackgroundHandler(
+        userCallbackHandleArg: Long,
+        statusArg: PCallkeepServiceStatus,
+        callDataArg: PCallkeepIncomingCallData?,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onWakeUpBackgroundHandler$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(userCallbackHandleArg, statusArg, callDataArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun onNotificationSync(pushNotificationSyncStatusHandleArg: Long, statusArg: PCallkeepPushNotificationSyncStatus, callDataArg: PCallkeepIncomingCallData?, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(pushNotificationSyncStatusHandleArg, statusArg, callDataArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun onApplicationStatusChanged(
+        applicationStatusCallbackHandleArg: Long,
+        statusArg: PCallkeepServiceStatus,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(applicationStatusCallbackHandleArg, statusArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    fun onNotificationSync(
+        pushNotificationSyncStatusHandleArg: Long,
+        statusArg: PCallkeepPushNotificationSyncStatus,
+        callDataArg: PCallkeepIncomingCallData?,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(pushNotificationSyncStatusHandleArg, statusArg, callDataArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostApi {
-  fun isSetUp(): Boolean
-  fun setUp(options: POptions, callback: (Result<Unit>) -> Unit)
-  fun tearDown(callback: (Result<Unit>) -> Unit)
-  fun reportNewIncomingCall(callId: String, handle: PHandle, displayName: String?, hasVideo: Boolean, callback: (Result<PIncomingCallError?>) -> Unit)
-  fun reportConnectingOutgoingCall(callId: String, callback: (Result<Unit>) -> Unit)
-  fun reportConnectedOutgoingCall(callId: String, callback: (Result<Unit>) -> Unit)
-  fun reportUpdateCall(callId: String, handle: PHandle?, displayName: String?, hasVideo: Boolean?, proximityEnabled: Boolean?, callback: (Result<Unit>) -> Unit)
-  fun reportEndCall(callId: String, displayName: String, reason: PEndCallReason, callback: (Result<Unit>) -> Unit)
-  fun startCall(callId: String, handle: PHandle, displayNameOrContactIdentifier: String?, video: Boolean, proximityEnabled: Boolean, callback: (Result<PCallRequestError?>) -> Unit)
-  fun answerCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit)
-  fun endCall(callId: String, callback: (Result<PCallRequestError?>) -> Unit)
-  fun setHeld(callId: String, onHold: Boolean, callback: (Result<PCallRequestError?>) -> Unit)
-  fun setMuted(callId: String, muted: Boolean, callback: (Result<PCallRequestError?>) -> Unit)
-  fun setSpeaker(callId: String, enabled: Boolean, callback: (Result<PCallRequestError?>) -> Unit)
-  fun setAudioDevice(callId: String, device: PAudioDevice, callback: (Result<PCallRequestError?>) -> Unit)
-  fun sendDTMF(callId: String, key: String, callback: (Result<PCallRequestError?>) -> Unit)
-  fun onDelegateSet()
+    fun isSetUp(): Boolean
 
-  companion object {
-    /** The codec used by PHostApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun setUp(
+        options: POptions,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun tearDown(callback: (Result<Unit>) -> Unit)
+
+    fun reportNewIncomingCall(
+        callId: String,
+        handle: PHandle,
+        displayName: String?,
+        hasVideo: Boolean,
+        callback: (Result<PIncomingCallError?>) -> Unit,
+    )
+
+    fun reportConnectingOutgoingCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun reportConnectedOutgoingCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun reportUpdateCall(
+        callId: String,
+        handle: PHandle?,
+        displayName: String?,
+        hasVideo: Boolean?,
+        proximityEnabled: Boolean?,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun reportEndCall(
+        callId: String,
+        displayName: String,
+        reason: PEndCallReason,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    fun startCall(
+        callId: String,
+        handle: PHandle,
+        displayNameOrContactIdentifier: String?,
+        video: Boolean,
+        proximityEnabled: Boolean,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun answerCall(
+        callId: String,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun endCall(
+        callId: String,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun setHeld(
+        callId: String,
+        onHold: Boolean,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun setMuted(
+        callId: String,
+        muted: Boolean,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun setSpeaker(
+        callId: String,
+        enabled: Boolean,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun setAudioDevice(
+        callId: String,
+        device: PAudioDevice,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun sendDTMF(
+        callId: String,
+        key: String,
+        callback: (Result<PCallRequestError?>) -> Unit,
+    )
+
+    fun onDelegateSet()
+
+    companion object {
+        /** The codec used by PHostApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.isSetUp$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        val wrapped: List<Any?> =
+                            try {
+                                listOf(api.isSetUp())
+                            } catch (exception: Throwable) {
+                                GeneratedPigeonUtils.wrapError(exception)
+                            }
+                        reply.reply(wrapped)
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setUp$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val optionsArg = args[0] as POptions
+                        api.setUp(optionsArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.tearDown$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.tearDown { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportNewIncomingCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val handleArg = args[1] as PHandle
+                        val displayNameArg = args[2] as String?
+                        val hasVideoArg = args[3] as Boolean
+                        api.reportNewIncomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<PIncomingCallError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportConnectingOutgoingCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.reportConnectingOutgoingCall(callIdArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportConnectedOutgoingCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.reportConnectedOutgoingCall(callIdArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportUpdateCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val handleArg = args[1] as PHandle?
+                        val displayNameArg = args[2] as String?
+                        val hasVideoArg = args[3] as Boolean?
+                        val proximityEnabledArg = args[4] as Boolean?
+                        api.reportUpdateCall(callIdArg, handleArg, displayNameArg, hasVideoArg, proximityEnabledArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportEndCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val displayNameArg = args[1] as String
+                        val reasonArg = args[2] as PEndCallReason
+                        api.reportEndCall(callIdArg, displayNameArg, reasonArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.startCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val handleArg = args[1] as PHandle
+                        val displayNameOrContactIdentifierArg = args[2] as String?
+                        val videoArg = args[3] as Boolean
+                        val proximityEnabledArg = args[4] as Boolean
+                        api.startCall(callIdArg, handleArg, displayNameOrContactIdentifierArg, videoArg, proximityEnabledArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.answerCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.answerCall(callIdArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.endCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.endCall(callIdArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setHeld$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val onHoldArg = args[1] as Boolean
+                        api.setHeld(callIdArg, onHoldArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setMuted$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val mutedArg = args[1] as Boolean
+                        api.setMuted(callIdArg, mutedArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setSpeaker$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val enabledArg = args[1] as Boolean
+                        api.setSpeaker(callIdArg, enabledArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setAudioDevice$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val deviceArg = args[1] as PAudioDevice
+                        api.setAudioDevice(callIdArg, deviceArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.sendDTMF$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        val keyArg = args[1] as String
+                        api.sendDTMF(callIdArg, keyArg) { result: Result<PCallRequestError?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.onDelegateSet$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        val wrapped: List<Any?> =
+                            try {
+                                api.onDelegateSet()
+                                listOf(null)
+                            } catch (exception: Throwable) {
+                                GeneratedPigeonUtils.wrapError(exception)
+                            }
+                        reply.reply(wrapped)
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.isSetUp$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              listOf(api.isSetUp())
-            } catch (exception: Throwable) {
-              GeneratedPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setUp$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val optionsArg = args[0] as POptions
-            api.setUp(optionsArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.tearDown$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.tearDown{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportNewIncomingCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val handleArg = args[1] as PHandle
-            val displayNameArg = args[2] as String?
-            val hasVideoArg = args[3] as Boolean
-            api.reportNewIncomingCall(callIdArg, handleArg, displayNameArg, hasVideoArg) { result: Result<PIncomingCallError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportConnectingOutgoingCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.reportConnectingOutgoingCall(callIdArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportConnectedOutgoingCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.reportConnectedOutgoingCall(callIdArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportUpdateCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val handleArg = args[1] as PHandle?
-            val displayNameArg = args[2] as String?
-            val hasVideoArg = args[3] as Boolean?
-            val proximityEnabledArg = args[4] as Boolean?
-            api.reportUpdateCall(callIdArg, handleArg, displayNameArg, hasVideoArg, proximityEnabledArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.reportEndCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val displayNameArg = args[1] as String
-            val reasonArg = args[2] as PEndCallReason
-            api.reportEndCall(callIdArg, displayNameArg, reasonArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.startCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val handleArg = args[1] as PHandle
-            val displayNameOrContactIdentifierArg = args[2] as String?
-            val videoArg = args[3] as Boolean
-            val proximityEnabledArg = args[4] as Boolean
-            api.startCall(callIdArg, handleArg, displayNameOrContactIdentifierArg, videoArg, proximityEnabledArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.answerCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.answerCall(callIdArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.endCall$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.endCall(callIdArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setHeld$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val onHoldArg = args[1] as Boolean
-            api.setHeld(callIdArg, onHoldArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setMuted$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val mutedArg = args[1] as Boolean
-            api.setMuted(callIdArg, mutedArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setSpeaker$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val enabledArg = args[1] as Boolean
-            api.setSpeaker(callIdArg, enabledArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.setAudioDevice$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val deviceArg = args[1] as PAudioDevice
-            api.setAudioDevice(callIdArg, deviceArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.sendDTMF$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            val keyArg = args[1] as String
-            api.sendDTMF(callIdArg, keyArg) { result: Result<PCallRequestError?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostApi.onDelegateSet$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              api.onDelegateSet()
-              listOf(null)
-            } catch (exception: Throwable) {
-              GeneratedPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostConnectionsApi {
-  fun getConnection(callId: String, callback: (Result<PCallkeepConnection?>) -> Unit)
-  fun getConnections(callback: (Result<List<PCallkeepConnection>>) -> Unit)
-  fun cleanConnections(callback: (Result<Unit>) -> Unit)
-  fun updateActivitySignalingStatus(status: PCallkeepSignalingStatus, callback: (Result<Unit>) -> Unit)
+    fun getConnection(
+        callId: String,
+        callback: (Result<PCallkeepConnection?>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostConnectionsApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    fun getConnections(callback: (Result<List<PCallkeepConnection>>) -> Unit)
+
+    fun cleanConnections(callback: (Result<Unit>) -> Unit)
+
+    fun updateActivitySignalingStatus(
+        status: PCallkeepSignalingStatus,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    companion object {
+        /** The codec used by PHostConnectionsApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostConnectionsApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostConnectionsApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.getConnection$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.getConnection(callIdArg) { result: Result<PCallkeepConnection?> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.getConnections$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.getConnections { result: Result<List<PCallkeepConnection>> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.cleanConnections$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.cleanConnections { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.updateActivitySignalingStatus$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val statusArg = args[0] as PCallkeepSignalingStatus
+                        api.updateActivitySignalingStatus(statusArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostConnectionsApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostConnectionsApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.getConnection$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callIdArg = args[0] as String
-            api.getConnection(callIdArg) { result: Result<PCallkeepConnection?> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.getConnections$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.getConnections{ result: Result<List<PCallkeepConnection>> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.cleanConnections$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.cleanConnections{ result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostConnectionsApi.updateActivitySignalingStatus$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val statusArg = args[0] as PCallkeepSignalingStatus
-            api.updateActivitySignalingStatus(statusArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PDelegateFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PDelegateFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  fun continueStartCallIntent(handleArg: PHandle, displayNameArg: String?, videoArg: Boolean, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.continueStartCallIntent$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(handleArg, displayNameArg, videoArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PDelegateFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PDelegateFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun didPushIncomingCall(handleArg: PHandle, displayNameArg: String?, videoArg: Boolean, callIdArg: String, errorArg: PIncomingCallError?, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didPushIncomingCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(handleArg, displayNameArg, videoArg, callIdArg, errorArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun continueStartCallIntent(
+        handleArg: PHandle,
+        displayNameArg: String?,
+        videoArg: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.continueStartCallIntent$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(handleArg, displayNameArg, videoArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performStartCall(callIdArg: String, handleArg: PHandle, displayNameOrContactIdentifierArg: String?, videoArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performStartCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, handleArg, displayNameOrContactIdentifierArg, videoArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun didPushIncomingCall(
+        handleArg: PHandle,
+        displayNameArg: String?,
+        videoArg: Boolean,
+        callIdArg: String,
+        errorArg: PIncomingCallError?,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didPushIncomingCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(handleArg, displayNameArg, videoArg, callIdArg, errorArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performAnswerCall(callIdArg: String, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAnswerCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performStartCall(
+        callIdArg: String,
+        handleArg: PHandle,
+        displayNameOrContactIdentifierArg: String?,
+        videoArg: Boolean,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performStartCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, handleArg, displayNameOrContactIdentifierArg, videoArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performEndCall(callIdArg: String, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performEndCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performAnswerCall(
+        callIdArg: String,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAnswerCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performSetHeld(callIdArg: String, onHoldArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetHeld$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, onHoldArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performEndCall(
+        callIdArg: String,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performEndCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performSetMuted(callIdArg: String, mutedArg: Boolean, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetMuted$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, mutedArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performSetHeld(
+        callIdArg: String,
+        onHoldArg: Boolean,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetHeld$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, onHoldArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performSendDTMF(callIdArg: String, keyArg: String, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSendDTMF$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, keyArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performSetMuted(
+        callIdArg: String,
+        mutedArg: Boolean,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSetMuted$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, mutedArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performAudioDeviceSet(callIdArg: String, deviceArg: PAudioDevice, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAudioDeviceSet$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, deviceArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performSendDTMF(
+        callIdArg: String,
+        keyArg: String,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performSendDTMF$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, keyArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performAudioDevicesUpdate(callIdArg: String, devicesArg: List<PAudioDevice>, callback: (Result<Boolean>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAudioDevicesUpdate$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg, devicesArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else if (it[0] == null) {
-          callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
-        } else {
-          val output = it[0] as Boolean
-          callback(Result.success(output))
+
+    fun performAudioDeviceSet(
+        callIdArg: String,
+        deviceArg: PAudioDevice,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAudioDeviceSet$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, deviceArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun didActivateAudioSession(callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didActivateAudioSession$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(null) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun performAudioDevicesUpdate(
+        callIdArg: String,
+        devicesArg: List<PAudioDevice>,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.performAudioDevicesUpdate$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg, devicesArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else if (it[0] == null) {
+                    callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
+                } else {
+                    val output = it[0] as Boolean
+                    callback(Result.success(output))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun didDeactivateAudioSession(callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didDeactivateAudioSession$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(null) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun didActivateAudioSession(callback: (Result<Unit>) -> Unit) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didActivateAudioSession$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(null) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun didReset(callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didReset$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(null) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun didDeactivateAudioSession(callback: (Result<Unit>) -> Unit) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didDeactivateAudioSession$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(null) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    fun didReset(callback: (Result<Unit>) -> Unit) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateFlutterApi.didReset$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(null) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PDelegateBackgroundServiceFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PDelegateBackgroundServiceFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  fun performAnswerCall(callIdArg: String, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.performAnswerCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PDelegateBackgroundServiceFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PDelegateBackgroundServiceFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
-  fun performEndCall(callIdArg: String, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.performEndCall$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(callIdArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+
+    fun performAnswerCall(
+        callIdArg: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.performAnswerCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    fun performEndCall(
+        callIdArg: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundServiceFlutterApi.performEndCall$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(callIdArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PPushRegistryHostApi {
-  fun pushTokenForPushTypeVoIP(): String?
+    fun pushTokenForPushTypeVoIP(): String?
 
-  companion object {
-    /** The codec used by PPushRegistryHostApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-    /** Sets up an instance of `PPushRegistryHostApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PPushRegistryHostApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PPushRegistryHostApi.pushTokenForPushTypeVoIP$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              listOf(api.pushTokenForPushTypeVoIP())
-            } catch (exception: Throwable) {
-              GeneratedPigeonUtils.wrapError(exception)
+    companion object {
+        /** The codec used by PPushRegistryHostApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PPushRegistryHostApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PPushRegistryHostApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PPushRegistryHostApi.pushTokenForPushTypeVoIP$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        val wrapped: List<Any?> =
+                            try {
+                                listOf(api.pushTokenForPushTypeVoIP())
+                            } catch (exception: Throwable) {
+                                GeneratedPigeonUtils.wrapError(exception)
+                            }
+                        reply.reply(wrapped)
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
             }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
         }
-      }
     }
-  }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PPushRegistryDelegateFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PPushRegistryDelegateFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  fun didUpdatePushTokenForPushTypeVoIP(tokenArg: String?, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PPushRegistryDelegateFlutterApi.didUpdatePushTokenForPushTypeVoIP$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(tokenArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PPushRegistryDelegateFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PPushRegistryDelegateFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    fun didUpdatePushTokenForPushTypeVoIP(
+        tokenArg: String?,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PPushRegistryDelegateFlutterApi.didUpdatePushTokenForPushTypeVoIP$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(tokenArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PDelegateLogsFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PDelegateLogsFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  fun onLog(typeArg: PLogTypeEnum, tagArg: String, messageArg: String, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateLogsFlutterApi.onLog$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(typeArg, tagArg, messageArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PDelegateLogsFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PDelegateLogsFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    fun onLog(
+        typeArg: PLogTypeEnum,
+        tagArg: String,
+        messageArg: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateLogsFlutterApi.onLog$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(typeArg, tagArg, messageArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class PDelegateSmsReceiverFlutterApi(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by PDelegateSmsReceiverFlutterApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-  }
-  /** Called by native side when a matching SMS is received */
-  fun onSmsReceived(textArg: String, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateSmsReceiverFlutterApi.onSmsReceived$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(textArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+class PDelegateSmsReceiverFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = "",
+) {
+    companion object {
+        /** The codec used by PDelegateSmsReceiverFlutterApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      } else {
-        callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
-      } 
     }
-  }
+
+    /** Called by native side when a matching SMS is received */
+    fun onSmsReceived(
+        textArg: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateSmsReceiverFlutterApi.onSmsReceived$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(textArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostSmsReceptionConfigApi {
-  /**
-   * Initializes the SMS receiver on Android and sets a prefix and regex to filter and parse messages.
-   *
-   * Only SMS messages starting with [messagePrefix] and matching [regexPattern]
-   * will be processed. The [regexPattern] must contain exactly 4 capturing groups
-   * in the following order:
-   * 1. callId
-   * 2. handle
-   * 3. displayName
-   * 4. hasVideo (true|false)
-   *
-   * Example:
-   * messagePrefix: "<#> WEBTRIT:"
-   * regexPattern: r'\{"type":"incoming","handle":"([^"]+)","callID":"([^"]+)","displayName":"([^"]+)","hasVideo":(true|false)\}'
-   */
-  fun initializeSmsReception(messagePrefix: String, regexPattern: String, callback: (Result<Unit>) -> Unit)
+    /**
+     * Initializes the SMS receiver on Android and sets a prefix and regex to filter and parse messages.
+     *
+     * Only SMS messages starting with [messagePrefix] and matching [regexPattern]
+     * will be processed. The [regexPattern] must contain exactly 4 capturing groups
+     * in the following order:
+     * 1. callId
+     * 2. handle
+     * 3. displayName
+     * 4. hasVideo (true|false)
+     *
+     * Example:
+     * messagePrefix: "<#> WEBTRIT:"
+     * regexPattern: r'\{"type":"incoming","handle":"([^"]+)","callID":"([^"]+)","displayName":"([^"]+)","hasVideo":(true|false)\}'
+     */
+    fun initializeSmsReception(
+        messagePrefix: String,
+        regexPattern: String,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostSmsReceptionConfigApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
-    }
-    /** Sets up an instance of `PHostSmsReceptionConfigApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostSmsReceptionConfigApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSmsReceptionConfigApi.initializeSmsReception$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val messagePrefixArg = args[0] as String
-            val regexPatternArg = args[1] as String
-            api.initializeSmsReception(messagePrefixArg, regexPatternArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
+    companion object {
+        /** The codec used by PHostSmsReceptionConfigApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
         }
-      }
+
+        /** Sets up an instance of `PHostSmsReceptionConfigApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostSmsReceptionConfigApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSmsReceptionConfigApi.initializeSmsReception$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val messagePrefixArg = args[0] as String
+                        val regexPatternArg = args[1] as String
+                        api.initializeSmsReception(messagePrefixArg, regexPatternArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-  }
 }
+
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface PHostActivityControlApi {
-  /**
-   * Allows the app's activity to be shown over the device lock screen.
-   *
-   * This is an Android-only feature.
-   */
-  fun showOverLockscreen(enable: Boolean, callback: (Result<Unit>) -> Unit)
-  /**
-   * Turns the screen on when the app's window is shown.
-   *
-   * Typically used in conjunction with [showOverLockscreen].
-   * This is an Android-only feature.
-   */
-  fun wakeScreenOnShow(enable: Boolean, callback: (Result<Unit>) -> Unit)
-  /**
-   * Moves the entire task (app) to the background.
-   *
-   * This is an Android-only feature.
-   * Returns `true` if successful.
-   */
-  fun sendToBackground(callback: (Result<Boolean>) -> Unit)
-  /**
-   * Checks if the device screen is currently locked (keyguard is active).
-   *
-   * Returns `false` on non-Android platforms.
-   */
-  fun isDeviceLocked(callback: (Result<Boolean>) -> Unit)
+    /**
+     * Allows the app's activity to be shown over the device lock screen.
+     *
+     * This is an Android-only feature.
+     */
+    fun showOverLockscreen(
+        enable: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    )
 
-  companion object {
-    /** The codec used by PHostActivityControlApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      GeneratedPigeonCodec()
+    /**
+     * Turns the screen on when the app's window is shown.
+     *
+     * Typically used in conjunction with [showOverLockscreen].
+     * This is an Android-only feature.
+     */
+    fun wakeScreenOnShow(
+        enable: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    /**
+     * Moves the entire task (app) to the background.
+     *
+     * This is an Android-only feature.
+     * Returns `true` if successful.
+     */
+    fun sendToBackground(callback: (Result<Boolean>) -> Unit)
+
+    /**
+     * Checks if the device screen is currently locked (keyguard is active).
+     *
+     * Returns `false` on non-Android platforms.
+     */
+    fun isDeviceLocked(callback: (Result<Boolean>) -> Unit)
+
+    companion object {
+        /** The codec used by PHostActivityControlApi. */
+        val codec: MessageCodec<Any?> by lazy {
+            GeneratedPigeonCodec()
+        }
+
+        /** Sets up an instance of `PHostActivityControlApi` to handle messages through the `binaryMessenger`. */
+        @JvmOverloads
+        fun setUp(
+            binaryMessenger: BinaryMessenger,
+            api: PHostActivityControlApi?,
+            messageChannelSuffix: String = "",
+        ) {
+            val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.showOverLockscreen$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val enableArg = args[0] as Boolean
+                        api.showOverLockscreen(enableArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.wakeScreenOnShow$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val enableArg = args[0] as Boolean
+                        api.wakeScreenOnShow(enableArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.sendToBackground$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.sendToBackground { result: Result<Boolean> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.isDeviceLocked$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.isDeviceLocked { result: Result<Boolean> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+        }
     }
-    /** Sets up an instance of `PHostActivityControlApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: PHostActivityControlApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.showOverLockscreen$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val enableArg = args[0] as Boolean
-            api.showOverLockscreen(enableArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.wakeScreenOnShow$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val enableArg = args[0] as Boolean
-            api.wakeScreenOnShow(enableArg) { result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedPigeonUtils.wrapResult(null))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.sendToBackground$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.sendToBackground{ result: Result<Boolean> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostActivityControlApi.isDeviceLocked$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            api.isDeviceLocked{ result: Result<Boolean> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedPigeonUtils.wrapError(error))
-              } else {
-                val data = result.getOrNull()
-                reply.reply(GeneratedPigeonUtils.wrapResult(data))
-              }
-            }
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -261,6 +261,12 @@ class PhoneConnectionService : ConnectionService() {
             // does NOT trigger onCreateIncomingConnectionFailed.
             connectionManager.removePending(metadata.callId)
             connectionManager.consumeAnswer(metadata.callId)
+            // Notify the main process that this call was rejected so it can clean
+            // up its pending state. Without this, MainProcessConnectionTracker retains
+            // the callId in pendingCallIds and a subsequent answerCall() sends a
+            // ReserveAnswer that is never consumed (no onCreateIncomingConnection fires again).
+            // This mirrors the HungUp path in onCreateIncomingConnectionFailed.
+            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, metadata.toBundle())
             return Connection.createFailedConnection(DisconnectCause(DisconnectCause.BUSY))
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -536,6 +536,12 @@ class ForegroundService :
                         logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
                         pendingIncomingTimeouts.remove(callId)
                         if (addedPending) core.removePending(callId)
+                        // Mark terminated and endCallDispatched so that a late-arriving HungUp
+                        // broadcast (after the timeout) does not cause handleCSReportDeclineCall
+                        // to fire performEndCall for a call Flutter already got
+                        // callRejectedBySystem for.
+                        core.markTerminated(callId)
+                        core.markEndCallDispatched(callId)
                         resolvePendingIncomingCallback(
                             callId,
                             Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
@@ -1161,6 +1167,7 @@ class ForegroundService :
             logger.w("onDestroy: resolving pending incoming callback for callId=$callId with CALL_REJECTED_BY_SYSTEM")
             core.markDirectNotified(callId)
             core.removePending(callId)
+            core.markTerminated(callId)
             core.markEndCallDispatched(callId)
             resolvePendingIncomingCallback(
                 callId,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1005,6 +1005,11 @@ class ForegroundService :
                 )
                 core.removePending(callId)
                 core.markTerminated(callId)
+                // Mark endCall as already dispatched so that a subsequent endCall()
+                // by Flutter (after receiving callRejectedBySystem) does not re-fire
+                // performEndCall — performEndCall must never fire for a call that was
+                // never confirmed to Flutter.
+                core.markEndCallDispatched(callId)
                 resolvePendingIncomingCallback(
                     callId,
                     Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
@@ -1149,8 +1154,14 @@ class ForegroundService :
 
         // Resolve any deferred reportNewIncomingCall callbacks that are still pending.
         // The service is being destroyed so Telecom confirmation will never arrive.
+        // Mirror the tearDown path: mark directNotified and remove from pending so
+        // that stale HungUp broadcasts from the dying CS process are suppressed and
+        // pendingCallIds do not leak into the next session's core state.
         pendingIncomingCallbacks.keys().toList().forEach { callId ->
             logger.w("onDestroy: resolving pending incoming callback for callId=$callId with CALL_REJECTED_BY_SYSTEM")
+            core.markDirectNotified(callId)
+            core.removePending(callId)
+            core.markEndCallDispatched(callId)
             resolvePendingIncomingCallback(
                 callId,
                 Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -85,6 +85,31 @@ class ForegroundService :
     // when startCall() is invoked again with the same callId.
     private val pendingCallCleanupsByCallId: ConcurrentHashMap<String, () -> Unit> = ConcurrentHashMap()
 
+    // Pigeon callbacks for reportNewIncomingCall() that are waiting for Telecom confirmation.
+    // Populated in startIncomingCall.onSuccess instead of resolving immediately, so that
+    // Flutter only gets "success" once Telecom has actually accepted the call (DidPushIncomingCall)
+    // or gets CALL_REJECTED_BY_SYSTEM when Telecom rejects it (HungUp / onCreateIncomingConnectionFailed).
+    private val pendingIncomingCallbacks: ConcurrentHashMap<String, (Result<PIncomingCallError?>) -> Unit> =
+        ConcurrentHashMap()
+
+    // Timeout runnables for pending incoming call confirmations, keyed by callId.
+    // Allows cancellation when the confirmation arrives before the timeout fires.
+    private val pendingIncomingTimeouts: ConcurrentHashMap<String, Runnable> = ConcurrentHashMap()
+
+    /**
+     * Resolves a pending [reportNewIncomingCall] Pigeon callback with [result].
+     * Cancels the associated safety timeout. Safe to call multiple times — only
+     * the first call has any effect (the entry is removed atomically).
+     */
+    private fun resolvePendingIncomingCallback(
+        callId: String,
+        result: Result<PIncomingCallError?>,
+    ) {
+        val cb = pendingIncomingCallbacks.remove(callId) ?: return
+        pendingIncomingTimeouts.remove(callId)?.let { mainHandler.removeCallbacks(it) }
+        cb(result)
+    }
+
     private var _flutterDelegateApi: PDelegateFlutterApi? = null
     var flutterDelegateApi: PDelegateFlutterApi?
         get() = _flutterDelegateApi
@@ -494,7 +519,30 @@ class ForegroundService :
                 // not fire an additional didPushIncomingCall Pigeon call. Flutter already
                 // learns about this call from __onCallSignalingEventIncoming.
                 core.markSignalingRegistered(callId)
-                callback(Result.success(null))
+
+                // Defer the Pigeon callback until Telecom confirms via DidPushIncomingCall
+                // (resolve with null) or rejects via HungUp (resolve with CALL_REJECTED_BY_SYSTEM).
+                // This prevents the broken API contract where Flutter receives success from
+                // reportNewIncomingCall and then immediately receives performEndCall — which
+                // happens on OEM devices (e.g. Huawei) that reject the second concurrent
+                // self-managed call in onCreateIncomingConnectionFailed.
+                pendingIncomingCallbacks[callId] = callback
+
+                // Safety timeout: if neither DidPushIncomingCall nor HungUp arrives within
+                // the expected window, resolve with CALL_REJECTED_BY_SYSTEM so the Pigeon
+                // callback is not leaked.
+                val timeoutRunnable =
+                    Runnable {
+                        logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
+                        pendingIncomingTimeouts.remove(callId)
+                        if (addedPending) core.removePending(callId)
+                        resolvePendingIncomingCallback(
+                            callId,
+                            Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
+                        )
+                    }
+                pendingIncomingTimeouts[callId] = timeoutRunnable
+                mainHandler.postDelayed(timeoutRunnable, INCOMING_CALL_CONFIRMATION_TIMEOUT_MS)
             },
             onError = { error ->
                 when (error?.value) {
@@ -589,6 +637,22 @@ class ForegroundService :
 
         // Step 1: Collect active call IDs from the core shadow state (promoted connections).
         val activeCallIds = core.getAll().map { it.callId }
+
+        // Step 1b: Drain any deferred reportNewIncomingCall callbacks that are still waiting
+        // for Telecom confirmation. These calls were accepted by startIncomingCall() but
+        // DidPushIncomingCall has not yet arrived. Resolve them with CALL_REJECTED_BY_SYSTEM
+        // and mark directNotified so that any subsequent HungUp broadcast is suppressed.
+        // Must run before drainUnconnectedPendingCallIds() so the callIds are removed from
+        // pendingCallIds first, preventing tearDown from also firing performEndCall for them.
+        pendingIncomingCallbacks.keys().toList().forEach { callId ->
+            logger.w("tearDown: resolving pending incoming callback for callId=$callId with CALL_REJECTED_BY_SYSTEM")
+            core.markDirectNotified(callId)
+            core.removePending(callId)
+            resolvePendingIncomingCallback(
+                callId,
+                Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
+            )
+        }
 
         // Step 2: Drain pending calls that were registered with Telecom but whose
         // PhoneConnection was never created (no DidPushIncomingCall received yet).
@@ -774,6 +838,18 @@ class ForegroundService :
         callback: (Result<PCallRequestError?>) -> Unit,
     ) {
         logger.i("endCall $callId.")
+
+        // If there is a deferred reportNewIncomingCall callback waiting for Telecom
+        // confirmation, resolve it immediately with null (success). The call was
+        // accepted by startIncomingCall() and is now being explicitly ended by the
+        // app — the subsequent HungUp broadcast must still fire performEndCall.
+        // Without this, handleCSReportDeclineCall would see the pending callback and
+        // return CALL_REJECTED_BY_SYSTEM while suppressing performEndCall.
+        if (pendingIncomingCallbacks.containsKey(callId)) {
+            logger.d("endCall $callId: resolving deferred incoming callback before explicit end")
+            resolvePendingIncomingCallback(callId, Result.success(null))
+        }
+
         if (core.isTerminated(callId)) {
             // Re-fire performEndCall only on the first endCall for a Telecom-terminated call
             // (e.g. onCreateIncomingConnectionFailed fired before the Dart callback was registered).
@@ -868,6 +944,11 @@ class ForegroundService :
             // Promote from pending to fully registered incoming connection.
             core.promote(metadata.callId, metadata, PCallkeepConnectionState.STATE_RINGING)
 
+            // Resolve any deferred reportNewIncomingCall Pigeon callback waiting for this
+            // Telecom confirmation. This is the success path: Telecom accepted the call,
+            // so Flutter learns the call is live via the resolved callback (null = no error).
+            resolvePendingIncomingCallback(metadata.callId, Result.success(null))
+
             // If this call was registered via reportNewIncomingCall (the foreground signaling
             // path), Flutter already knows about it through __onCallSignalingEventIncoming.
             // Suppress didPushIncomingCall to prevent a duplicate push-path entry (line -1)
@@ -910,6 +991,23 @@ class ForegroundService :
             if (core.consumeDirectNotified(callId)) {
                 logger.d(
                     "handleCSReportDeclineCall: suppressing stale broadcast for callId=$callId (already notified directly)",
+                )
+                return@let
+            }
+
+            // If there is a pending reportNewIncomingCall callback for this callId, Telecom
+            // rejected the call before Flutter was ever notified of it. Resolve the Pigeon
+            // callback with CALL_REJECTED_BY_SYSTEM and return early — do NOT fire
+            // performEndCall since Flutter never received a successful registration.
+            if (pendingIncomingCallbacks.containsKey(callId)) {
+                logger.w(
+                    "handleCSReportDeclineCall: Telecom rejected callId=$callId before Flutter confirmation — resolving with CALL_REJECTED_BY_SYSTEM",
+                )
+                core.removePending(callId)
+                core.markTerminated(callId)
+                resolvePendingIncomingCallback(
+                    callId,
+                    Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
                 )
                 return@let
             }
@@ -1049,6 +1147,16 @@ class ForegroundService :
         pendingCallCleanupsByCallId.values.toList().forEach { it() }
         pendingCallCleanupsByCallId.clear()
 
+        // Resolve any deferred reportNewIncomingCall callbacks that are still pending.
+        // The service is being destroyed so Telecom confirmation will never arrive.
+        pendingIncomingCallbacks.keys().toList().forEach { callId ->
+            logger.w("onDestroy: resolving pending incoming callback for callId=$callId with CALL_REJECTED_BY_SYSTEM")
+            resolvePendingIncomingCallback(
+                callId,
+                Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
+            )
+        }
+
         // Cancel any in-progress tearDown so the receiver and timeout do not outlive the service.
         tearDownTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
         tearDownTimeoutRunnable = null
@@ -1077,6 +1185,11 @@ class ForegroundService :
 
         private const val OUTGOING_CALL_TIMEOUT_MS = 5_000L
         private const val TEAR_DOWN_ACK_TIMEOUT_MS = 3_000L
+
+        // Maximum time to wait for Telecom to confirm an incoming call via DidPushIncomingCall.
+        // If this elapses without confirmation or rejection, resolve the Pigeon callback with
+        // CALL_REJECTED_BY_SYSTEM to avoid leaking the deferred callback.
+        private const val INCOMING_CALL_CONFIRMATION_TIMEOUT_MS = 5_000L
 
         /**
          * Process-wide facade for all interactions with the `:callkeep_core` process.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -917,6 +917,14 @@ class ForegroundService :
             // Update tracker: call has ended.
             core.markTerminated(callId)
 
+            // Mark that performEndCall is being dispatched now, so that a subsequent
+            // endCall() call with isTerminated=true does NOT re-fire performEndCall.
+            // Without this, if onCreateIncomingConnectionFailed fires a HungUp broadcast
+            // while the call is still in the pending window (before Dart calls endCall),
+            // the broadcast fires performEndCall once here AND the endCall re-fire path
+            // fires it a second time — producing a duplicate delegate callback.
+            core.markEndCallDispatched(callId)
+
             flutterDelegateApi?.performEndCall(callId) {}
             flutterDelegateApi?.didDeactivateAudioSession {}
 

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -91,6 +91,43 @@ incoming call event.
 
 ---
 
+## Incoming Call Rejected by Telecom (`callRejectedBySystem`)
+
+Android does not allow two self-managed calls to be simultaneously in RINGING state. When a
+second incoming call arrives while the first is still ringing, Telecom calls
+`onCreateIncomingConnectionFailed` — **without** calling `onCreateIncomingConnection` first.
+
+```text
+1.  Dart / Push isolate calls reportNewIncomingCall(id2, meta)
+        |  (call id1 is already in RINGING state)
+        v
+2.  TelephonyUtils.addNewIncomingCall()  -->  Android Telecom
+        |
+        v
+3.  Telecom --> PhoneConnectionService.onCreateIncomingConnectionFailed(callId=id2)
+        |   ConnectionManager.isPending(id2) == true  (was registered in step 2)
+        |   broadcast: HungUp(id2)
+        v
+4.  ForegroundService.handleCSReportDeclineCall()
+        |   pendingIncomingCallbacks[id2] exists (Pigeon response deferred)
+        |   reply with PIncomingCallError(callRejectedBySystem)
+        |   (performEndCall is NOT fired — call was never confirmed to Flutter)
+        v
+5.  Dart receives reportNewIncomingCall() result = callRejectedBySystem
+```
+
+**Key consequences**:
+
+- `performEndCall` does **not** fire for `id2` — the call never existed in Telecom.
+- The app must send the appropriate signaling (e.g. SIP BYE) to the server itself,
+  without waiting for `performEndCall`.
+
+**Scope**: this is standard AOSP behaviour on Android 11+ (confirmed on stock Pixel 5).
+Some vendors (Huawei, certain MediaTek OEMs) apply the same restriction even when the
+first call is ACTIVE rather than RINGING.
+
+---
+
 ## Outgoing Call
 
 Triggered when the user initiates a call from the app UI.

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -69,7 +69,7 @@ enum PIncomingCallErrorEnum {
   ///
   /// Telecom rejected the incoming call registration — e.g. the device does
   /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to Flutter so no [performEndCall]
+  /// devices). The call was never confirmed to Flutter so no `performEndCall`
   /// will be fired.
   callRejectedBySystem,
 }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -64,6 +64,14 @@ enum PIncomingCallErrorEnum {
   filteredByDoNotDisturb,
   filteredByBlockList,
   internal,
+
+  /// Android only.
+  ///
+  /// Telecom rejected the incoming call registration — e.g. the device does
+  /// not support concurrent self-managed calls (common on Huawei and other OEM
+  /// devices). The call was never confirmed to Flutter so no [performEndCall]
+  /// will be fired.
+  callRejectedBySystem,
 }
 
 enum PCallRequestErrorEnum {

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -59,6 +59,8 @@ extension PIncomingCallErrorEnumConverter on PIncomingCallErrorEnum {
         return CallkeepIncomingCallError.filteredByBlockList;
       case PIncomingCallErrorEnum.internal:
         return CallkeepIncomingCallError.internal;
+      case PIncomingCallErrorEnum.callRejectedBySystem:
+        return CallkeepIncomingCallError.callRejectedBySystem;
     }
   }
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -82,6 +82,14 @@ enum PIncomingCallErrorEnum {
   filteredByDoNotDisturb,
   filteredByBlockList,
   internal,
+
+  /// Android only.
+  ///
+  /// Telecom rejected the incoming call registration — e.g. the device does
+  /// not support concurrent self-managed calls (common on Huawei and other OEM
+  /// devices). The call was never confirmed to Flutter so no [performEndCall]
+  /// will be fired.
+  callRejectedBySystem,
 }
 
 // TODO: See https://github.com/flutter/flutter/issues/87307

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -87,7 +87,7 @@ enum PIncomingCallErrorEnum {
   ///
   /// Telecom rejected the incoming call registration — e.g. the device does
   /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to Flutter so no [performEndCall]
+  /// devices). The call was never confirmed to Flutter so no `performEndCall`
   /// will be fired.
   callRejectedBySystem,
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -85,10 +85,23 @@ enum PIncomingCallErrorEnum {
 
   /// Android only.
   ///
-  /// Telecom rejected the incoming call registration — e.g. the device does
-  /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to Flutter so no `performEndCall`
-  /// will be fired.
+  /// Telecom rejected the incoming call registration via
+  /// `onCreateIncomingConnectionFailed` (i.e. without ever calling
+  /// `onCreateIncomingConnection`).
+  ///
+  /// **When this happens**: Android does not allow two self-managed calls to be
+  /// simultaneously in RINGING state. If a call is already ringing, Telecom
+  /// rejects every subsequent incoming self-managed call. This is standard
+  /// AOSP behaviour (observed on stock Pixel devices running Android 11+), not
+  /// an OEM-specific restriction. Some vendors (Huawei, certain MediaTek OEMs)
+  /// apply the same rejection even when the first call is already ACTIVE.
+  ///
+  /// **Consequences for the app**:
+  /// - The call was never confirmed to Flutter, so `performEndCall` will NOT
+  ///   fire for this call ID.
+  /// - The app must send the appropriate signaling (e.g. SIP BYE) to the
+  ///   server itself upon receiving this error, without waiting for
+  ///   `performEndCall`.
   callRejectedBySystem,
 }
 

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
@@ -22,9 +22,9 @@ enum CallkeepIncomingCallError {
   /// apply the same rejection even when the first call is already ACTIVE.
   ///
   /// **Consequences for the app**:
-  /// - The call was never presented to the user, so [performEndCall] will NOT
+  /// - The call was never presented to the user, so `performEndCall` will NOT
   ///   fire for this call ID.
   /// - The app must notify the server (e.g. send a SIP BYE) immediately upon
-  ///   receiving this error, without waiting for [performEndCall].
+  ///   receiving this error, without waiting for `performEndCall`.
   callRejectedBySystem,
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
@@ -12,7 +12,7 @@ enum CallkeepIncomingCallError {
   ///
   /// Telecom rejected the incoming call registration — e.g. the device does
   /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to the app so no [performEndCall]
+  /// devices). The call was never confirmed to the app so no `performEndCall`
   /// will be fired.
   callRejectedBySystem,
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
@@ -7,4 +7,12 @@ enum CallkeepIncomingCallError {
   filteredByDoNotDisturb,
   filteredByBlockList,
   internal,
+
+  /// Android only.
+  ///
+  /// Telecom rejected the incoming call registration — e.g. the device does
+  /// not support concurrent self-managed calls (common on Huawei and other OEM
+  /// devices). The call was never confirmed to the app so no [performEndCall]
+  /// will be fired.
+  callRejectedBySystem,
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_incoming_call_error.dart
@@ -10,9 +10,21 @@ enum CallkeepIncomingCallError {
 
   /// Android only.
   ///
-  /// Telecom rejected the incoming call registration — e.g. the device does
-  /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to the app so no `performEndCall`
-  /// will be fired.
+  /// Telecom rejected the incoming call registration via
+  /// `onCreateIncomingConnectionFailed` (without calling
+  /// `onCreateIncomingConnection` first).
+  ///
+  /// **When this happens**: Android does not allow two self-managed calls to be
+  /// simultaneously in RINGING state. If a call is already ringing, Telecom
+  /// rejects every subsequent incoming self-managed call. This is standard
+  /// AOSP behaviour (reproducible on stock Pixel devices running Android 11+),
+  /// not limited to OEM devices. Some vendors (Huawei, certain MediaTek OEMs)
+  /// apply the same rejection even when the first call is already ACTIVE.
+  ///
+  /// **Consequences for the app**:
+  /// - The call was never presented to the user, so [performEndCall] will NOT
+  ///   fire for this call ID.
+  /// - The app must notify the server (e.g. send a SIP BYE) immediately upon
+  ///   receiving this error, without waiting for [performEndCall].
   callRejectedBySystem,
 }


### PR DESCRIPTION
## Problem

On OEM devices that do not support concurrent self-managed calls (Huawei, some Xiaomi), `reportNewIncomingCall` for a second concurrent call broke the API contract:

1. Flutter received `null` (success) from `reportNewIncomingCall(id2)`
2. Telecom called `onCreateIncomingConnectionFailed` shortly after
3. Flutter received `performEndCall(id2)` — a call that was never confirmed as live

Additionally, the BUSY path in `onCreateIncomingConnection` did not notify the main process, leaving `id2` in `pendingCallIds` indefinitely, which caused a `ReserveAnswer` to be sent to CS on `answerCall` — resulting in duplicate `performEndCall` events in stress tests.

## Changes

### Android implementation

**`PhoneConnectionService`**
- Dispatch `HungUp` broadcast before returning `createFailedConnection(BUSY)` in `onCreateIncomingConnection`. This mirrors the `onCreateIncomingConnectionFailed` path and unblocks main-process state cleanup.

**`ForegroundService`**
- Defer the Pigeon callback in `startIncomingCall.onSuccess` instead of resolving immediately. Store it in `pendingIncomingCallbacks[callId]` with a 5-second safety timeout.
- Resolve with `null` (success) in `handleCSReportDidPushIncomingCall` — Telecom confirmed the call.
- Resolve with `callRejectedBySystem` in `handleCSReportDeclineCall` when a pending callback exists — Telecom rejected the call. Return early without firing `performEndCall` since Flutter never received a confirmed registration.
- In `endCall`: if a pending callback exists, resolve it with `null` before the explicit end. This ensures the subsequent `HungUp` broadcast fires `performEndCall` normally (fixes immediate-decline scenario).
- In `tearDown` and `onDestroy`: drain all pending callbacks with `callRejectedBySystem` before processing active/pending connections.

**Pigeon / platform interface**
- Add `callRejectedBySystem` (raw: 8) to `PIncomingCallErrorEnum` in the source definition, generated Kotlin, and generated Dart.
- Add `callRejectedBySystem` to `CallkeepIncomingCallError` in `webtrit_callkeep_platform_interface`.
- Add mapping in `converters.dart`.

### Integration tests

- `callkeep_state_machine_test` / `callkeep_call_scenarios_test`: skip two-call scenarios gracefully when `_waitForConnection(id2)` returns `null` (device does not support concurrent calls).
- `callkeep_stress_test`: accept `callRejectedBySystem` as a valid outcome for the second concurrent call; make `tearDown` assertions dynamic so they only expect `performEndCall` for calls that were actually accepted.
- `callkeep_foreground_service_test`: same dynamic `expectedIds` approach for the `tearDown` test.

## Contract after this fix

| Outcome | `reportNewIncomingCall` result | `performEndCall` fires? |
|---|---|---|
| Telecom accepted the call | `null` | Yes (from tearDown / endCall) |
| Telecom rejected (OEM limitation) | `callRejectedBySystem` | No |
| App explicitly ended before confirmation | `null` | Yes |

## Tested on

- **RF8TB0XW0ZW** (standard Android): all tests pass
- **LBDYD23912002978** (Huawei): all tests pass (OEM-limited scenarios skipped gracefully)