### PR TITLE
fix(android): unregister PhoneAccount on tearDown and onDestroy

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -56,6 +56,10 @@ class TelephonyUtils(
         getTelecomManager().registerPhoneAccount(phoneAccountBuilder.build())
     }
 
+    fun unregisterPhoneAccount() {
+        getTelecomManager().unregisterPhoneAccount(getPhoneAccountHandle())
+    }
+
     fun getPhoneAccountHandle(): PhoneAccountHandle {
         val componentName = ComponentName(context, PhoneConnectionService::class.java)
         val connectionServiceId = getConnectionServiceId()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -716,6 +716,8 @@ class ForegroundService :
             // Keep PhoneConnectionService alive for the next session so that its next
             // incoming intents (e.g. AnswerCall) arrive at a live service instance.
             core.tearDownService()
+            runCatching { TelephonyUtils(baseContext).unregisterPhoneAccount() }
+                .onFailure { e -> logger.w("tearDown: unregisterPhoneAccount failed: $e") }
             callback.invoke(Result.success(Unit))
         }
 
@@ -1184,6 +1186,9 @@ class ForegroundService :
             }
         }
         tearDownAckReceiver = null
+
+        runCatching { TelephonyUtils(baseContext).unregisterPhoneAccount() }
+            .onFailure { e -> logger.w("onDestroy: unregisterPhoneAccount failed: $e") }
 
         isRunning = false
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -717,7 +717,7 @@ class ForegroundService :
             // incoming intents (e.g. AnswerCall) arrive at a live service instance.
             core.tearDownService()
             runCatching { TelephonyUtils(baseContext).unregisterPhoneAccount() }
-                .onFailure { e -> logger.w("tearDown: unregisterPhoneAccount failed: $e") }
+                .onFailure { e -> logger.w("tearDown: unregisterPhoneAccount failed: ${e.message}", e) }
             callback.invoke(Result.success(Unit))
         }
 
@@ -1188,7 +1188,7 @@ class ForegroundService :
         tearDownAckReceiver = null
 
         runCatching { TelephonyUtils(baseContext).unregisterPhoneAccount() }
-            .onFailure { e -> logger.w("onDestroy: unregisterPhoneAccount failed: $e") }
+            .onFailure { e -> logger.w("onDestroy: unregisterPhoneAccount failed: ${e.message}", e) }
 
         isRunning = false
     }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/TelephonyUtilsPhoneAccountTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/TelephonyUtilsPhoneAccountTest.kt
@@ -1,0 +1,82 @@
+package com.webtrit.callkeep.common
+
+import android.content.Context
+import android.os.Build
+import android.telecom.TelecomManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class TelephonyUtilsPhoneAccountTest {
+    private lateinit var context: Context
+    private lateinit var utils: TelephonyUtils
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        // Robolectric leaves applicationInfo.nonLocalizedLabel null; set it so
+        // TelephonyUtils.getApplicationName() does not throw NPE.
+        context.applicationInfo.nonLocalizedLabel = "TestApp"
+        utils = TelephonyUtils(context)
+    }
+
+    private fun registeredHandles() =
+        Shadows
+            .shadowOf(context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager)
+            .allPhoneAccounts
+            .map { it.accountHandle }
+
+    // -------------------------------------------------------------------------
+    // registerPhoneAccount
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `registerPhoneAccount makes account visible in TelecomManager`() {
+        utils.registerPhoneAccount()
+        assertTrue(utils.getPhoneAccountHandle() in registeredHandles())
+    }
+
+    // -------------------------------------------------------------------------
+    // unregisterPhoneAccount
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `unregisterPhoneAccount removes account from TelecomManager`() {
+        utils.registerPhoneAccount()
+        utils.unregisterPhoneAccount()
+        assertEquals(emptyList<Any>(), registeredHandles())
+    }
+
+    @Test
+    fun `unregisterPhoneAccount on non-existent account does not throw`() {
+        // Must be a no-op — no prior registerPhoneAccount() call
+        utils.unregisterPhoneAccount()
+    }
+
+    @Test
+    fun `second unregisterPhoneAccount call is a safe no-op`() {
+        utils.registerPhoneAccount()
+        utils.unregisterPhoneAccount()
+        utils.unregisterPhoneAccount()
+    }
+
+    // -------------------------------------------------------------------------
+    // register / unregister symmetry
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `re-registering after unregister makes account visible again`() {
+        utils.registerPhoneAccount()
+        utils.unregisterPhoneAccount()
+        utils.registerPhoneAccount()
+        assertTrue(utils.getPhoneAccountHandle() in registeredHandles())
+    }
+}


### PR DESCRIPTION
## Problem

After `tearDown()`, the `PhoneAccount` remained registered in Android Telecom. Telecom continued binding to the dead `PhoneConnectionService`, producing DEAD connection records in `ActivityManager`. This slows every subsequent `TelecomManager.addNewIncomingCall()` call because it is a synchronous Binder IPC and Telecom iterates all registered accounts including stale ones.

## Changes

- **`TelephonyUtils`** — add `unregisterPhoneAccount()` symmetric to the existing `registerPhoneAccount()`
- **`ForegroundService.finishTearDown()`** — call `unregisterPhoneAccount()` after `core.tearDownService()`, wrapped in `runCatching` so a Telecom error never blocks the tearDown callback
- **`ForegroundService.onDestroy()`** — call `unregisterPhoneAccount()` as a safety net for process kill, crash, or `adb install -r`; unregistering a non-existent account is a no-op

## Test plan

- [ ] Start a call, end it, call `tearDown()` — confirm no stale PhoneAccount visible via `adb shell dumpsys telecom`
- [ ] Kill the process without calling `tearDown()` — confirm PhoneAccount is cleaned up on restart
- [ ] Verify subsequent `addNewIncomingCall()` is not delayed by dead account iteration