### PR TITLE
test(android): add comprehensive Dart layer unit tests

### DIFF
--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_relative_lib_imports
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
 import 'package:webtrit_callkeep_android/src/common/converters.dart';

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -1,0 +1,760 @@
+// ignore_for_file: avoid_relative_lib_imports
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
+import 'package:webtrit_callkeep_android/src/common/converters.dart';
+import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // PHandleTypeEnumConverter
+  // ---------------------------------------------------------------------------
+
+  group('PHandleTypeEnumConverter.toCallkeep()', () {
+    test('generic maps to CallkeepHandleType.generic', () {
+      expect(PHandleTypeEnum.generic.toCallkeep(), CallkeepHandleType.generic);
+    });
+
+    test('number maps to CallkeepHandleType.number', () {
+      expect(PHandleTypeEnum.number.toCallkeep(), CallkeepHandleType.number);
+    });
+
+    test('email maps to CallkeepHandleType.email', () {
+      expect(PHandleTypeEnum.email.toCallkeep(), CallkeepHandleType.email);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PLogTypeEnumConverter
+  // ---------------------------------------------------------------------------
+
+  group('PLogTypeEnumConverter.toCallkeep()', () {
+    test('debug maps to CallkeepLogType.debug', () {
+      expect(PLogTypeEnum.debug.toCallkeep(), CallkeepLogType.debug);
+    });
+
+    test('error maps to CallkeepLogType.error', () {
+      expect(PLogTypeEnum.error.toCallkeep(), CallkeepLogType.error);
+    });
+
+    test('info maps to CallkeepLogType.info', () {
+      expect(PLogTypeEnum.info.toCallkeep(), CallkeepLogType.info);
+    });
+
+    test('verbose maps to CallkeepLogType.verbose', () {
+      expect(PLogTypeEnum.verbose.toCallkeep(), CallkeepLogType.verbose);
+    });
+
+    test('warn maps to CallkeepLogType.warn', () {
+      expect(PLogTypeEnum.warn.toCallkeep(), CallkeepLogType.warn);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHandleConverter
+  // ---------------------------------------------------------------------------
+
+  group('PHandleConverter.toCallkeep()', () {
+    test('number handle maps type and value', () {
+      final result = PHandle(type: PHandleTypeEnum.number, value: '+1234567890').toCallkeep();
+      expect(result.type, CallkeepHandleType.number);
+      expect(result.value, '+1234567890');
+    });
+
+    test('email handle maps type and value', () {
+      final result = PHandle(type: PHandleTypeEnum.email, value: 'alice@example.com').toCallkeep();
+      expect(result.type, CallkeepHandleType.email);
+      expect(result.value, 'alice@example.com');
+    });
+
+    test('generic handle maps type and value', () {
+      final result = PHandle(type: PHandleTypeEnum.generic, value: 'sip:alice@example.com').toCallkeep();
+      expect(result.type, CallkeepHandleType.generic);
+      expect(result.value, 'sip:alice@example.com');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PIncomingCallErrorEnumConverter
+  // ---------------------------------------------------------------------------
+
+  group('PIncomingCallErrorEnumConverter.toCallkeep()', () {
+    test('unknown', () {
+      expect(PIncomingCallErrorEnum.unknown.toCallkeep(), CallkeepIncomingCallError.unknown);
+    });
+
+    test('unentitled', () {
+      expect(PIncomingCallErrorEnum.unentitled.toCallkeep(), CallkeepIncomingCallError.unentitled);
+    });
+
+    test('callIdAlreadyExists', () {
+      expect(PIncomingCallErrorEnum.callIdAlreadyExists.toCallkeep(), CallkeepIncomingCallError.callIdAlreadyExists);
+    });
+
+    test('callIdAlreadyExistsAndAnswered', () {
+      expect(
+        PIncomingCallErrorEnum.callIdAlreadyExistsAndAnswered.toCallkeep(),
+        CallkeepIncomingCallError.callIdAlreadyExistsAndAnswered,
+      );
+    });
+
+    test('callIdAlreadyTerminated', () {
+      expect(
+        PIncomingCallErrorEnum.callIdAlreadyTerminated.toCallkeep(),
+        CallkeepIncomingCallError.callIdAlreadyTerminated,
+      );
+    });
+
+    test('filteredByDoNotDisturb', () {
+      expect(
+        PIncomingCallErrorEnum.filteredByDoNotDisturb.toCallkeep(),
+        CallkeepIncomingCallError.filteredByDoNotDisturb,
+      );
+    });
+
+    test('filteredByBlockList', () {
+      expect(PIncomingCallErrorEnum.filteredByBlockList.toCallkeep(), CallkeepIncomingCallError.filteredByBlockList);
+    });
+
+    test('internal', () {
+      expect(PIncomingCallErrorEnum.internal.toCallkeep(), CallkeepIncomingCallError.internal);
+    });
+
+    test('callRejectedBySystem', () {
+      expect(PIncomingCallErrorEnum.callRejectedBySystem.toCallkeep(), CallkeepIncomingCallError.callRejectedBySystem);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallRequestErrorEnumConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallRequestErrorEnumConverter.toCallkeep()', () {
+    test('unknown', () {
+      expect(PCallRequestErrorEnum.unknown.toCallkeep(), CallkeepCallRequestError.unknown);
+    });
+
+    test('unentitled', () {
+      expect(PCallRequestErrorEnum.unentitled.toCallkeep(), CallkeepCallRequestError.unentitled);
+    });
+
+    test('unknownCallUuid', () {
+      expect(PCallRequestErrorEnum.unknownCallUuid.toCallkeep(), CallkeepCallRequestError.unknownCallUuid);
+    });
+
+    test('callUuidAlreadyExists', () {
+      expect(PCallRequestErrorEnum.callUuidAlreadyExists.toCallkeep(), CallkeepCallRequestError.callUuidAlreadyExists);
+    });
+
+    test('maximumCallGroupsReached', () {
+      expect(
+        PCallRequestErrorEnum.maximumCallGroupsReached.toCallkeep(),
+        CallkeepCallRequestError.maximumCallGroupsReached,
+      );
+    });
+
+    test('internal', () {
+      expect(PCallRequestErrorEnum.internal.toCallkeep(), CallkeepCallRequestError.internal);
+    });
+
+    test('emergencyNumber', () {
+      expect(PCallRequestErrorEnum.emergencyNumber.toCallkeep(), CallkeepCallRequestError.emergencyNumber);
+    });
+
+    test('selfManagedPhoneAccountNotRegistered', () {
+      expect(
+        PCallRequestErrorEnum.selfManagedPhoneAccountNotRegistered.toCallkeep(),
+        CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered,
+      );
+    });
+
+    test('timeout', () {
+      expect(PCallRequestErrorEnum.timeout.toCallkeep(), CallkeepCallRequestError.timeout);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepTypeEnumConverter (CallkeepLogType -> PLogTypeEnum)
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepTypeEnumConverter.toPigeon()', () {
+    test('debug maps to PLogTypeEnum.debug', () {
+      expect(CallkeepLogType.debug.toPigeon(), PLogTypeEnum.debug);
+    });
+
+    test('error maps to PLogTypeEnum.error', () {
+      expect(CallkeepLogType.error.toPigeon(), PLogTypeEnum.error);
+    });
+
+    test('info maps to PLogTypeEnum.info', () {
+      expect(CallkeepLogType.info.toPigeon(), PLogTypeEnum.info);
+    });
+
+    test('verbose maps to PLogTypeEnum.verbose', () {
+      expect(CallkeepLogType.verbose.toPigeon(), PLogTypeEnum.verbose);
+    });
+
+    test('warn maps to PLogTypeEnum.warn', () {
+      expect(CallkeepLogType.warn.toPigeon(), PLogTypeEnum.warn);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepHandleTypeConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepHandleTypeConverter.toPigeon()', () {
+    test('generic maps to PHandleTypeEnum.generic', () {
+      expect(CallkeepHandleType.generic.toPigeon(), PHandleTypeEnum.generic);
+    });
+
+    test('number maps to PHandleTypeEnum.number', () {
+      expect(CallkeepHandleType.number.toPigeon(), PHandleTypeEnum.number);
+    });
+
+    test('email maps to PHandleTypeEnum.email', () {
+      expect(CallkeepHandleType.email.toPigeon(), PHandleTypeEnum.email);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepHandleConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepHandleConverter.toPigeon()', () {
+    test('number handle maps type and value', () {
+      const handle = CallkeepHandle(type: CallkeepHandleType.number, value: '+1234567890');
+      final result = handle.toPigeon();
+      expect(result.type, PHandleTypeEnum.number);
+      expect(result.value, '+1234567890');
+    });
+
+    test('email handle maps type and value', () {
+      const handle = CallkeepHandle(type: CallkeepHandleType.email, value: 'alice@example.com');
+      final result = handle.toPigeon();
+      expect(result.type, PHandleTypeEnum.email);
+      expect(result.value, 'alice@example.com');
+    });
+
+    test('round-trip: CallkeepHandle -> PHandle -> CallkeepHandle preserves data', () {
+      const original = CallkeepHandle(type: CallkeepHandleType.number, value: '555-1234');
+      final roundTripped = original.toPigeon().toCallkeep();
+      expect(roundTripped.type, original.type);
+      expect(roundTripped.value, original.value);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepEndCallReasonConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepEndCallReasonConverter.toPigeon()', () {
+    test('failed maps to PEndCallReasonEnum.failed', () {
+      expect(CallkeepEndCallReason.failed.toPigeon(), PEndCallReasonEnum.failed);
+    });
+
+    test('remoteEnded maps to PEndCallReasonEnum.remoteEnded', () {
+      expect(CallkeepEndCallReason.remoteEnded.toPigeon(), PEndCallReasonEnum.remoteEnded);
+    });
+
+    test('unanswered maps to PEndCallReasonEnum.unanswered', () {
+      expect(CallkeepEndCallReason.unanswered.toPigeon(), PEndCallReasonEnum.unanswered);
+    });
+
+    test('answeredElsewhere maps to PEndCallReasonEnum.answeredElsewhere', () {
+      expect(CallkeepEndCallReason.answeredElsewhere.toPigeon(), PEndCallReasonEnum.answeredElsewhere);
+    });
+
+    test('declinedElsewhere maps to PEndCallReasonEnum.declinedElsewhere', () {
+      expect(CallkeepEndCallReason.declinedElsewhere.toPigeon(), PEndCallReasonEnum.declinedElsewhere);
+    });
+
+    test('missed maps to PEndCallReasonEnum.missed', () {
+      expect(CallkeepEndCallReason.missed.toPigeon(), PEndCallReasonEnum.missed);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepOptionsConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepOptionsConverter.toPigeon()', () {
+    const options = CallkeepOptions(
+      ios: CallkeepIOSOptions(
+        localizedName: 'TestApp',
+        maximumCallGroups: 2,
+        maximumCallsPerCallGroup: 1,
+        supportedHandleTypes: {CallkeepHandleType.number, CallkeepHandleType.email},
+      ),
+      android: CallkeepAndroidOptions(
+        ringtoneSound: 'ring.mp3',
+        ringbackSound: 'ringback.mp3',
+        incomingCallFullScreen: true,
+      ),
+    );
+
+    test('ios field maps to PIOSOptions', () {
+      final result = options.toPigeon();
+      expect(result.ios, isA<PIOSOptions>());
+      expect(result.ios.localizedName, 'TestApp');
+      expect(result.ios.maximumCallGroups, 2);
+      expect(result.ios.maximumCallsPerCallGroup, 1);
+    });
+
+    test('android field maps to PAndroidOptions', () {
+      final result = options.toPigeon();
+      expect(result.android, isA<PAndroidOptions>());
+      expect(result.android.ringtoneSound, 'ring.mp3');
+      expect(result.android.ringbackSound, 'ringback.mp3');
+      expect(result.android.incomingCallFullScreen, true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepIOSOptionsConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepIOSOptionsConverter.toPigeon()', () {
+    test('localizedName is forwarded', () {
+      const ios = CallkeepIOSOptions(
+        localizedName: 'MyApp',
+        maximumCallGroups: 1,
+        maximumCallsPerCallGroup: 1,
+        supportedHandleTypes: {CallkeepHandleType.number},
+      );
+      expect(ios.toPigeon().localizedName, 'MyApp');
+    });
+
+    test('supportedHandleTypes: only number sets supportsHandleTypePhoneNumber=true, others false', () {
+      const ios = CallkeepIOSOptions(
+        localizedName: 'App',
+        maximumCallGroups: 1,
+        maximumCallsPerCallGroup: 1,
+        supportedHandleTypes: {CallkeepHandleType.number},
+      );
+      final result = ios.toPigeon();
+      expect(result.supportsHandleTypePhoneNumber, true);
+      expect(result.supportsHandleTypeGeneric, false);
+      expect(result.supportsHandleTypeEmailAddress, false);
+    });
+
+    test('supportedHandleTypes: all three types set all flags true', () {
+      const ios = CallkeepIOSOptions(
+        localizedName: 'App',
+        maximumCallGroups: 1,
+        maximumCallsPerCallGroup: 1,
+        supportedHandleTypes: {CallkeepHandleType.number, CallkeepHandleType.email, CallkeepHandleType.generic},
+      );
+      final result = ios.toPigeon();
+      expect(result.supportsHandleTypePhoneNumber, true);
+      expect(result.supportsHandleTypeEmailAddress, true);
+      expect(result.supportsHandleTypeGeneric, true);
+    });
+
+    test('maximumCallGroups and maximumCallsPerCallGroup are forwarded', () {
+      const ios = CallkeepIOSOptions(
+        localizedName: 'App',
+        maximumCallGroups: 3,
+        maximumCallsPerCallGroup: 5,
+        supportedHandleTypes: {},
+      );
+      final result = ios.toPigeon();
+      expect(result.maximumCallGroups, 3);
+      expect(result.maximumCallsPerCallGroup, 5);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PSpecialPermissionStatusTypeEnumConverter
+  // ---------------------------------------------------------------------------
+
+  group('PSpecialPermissionStatusTypeEnumConverter.toCallkeep()', () {
+    test('denied maps to CallkeepSpecialPermissionStatus.denied', () {
+      expect(PSpecialPermissionStatusTypeEnum.denied.toCallkeep(), CallkeepSpecialPermissionStatus.denied);
+    });
+
+    test('granted maps to CallkeepSpecialPermissionStatus.granted', () {
+      expect(PSpecialPermissionStatusTypeEnum.granted.toCallkeep(), CallkeepSpecialPermissionStatus.granted);
+    });
+
+    test('unknown maps to CallkeepSpecialPermissionStatus.unknown', () {
+      expect(PSpecialPermissionStatusTypeEnum.unknown.toCallkeep(), CallkeepSpecialPermissionStatus.unknown);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepPermissionConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepPermissionConverter.toPigeon()', () {
+    test('readPhoneState maps to PCallkeepPermission.readPhoneState', () {
+      expect(CallkeepPermission.readPhoneState.toPigeon(), PCallkeepPermission.readPhoneState);
+    });
+
+    test('readPhoneNumbers maps to PCallkeepPermission.readPhoneNumbers', () {
+      expect(CallkeepPermission.readPhoneNumbers.toPigeon(), PCallkeepPermission.readPhoneNumbers);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepPermissionConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepPermissionConverter.toCallkeep()', () {
+    test('readPhoneState maps to CallkeepPermission.readPhoneState', () {
+      expect(PCallkeepPermission.readPhoneState.toCallkeep(), CallkeepPermission.readPhoneState);
+    });
+
+    test('readPhoneNumbers maps to CallkeepPermission.readPhoneNumbers', () {
+      expect(PCallkeepPermission.readPhoneNumbers.toCallkeep(), CallkeepPermission.readPhoneNumbers);
+    });
+
+    test('round-trip: CallkeepPermission -> PCallkeepPermission -> CallkeepPermission', () {
+      for (final perm in CallkeepPermission.values) {
+        expect(perm.toPigeon().toCallkeep(), perm);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepAndroidBatteryModeConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepAndroidBatteryModeConverter.toCallkeep()', () {
+    test('unrestricted maps to CallkeepAndroidBatteryMode.unrestricted', () {
+      expect(PCallkeepAndroidBatteryMode.unrestricted.toCallkeep(), CallkeepAndroidBatteryMode.unrestricted);
+    });
+
+    test('optimized maps to CallkeepAndroidBatteryMode.optimized', () {
+      expect(PCallkeepAndroidBatteryMode.optimized.toCallkeep(), CallkeepAndroidBatteryMode.optimized);
+    });
+
+    test('restricted maps to CallkeepAndroidBatteryMode.restricted', () {
+      expect(PCallkeepAndroidBatteryMode.restricted.toCallkeep(), CallkeepAndroidBatteryMode.restricted);
+    });
+
+    test('unknown maps to CallkeepAndroidBatteryMode.unknown', () {
+      expect(PCallkeepAndroidBatteryMode.unknown.toCallkeep(), CallkeepAndroidBatteryMode.unknown);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepLifecycleTypeConverter (CallkeepLifecycleEvent -> PCallkeepLifecycleEvent)
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepLifecycleTypeConverter.toPigeon()', () {
+    test('onCreate', () => expect(CallkeepLifecycleEvent.onCreate.toPigeon(), PCallkeepLifecycleEvent.onCreate));
+    test('onStart', () => expect(CallkeepLifecycleEvent.onStart.toPigeon(), PCallkeepLifecycleEvent.onStart));
+    test('onResume', () => expect(CallkeepLifecycleEvent.onResume.toPigeon(), PCallkeepLifecycleEvent.onResume));
+    test('onPause', () => expect(CallkeepLifecycleEvent.onPause.toPigeon(), PCallkeepLifecycleEvent.onPause));
+    test('onStop', () => expect(CallkeepLifecycleEvent.onStop.toPigeon(), PCallkeepLifecycleEvent.onStop));
+    test('onDestroy', () => expect(CallkeepLifecycleEvent.onDestroy.toPigeon(), PCallkeepLifecycleEvent.onDestroy));
+    test('onAny', () => expect(CallkeepLifecycleEvent.onAny.toPigeon(), PCallkeepLifecycleEvent.onAny));
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepLifecycleTypeConverter (PCallkeepLifecycleEvent -> CallkeepLifecycleEvent)
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepLifecycleTypeConverter.toCallkeep()', () {
+    test('onCreate', () => expect(PCallkeepLifecycleEvent.onCreate.toCallkeep(), CallkeepLifecycleEvent.onCreate));
+    test('onStart', () => expect(PCallkeepLifecycleEvent.onStart.toCallkeep(), CallkeepLifecycleEvent.onStart));
+    test('onResume', () => expect(PCallkeepLifecycleEvent.onResume.toCallkeep(), CallkeepLifecycleEvent.onResume));
+    test('onPause', () => expect(PCallkeepLifecycleEvent.onPause.toCallkeep(), CallkeepLifecycleEvent.onPause));
+    test('onStop', () => expect(PCallkeepLifecycleEvent.onStop.toCallkeep(), CallkeepLifecycleEvent.onStop));
+    test('onDestroy', () => expect(PCallkeepLifecycleEvent.onDestroy.toCallkeep(), CallkeepLifecycleEvent.onDestroy));
+    test('onAny', () => expect(PCallkeepLifecycleEvent.onAny.toCallkeep(), CallkeepLifecycleEvent.onAny));
+
+    test('round-trip for all values', () {
+      for (final event in CallkeepLifecycleEvent.values) {
+        expect(event.toPigeon().toCallkeep(), event);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepSignalingStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepSignalingStatusConverter.toCallkeep()', () {
+    test('disconnecting', () {
+      expect(PCallkeepSignalingStatus.disconnecting.toCallkeep(), CallkeepSignalingStatus.disconnecting);
+    });
+
+    test('disconnect', () {
+      expect(PCallkeepSignalingStatus.disconnect.toCallkeep(), CallkeepSignalingStatus.disconnect);
+    });
+
+    test('connecting', () {
+      expect(PCallkeepSignalingStatus.connecting.toCallkeep(), CallkeepSignalingStatus.connecting);
+    });
+
+    test('connect', () {
+      expect(PCallkeepSignalingStatus.connect.toCallkeep(), CallkeepSignalingStatus.connect);
+    });
+
+    test('failure', () {
+      expect(PCallkeepSignalingStatus.failure.toCallkeep(), CallkeepSignalingStatus.failure);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepSignalingStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepSignalingStatusConverter.toPigeon()', () {
+    test('disconnecting', () {
+      expect(CallkeepSignalingStatus.disconnecting.toPigeon(), PCallkeepSignalingStatus.disconnecting);
+    });
+
+    test('disconnect', () {
+      expect(CallkeepSignalingStatus.disconnect.toPigeon(), PCallkeepSignalingStatus.disconnect);
+    });
+
+    test('connecting', () {
+      expect(CallkeepSignalingStatus.connecting.toPigeon(), PCallkeepSignalingStatus.connecting);
+    });
+
+    test('connect', () {
+      expect(CallkeepSignalingStatus.connect.toPigeon(), PCallkeepSignalingStatus.connect);
+    });
+
+    test('failure', () {
+      expect(CallkeepSignalingStatus.failure.toPigeon(), PCallkeepSignalingStatus.failure);
+    });
+
+    test('round-trip for all values', () {
+      for (final status in CallkeepSignalingStatus.values) {
+        expect(status.toPigeon().toCallkeep(), status);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepPushNotificationSyncStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepPushNotificationSyncStatusConverter.toCallkeep()', () {
+    test('synchronizeCallStatus', () {
+      expect(
+        PCallkeepPushNotificationSyncStatus.synchronizeCallStatus.toCallkeep(),
+        CallkeepPushNotificationSyncStatus.synchronizeCallStatus,
+      );
+    });
+
+    test('releaseResources', () {
+      expect(
+        PCallkeepPushNotificationSyncStatus.releaseResources.toCallkeep(),
+        CallkeepPushNotificationSyncStatus.releaseResources,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepIncomingCallDataConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepIncomingCallDataConverter.toCallkeep()', () {
+    test('all fields populated map correctly', () {
+      final data = PCallkeepIncomingCallData(
+        callId: 'call-42',
+        handle: PHandle(type: PHandleTypeEnum.number, value: '555-0100'),
+        displayName: 'Alice',
+        hasVideo: true,
+      );
+      final result = data.toCallkeep();
+      expect(result.callId, 'call-42');
+      expect(result.handle?.type, CallkeepHandleType.number);
+      expect(result.handle?.value, '555-0100');
+      expect(result.displayName, 'Alice');
+      expect(result.hasVideo, true);
+    });
+
+    test('null handle stays null', () {
+      final data = PCallkeepIncomingCallData(callId: 'call-43', handle: null, displayName: null, hasVideo: false);
+      final result = data.toCallkeep();
+      expect(result.callId, 'call-43');
+      expect(result.handle, isNull);
+      expect(result.displayName, isNull);
+      expect(result.hasVideo, false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepServiceStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepServiceStatusConverter.toCallkeep()', () {
+    test('lifecycleEvent is converted', () {
+      final status = PCallkeepServiceStatus(lifecycleEvent: PCallkeepLifecycleEvent.onResume);
+      final result = status.toCallkeep();
+      expect(result.lifecycleEvent, CallkeepLifecycleEvent.onResume);
+    });
+
+    test('null mainSignalingStatus stays null', () {
+      final status = PCallkeepServiceStatus(lifecycleEvent: PCallkeepLifecycleEvent.onStart, mainSignalingStatus: null);
+      final result = status.toCallkeep();
+      expect(result.mainSignalingStatus, isNull);
+    });
+
+    test('non-null mainSignalingStatus is converted', () {
+      final status = PCallkeepServiceStatus(
+        lifecycleEvent: PCallkeepLifecycleEvent.onResume,
+        mainSignalingStatus: PCallkeepSignalingStatus.connect,
+      );
+      final result = status.toCallkeep();
+      expect(result.mainSignalingStatus, CallkeepSignalingStatus.connect);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepServiceStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepServiceStatusConverter.toPigeon()', () {
+    test('lifecycleEvent is forwarded', () {
+      final status = CallkeepServiceStatus(lifecycleEvent: CallkeepLifecycleEvent.onDestroy);
+      final result = status.toPigeon();
+      expect(result.lifecycleEvent, PCallkeepLifecycleEvent.onDestroy);
+    });
+
+    test('mainSignalingStatus is intentionally dropped (not serialized to Pigeon)', () {
+      final status = CallkeepServiceStatus(
+        lifecycleEvent: CallkeepLifecycleEvent.onResume,
+        mainSignalingStatus: CallkeepSignalingStatus.connect,
+      );
+      final result = status.toPigeon();
+      expect(result.mainSignalingStatus, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepConnectionStateConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepConnectionStateConverter.toCallkeep()', () {
+    test('stateInitializing', () {
+      expect(PCallkeepConnectionState.stateInitializing.toCallkeep(), CallkeepConnectionState.stateInitializing);
+    });
+
+    test('stateNew', () {
+      expect(PCallkeepConnectionState.stateNew.toCallkeep(), CallkeepConnectionState.stateNew);
+    });
+
+    test('stateRinging', () {
+      expect(PCallkeepConnectionState.stateRinging.toCallkeep(), CallkeepConnectionState.stateRinging);
+    });
+
+    test('stateDialing', () {
+      expect(PCallkeepConnectionState.stateDialing.toCallkeep(), CallkeepConnectionState.stateDialing);
+    });
+
+    test('stateActive', () {
+      expect(PCallkeepConnectionState.stateActive.toCallkeep(), CallkeepConnectionState.stateActive);
+    });
+
+    test('stateHolding', () {
+      expect(PCallkeepConnectionState.stateHolding.toCallkeep(), CallkeepConnectionState.stateHolding);
+    });
+
+    test('stateDisconnected', () {
+      expect(PCallkeepConnectionState.stateDisconnected.toCallkeep(), CallkeepConnectionState.stateDisconnected);
+    });
+
+    test('statePullingCall', () {
+      expect(PCallkeepConnectionState.statePullingCall.toCallkeep(), CallkeepConnectionState.statePullingCall);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepDisconnectCauseTypeConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepDisconnectCauseTypeConverter.toCallkeep()', () {
+    test(
+      'unknown',
+      () => expect(PCallkeepDisconnectCauseType.unknown.toCallkeep(), CallkeepDisconnectCauseType.unknown),
+    );
+    test('error', () => expect(PCallkeepDisconnectCauseType.error.toCallkeep(), CallkeepDisconnectCauseType.error));
+    test('local', () => expect(PCallkeepDisconnectCauseType.local.toCallkeep(), CallkeepDisconnectCauseType.local));
+    test('remote', () => expect(PCallkeepDisconnectCauseType.remote.toCallkeep(), CallkeepDisconnectCauseType.remote));
+    test('canceled', () {
+      expect(PCallkeepDisconnectCauseType.canceled.toCallkeep(), CallkeepDisconnectCauseType.canceled);
+    });
+    test('missed', () => expect(PCallkeepDisconnectCauseType.missed.toCallkeep(), CallkeepDisconnectCauseType.missed));
+    test('rejected', () {
+      expect(PCallkeepDisconnectCauseType.rejected.toCallkeep(), CallkeepDisconnectCauseType.rejected);
+    });
+    test('busy', () => expect(PCallkeepDisconnectCauseType.busy.toCallkeep(), CallkeepDisconnectCauseType.busy));
+    test('restricted', () {
+      expect(PCallkeepDisconnectCauseType.restricted.toCallkeep(), CallkeepDisconnectCauseType.restricted);
+    });
+    test('other', () => expect(PCallkeepDisconnectCauseType.other.toCallkeep(), CallkeepDisconnectCauseType.other));
+    test('connectionManagerNotSupported', () {
+      expect(
+        PCallkeepDisconnectCauseType.connectionManagerNotSupported.toCallkeep(),
+        CallkeepDisconnectCauseType.connectionManagerNotSupported,
+      );
+    });
+    test('answeredElsewhere', () {
+      expect(
+        PCallkeepDisconnectCauseType.answeredElsewhere.toCallkeep(),
+        CallkeepDisconnectCauseType.answeredElsewhere,
+      );
+    });
+    test('callPulled', () {
+      expect(PCallkeepDisconnectCauseType.callPulled.toCallkeep(), CallkeepDisconnectCauseType.callPulled);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepDisconnectCauseConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepDisconnectCauseConverter.toCallkeep()', () {
+    test('type and reason are mapped', () {
+      final cause = PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.local, reason: 'user action');
+      final result = cause.toCallkeep();
+      expect(result.type, CallkeepDisconnectCauseType.local);
+      expect(result.reason, 'user action');
+    });
+
+    test('null reason stays null', () {
+      final cause = PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.remote, reason: null);
+      final result = cause.toCallkeep();
+      expect(result.type, CallkeepDisconnectCauseType.remote);
+      expect(result.reason, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PCallkeepConnectionConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepConnectionConverter.toCallkeep()', () {
+    test('callId, state and disconnectCause are all mapped', () {
+      final connection = PCallkeepConnection(
+        callId: 'abc-123',
+        state: PCallkeepConnectionState.stateActive,
+        disconnectCause: PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.unknown, reason: null),
+      );
+      final result = connection.toCallkeep();
+      expect(result.callId, 'abc-123');
+      expect(result.state, CallkeepConnectionState.stateActive);
+      expect(result.disconnectCause!.type, CallkeepDisconnectCauseType.unknown);
+      expect(result.disconnectCause!.reason, isNull);
+    });
+
+    test('disconnected state with reason', () {
+      final connection = PCallkeepConnection(
+        callId: 'xyz',
+        state: PCallkeepConnectionState.stateDisconnected,
+        disconnectCause: PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.local, reason: 'hung up'),
+      );
+      final result = connection.toCallkeep();
+      expect(result.state, CallkeepConnectionState.stateDisconnected);
+      expect(result.disconnectCause!.type, CallkeepDisconnectCauseType.local);
+      expect(result.disconnectCause!.reason, 'hung up');
+    });
+  });
+}

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: avoid_relative_lib_imports
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -100,18 +99,14 @@ class _FakeCallkeepDelegate implements CallkeepDelegate {
   @override
   void didReset() => _record('didReset', []);
 
-  @override
   void performIncomingCall(String callId, CallkeepHandle handle, String? displayName, bool video) {
     _record('performIncomingCall', [callId, handle, displayName, video]);
   }
 
-  @override
   void performConnecting(String callId) => _record('performConnecting', [callId]);
 
-  @override
   void performConnected(String callId) => _record('performConnected', [callId]);
 
-  @override
   Future<bool> performEndCallWithUUID(String callId) async {
     _record('performEndCallWithUUID', [callId]);
     return true;

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -8,10 +8,8 @@ import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
 import 'package:webtrit_callkeep_android/webtrit_callkeep_android.dart';
 import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
 
-import 'src/common/test_callkeep.pigeon.dart' as test_pigeon;
-
 const _prefix = 'dev.flutter.pigeon.webtrit_callkeep_android';
-const _codec = test_pigeon.testPigeonCodec;
+final _codec = PHostApi.pigeonChannelCodec;
 
 // ── Fake delegates ───────────────────────────────────────────────────────────
 

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_relative_lib_imports
-
 import 'dart:async';
 
 import 'package:flutter/services.dart';

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -1,0 +1,454 @@
+// ignore_for_file: avoid_relative_lib_imports
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
+import 'package:webtrit_callkeep_android/webtrit_callkeep_android.dart';
+import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
+
+import 'src/common/test_callkeep.pigeon.dart' as test_pigeon;
+
+const _prefix = 'dev.flutter.pigeon.webtrit_callkeep_android';
+const _codec = test_pigeon.testPigeonCodec;
+
+// ── Fake delegates ───────────────────────────────────────────────────────────
+
+class _FakeCallkeepDelegate implements CallkeepDelegate {
+  // Recorded invocations: method name -> list of argument lists
+  final Map<String, List<List<dynamic>>> calls = {};
+
+  void _record(String method, List<dynamic> args) => (calls[method] ??= []).add(args);
+
+  @override
+  void continueStartCallIntent(CallkeepHandle handle, String? displayName, bool video) {
+    _record('continueStartCallIntent', [handle, displayName, video]);
+  }
+
+  @override
+  void didPushIncomingCall(
+    CallkeepHandle handle,
+    String? displayName,
+    bool video,
+    String callId,
+    CallkeepIncomingCallError? error,
+  ) {
+    _record('didPushIncomingCall', [handle, displayName, video, callId, error]);
+  }
+
+  @override
+  Future<bool> performStartCall(
+    String callId,
+    CallkeepHandle handle,
+    String? displayNameOrContactIdentifier,
+    bool video,
+  ) async {
+    _record('performStartCall', [callId, handle, displayNameOrContactIdentifier, video]);
+    return true;
+  }
+
+  @override
+  Future<bool> performAnswerCall(String callId) async {
+    _record('performAnswerCall', [callId]);
+    return true;
+  }
+
+  @override
+  Future<bool> performEndCall(String callId) async {
+    _record('performEndCall', [callId]);
+    return false;
+  }
+
+  @override
+  Future<bool> performSetHeld(String callId, bool onHold) async {
+    _record('performSetHeld', [callId, onHold]);
+    return true;
+  }
+
+  @override
+  Future<bool> performSetMuted(String callId, bool muted) async {
+    _record('performSetMuted', [callId, muted]);
+    return true;
+  }
+
+  @override
+  Future<bool> performSendDTMF(String callId, String key) async {
+    _record('performSendDTMF', [callId, key]);
+    return true;
+  }
+
+  @override
+  Future<bool> performAudioDeviceSet(String callId, CallkeepAudioDevice device) async {
+    _record('performAudioDeviceSet', [callId, device]);
+    return true;
+  }
+
+  @override
+  Future<bool> performAudioDevicesUpdate(String callId, List<CallkeepAudioDevice> devices) async {
+    _record('performAudioDevicesUpdate', [callId, devices]);
+    return true;
+  }
+
+  @override
+  void didActivateAudioSession() => _record('didActivateAudioSession', []);
+
+  @override
+  void didDeactivateAudioSession() => _record('didDeactivateAudioSession', []);
+
+  @override
+  void didReset() => _record('didReset', []);
+
+  @override
+  void performIncomingCall(String callId, CallkeepHandle handle, String? displayName, bool video) {
+    _record('performIncomingCall', [callId, handle, displayName, video]);
+  }
+
+  @override
+  void performConnecting(String callId) => _record('performConnecting', [callId]);
+
+  @override
+  void performConnected(String callId) => _record('performConnected', [callId]);
+
+  @override
+  Future<bool> performEndCallWithUUID(String callId) async {
+    _record('performEndCallWithUUID', [callId]);
+    return true;
+  }
+}
+
+class _FakeLogsDelegate implements CallkeepLogsDelegate {
+  final List<List<dynamic>> calls = [];
+
+  @override
+  void onLog(CallkeepLogType type, String tag, String message) {
+    calls.add([type, tag, message]);
+  }
+}
+
+class _FakePushRegistryDelegate implements PushRegistryDelegate {
+  final List<String?> tokens = [];
+
+  @override
+  void didUpdatePushTokenForPushTypeVoIP(String? token) {
+    tokens.add(token);
+  }
+}
+
+class _FakeBackgroundServiceDelegate implements CallkeepBackgroundServiceDelegate {
+  final Map<String, List<String>> calls = {};
+
+  @override
+  Future<void> performAnswerCall(String callId) async {
+    (calls['performAnswerCall'] ??= []).add(callId);
+  }
+
+  @override
+  Future<void> performEndCall(String callId) async {
+    (calls['performEndCall'] ??= []).add(callId);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Simulates native side sending a message on a Pigeon Flutter-API channel.
+Future<ByteData?> _send(String channelName, List<Object?> args) {
+  final completer = Completer<ByteData?>();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    channelName,
+    _codec.encodeMessage(args),
+    (reply) => completer.complete(reply),
+  );
+  return completer.future;
+}
+
+void _mockVoid(String channel) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+    channel,
+    (message) async => const StandardMessageCodec().encodeMessage([null]),
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    WebtritCallkeepAndroid.registerWith();
+    _mockVoid('$_prefix.PHostApi.onDelegateSet');
+  });
+
+  // ---------------------------------------------------------------------------
+  // _CallkeepDelegateRelay
+  // ---------------------------------------------------------------------------
+
+  group('_CallkeepDelegateRelay', () {
+    late _FakeCallkeepDelegate fake;
+
+    setUp(() {
+      fake = _FakeCallkeepDelegate();
+      WebtritCallkeepPlatform.instance.setDelegate(fake);
+    });
+
+    tearDown(() {
+      WebtritCallkeepPlatform.instance.setDelegate(null);
+    });
+
+    test('setDelegate(null) clears handlers without error', () {
+      expect(() => WebtritCallkeepPlatform.instance.setDelegate(null), returnsNormally);
+    });
+
+    test('continueStartCallIntent forwards converted handle and args', () async {
+      await _send('$_prefix.PDelegateFlutterApi.continueStartCallIntent', [
+        PHandle(type: PHandleTypeEnum.number, value: '+1234'),
+        'Alice',
+        true,
+      ]);
+      expect(fake.calls['continueStartCallIntent'], hasLength(1));
+      final args = fake.calls['continueStartCallIntent']![0];
+      expect((args[0] as CallkeepHandle).type, CallkeepHandleType.number);
+      expect((args[0] as CallkeepHandle).value, '+1234');
+      expect(args[1], 'Alice');
+      expect(args[2], true);
+    });
+
+    test('continueStartCallIntent forwards null displayName', () async {
+      await _send('$_prefix.PDelegateFlutterApi.continueStartCallIntent', [
+        PHandle(type: PHandleTypeEnum.email, value: 'a@b.com'),
+        null,
+        false,
+      ]);
+      final args = fake.calls['continueStartCallIntent']![0];
+      expect(args[1], isNull);
+    });
+
+    test('didPushIncomingCall with null error forwards null error', () async {
+      await _send('$_prefix.PDelegateFlutterApi.didPushIncomingCall', [
+        PHandle(type: PHandleTypeEnum.number, value: '555'),
+        'Bob',
+        false,
+        'call-42',
+        null,
+      ]);
+      final args = fake.calls['didPushIncomingCall']![0];
+      expect(args[3], 'call-42');
+      expect(args[4], isNull);
+    });
+
+    test('didPushIncomingCall converts PIncomingCallError to CallkeepIncomingCallError', () async {
+      await _send('$_prefix.PDelegateFlutterApi.didPushIncomingCall', [
+        PHandle(type: PHandleTypeEnum.number, value: '555'),
+        null,
+        false,
+        'call-43',
+        PIncomingCallError(value: PIncomingCallErrorEnum.callRejectedBySystem),
+      ]);
+      final args = fake.calls['didPushIncomingCall']![0];
+      expect(args[4], CallkeepIncomingCallError.callRejectedBySystem);
+    });
+
+    test('performStartCall calls delegate and returns bool', () async {
+      final replyData = await _send('$_prefix.PDelegateFlutterApi.performStartCall', [
+        'call-1',
+        PHandle(type: PHandleTypeEnum.email, value: 'a@b.com'),
+        null,
+        false,
+      ]);
+      expect(fake.calls['performStartCall'], hasLength(1));
+      final args = fake.calls['performStartCall']![0];
+      expect(args[0], 'call-1');
+      expect((args[1] as CallkeepHandle).type, CallkeepHandleType.email);
+      // Pigeon encodes wrapResponse(result: true) which the relay returned
+      final reply = _codec.decodeMessage(replyData) as List<Object?>;
+      expect(reply[0], true);
+    });
+
+    test('performAnswerCall forwards callId and returns true', () async {
+      final replyData = await _send('$_prefix.PDelegateFlutterApi.performAnswerCall', ['call-99']);
+      expect(fake.calls['performAnswerCall']![0][0], 'call-99');
+      final reply = _codec.decodeMessage(replyData) as List<Object?>;
+      expect(reply[0], true);
+    });
+
+    test('performEndCall forwards callId and returns false', () async {
+      final replyData = await _send('$_prefix.PDelegateFlutterApi.performEndCall', ['call-77']);
+      expect(fake.calls['performEndCall']![0][0], 'call-77');
+      final reply = _codec.decodeMessage(replyData) as List<Object?>;
+      expect(reply[0], false);
+    });
+
+    test('performSetHeld forwards callId and onHold=true', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performSetHeld', ['call-1', true]);
+      final args = fake.calls['performSetHeld']![0];
+      expect(args[0], 'call-1');
+      expect(args[1], true);
+    });
+
+    test('performSetHeld forwards onHold=false', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performSetHeld', ['call-1', false]);
+      expect(fake.calls['performSetHeld']![0][1], false);
+    });
+
+    test('performSetMuted forwards callId and muted', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performSetMuted', ['call-2', false]);
+      final args = fake.calls['performSetMuted']![0];
+      expect(args[0], 'call-2');
+      expect(args[1], false);
+    });
+
+    test('performSendDTMF forwards callId and key', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performSendDTMF', ['call-3', '5']);
+      final args = fake.calls['performSendDTMF']![0];
+      expect(args[0], 'call-3');
+      expect(args[1], '5');
+    });
+
+    test('performAudioDeviceSet converts PAudioDevice by name mapping', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performAudioDeviceSet', [
+        'call-1',
+        PAudioDevice(type: PAudioDeviceType.bluetooth, id: 'bt1', name: 'Headset'),
+      ]);
+      final args = fake.calls['performAudioDeviceSet']![0];
+      expect(args[0], 'call-1');
+      final device = args[1] as CallkeepAudioDevice;
+      expect(device.type, CallkeepAudioDeviceType.bluetooth);
+      expect(device.id, 'bt1');
+      expect(device.name, 'Headset');
+    });
+
+    test('performAudioDevicesUpdate converts list of PAudioDevice', () async {
+      await _send('$_prefix.PDelegateFlutterApi.performAudioDevicesUpdate', [
+        'call-1',
+        [
+          PAudioDevice(type: PAudioDeviceType.earpiece, id: null, name: null),
+          PAudioDevice(type: PAudioDeviceType.speaker, id: null, name: null),
+        ],
+      ]);
+      final args = fake.calls['performAudioDevicesUpdate']![0];
+      expect(args[0], 'call-1');
+      final devices = args[1] as List<CallkeepAudioDevice>;
+      expect(devices.length, 2);
+      expect(devices[0].type, CallkeepAudioDeviceType.earpiece);
+      expect(devices[1].type, CallkeepAudioDeviceType.speaker);
+    });
+
+    test('didActivateAudioSession calls delegate', () async {
+      await _send('$_prefix.PDelegateFlutterApi.didActivateAudioSession', []);
+      expect(fake.calls['didActivateAudioSession'], hasLength(1));
+    });
+
+    test('didDeactivateAudioSession calls delegate', () async {
+      await _send('$_prefix.PDelegateFlutterApi.didDeactivateAudioSession', []);
+      expect(fake.calls['didDeactivateAudioSession'], hasLength(1));
+    });
+
+    test('didReset calls delegate', () async {
+      await _send('$_prefix.PDelegateFlutterApi.didReset', []);
+      expect(fake.calls['didReset'], hasLength(1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _LogsDelegateRelay
+  // ---------------------------------------------------------------------------
+
+  group('_LogsDelegateRelay', () {
+    late _FakeLogsDelegate fake;
+
+    setUp(() {
+      fake = _FakeLogsDelegate();
+      WebtritCallkeepPlatform.instance.setLogsDelegate(fake);
+    });
+
+    tearDown(() {
+      WebtritCallkeepPlatform.instance.setLogsDelegate(null);
+    });
+
+    test('setLogsDelegate(null) clears without error', () {
+      expect(() => WebtritCallkeepPlatform.instance.setLogsDelegate(null), returnsNormally);
+    });
+
+    test('onLog converts PLogTypeEnum and forwards all fields', () async {
+      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.warn, 'TAG', 'some message']);
+      expect(fake.calls.length, 1);
+      expect(fake.calls[0][0], CallkeepLogType.warn);
+      expect(fake.calls[0][1], 'TAG');
+      expect(fake.calls[0][2], 'some message');
+    });
+
+    test('onLog with debug type', () async {
+      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.debug, 'DEBUG_TAG', 'debug msg']);
+      expect(fake.calls[0][0], CallkeepLogType.debug);
+    });
+
+    test('onLog with error type', () async {
+      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.error, 'ERR', 'err msg']);
+      expect(fake.calls[0][0], CallkeepLogType.error);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _PushRegistryDelegateRelay
+  // ---------------------------------------------------------------------------
+
+  group('_PushRegistryDelegateRelay', () {
+    late _FakePushRegistryDelegate fake;
+
+    setUp(() {
+      fake = _FakePushRegistryDelegate();
+      WebtritCallkeepPlatform.instance.setPushRegistryDelegate(fake);
+    });
+
+    tearDown(() {
+      WebtritCallkeepPlatform.instance.setPushRegistryDelegate(null);
+    });
+
+    test('setPushRegistryDelegate(null) clears without error', () {
+      expect(() => WebtritCallkeepPlatform.instance.setPushRegistryDelegate(null), returnsNormally);
+    });
+
+    test('didUpdatePushTokenForPushTypeVoIP forwards token', () async {
+      await _send('$_prefix.PPushRegistryDelegateFlutterApi.didUpdatePushTokenForPushTypeVoIP', ['abc-token-123']);
+      expect(fake.tokens.length, 1);
+      expect(fake.tokens[0], 'abc-token-123');
+    });
+
+    test('didUpdatePushTokenForPushTypeVoIP forwards null token', () async {
+      await _send('$_prefix.PPushRegistryDelegateFlutterApi.didUpdatePushTokenForPushTypeVoIP', [null]);
+      expect(fake.tokens[0], isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _CallkeepBackgroundServiceDelegateRelay
+  // ---------------------------------------------------------------------------
+
+  group('_CallkeepBackgroundServiceDelegateRelay', () {
+    late _FakeBackgroundServiceDelegate fake;
+
+    setUp(() {
+      fake = _FakeBackgroundServiceDelegate();
+      WebtritCallkeepPlatform.instance.setBackgroundServiceDelegate(fake);
+    });
+
+    tearDown(() {
+      WebtritCallkeepPlatform.instance.setBackgroundServiceDelegate(null);
+    });
+
+    test('setBackgroundServiceDelegate(null) clears without error', () {
+      expect(() => WebtritCallkeepPlatform.instance.setBackgroundServiceDelegate(null), returnsNormally);
+    });
+
+    test('performAnswerCall forwards callId', () async {
+      await _send('$_prefix.PDelegateBackgroundServiceFlutterApi.performAnswerCall', ['call-bg-1']);
+      expect(fake.calls['performAnswerCall'], contains('call-bg-1'));
+    });
+
+    test('performEndCall forwards callId', () async {
+      await _send('$_prefix.PDelegateBackgroundServiceFlutterApi.performEndCall', ['call-bg-2']);
+      expect(fake.calls['performEndCall'], contains('call-bg-2'));
+    });
+  });
+}

--- a/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
@@ -185,3 +185,6 @@ class _PigeonCodec extends StandardMessageCodec {
     }
   }
 }
+
+// Public accessor so tests can encode Pigeon objects into mock channel responses.
+const testPigeonCodec = _PigeonCodec();

--- a/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
@@ -185,6 +185,3 @@ class _PigeonCodec extends StandardMessageCodec {
     }
   }
 }
-
-// Public accessor so tests can encode Pigeon objects into mock channel responses.
-const testPigeonCodec = _PigeonCodec();

--- a/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
+++ b/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
@@ -1,0 +1,522 @@
+// ignore_for_file: avoid_relative_lib_imports
+
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
+import 'package:webtrit_callkeep_android/webtrit_callkeep_android.dart';
+import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
+
+import 'src/common/test_callkeep.pigeon.dart' as test_pigeon;
+
+const _prefix = 'dev.flutter.pigeon.webtrit_callkeep_android';
+const _codec = test_pigeon.testPigeonCodec;
+
+void _mockVoid(String channel) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+    channel,
+    (message) async => const StandardMessageCodec().encodeMessage([null]),
+  );
+}
+
+void _mockValue(String channel, Object? value) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+    channel,
+    (message) async => const StandardMessageCodec().encodeMessage([value]),
+  );
+}
+
+void _mockPigeon(String channel, Object? pigeonValue) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+    channel,
+    (message) async => _codec.encodeMessage([pigeonValue]),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    WebtritCallkeepAndroid.registerWith();
+    _mockVoid('$_prefix.PHostApi.setUp');
+    _mockVoid('$_prefix.PHostApi.tearDown');
+    _mockVoid('$_prefix.PHostApi.onDelegateSet');
+    await WebtritCallkeepPlatform.instance.setUp(
+      const CallkeepOptions(
+        ios: CallkeepIOSOptions(
+          localizedName: 'Test',
+          maximumCallGroups: 1,
+          maximumCallsPerCallGroup: 1,
+          supportedHandleTypes: {CallkeepHandleType.number},
+        ),
+        android: CallkeepAndroidOptions(),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await WebtritCallkeepPlatform.instance.tearDown();
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostApi', () {
+    test('isSetUp returns true', () async {
+      _mockValue('$_prefix.PHostApi.isSetUp', true);
+      expect(await WebtritCallkeepPlatform.instance.isSetUp(), true);
+    });
+
+    test('isSetUp returns false', () async {
+      _mockValue('$_prefix.PHostApi.isSetUp', false);
+      expect(await WebtritCallkeepPlatform.instance.isSetUp(), false);
+    });
+
+    test('reportNewIncomingCall returns null when channel replies null', () async {
+      _mockValue('$_prefix.PHostApi.reportNewIncomingCall', null);
+      final result = await WebtritCallkeepPlatform.instance.reportNewIncomingCall(
+        'call-1',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        'Alice',
+        false,
+      );
+      expect(result, isNull);
+    });
+
+    test('reportNewIncomingCall returns CallkeepIncomingCallError.unknown', () async {
+      _mockPigeon('$_prefix.PHostApi.reportNewIncomingCall', PIncomingCallError(value: PIncomingCallErrorEnum.unknown));
+      final result = await WebtritCallkeepPlatform.instance.reportNewIncomingCall(
+        'call-2',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+      );
+      expect(result, CallkeepIncomingCallError.unknown);
+    });
+
+    test('reportNewIncomingCall returns CallkeepIncomingCallError.callRejectedBySystem', () async {
+      _mockPigeon(
+        '$_prefix.PHostApi.reportNewIncomingCall',
+        PIncomingCallError(value: PIncomingCallErrorEnum.callRejectedBySystem),
+      );
+      final result = await WebtritCallkeepPlatform.instance.reportNewIncomingCall(
+        'call-3',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+      );
+      expect(result, CallkeepIncomingCallError.callRejectedBySystem);
+    });
+
+    test('reportNewIncomingCall returns CallkeepIncomingCallError.callIdAlreadyExists', () async {
+      _mockPigeon(
+        '$_prefix.PHostApi.reportNewIncomingCall',
+        PIncomingCallError(value: PIncomingCallErrorEnum.callIdAlreadyExists),
+      );
+      final result = await WebtritCallkeepPlatform.instance.reportNewIncomingCall(
+        'call-4',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+      );
+      expect(result, CallkeepIncomingCallError.callIdAlreadyExists);
+    });
+
+    test('reportConnectingOutgoingCall completes', () async {
+      _mockVoid('$_prefix.PHostApi.reportConnectingOutgoingCall');
+      await expectLater(WebtritCallkeepPlatform.instance.reportConnectingOutgoingCall('call-1'), completes);
+    });
+
+    test('reportConnectedOutgoingCall completes', () async {
+      _mockVoid('$_prefix.PHostApi.reportConnectedOutgoingCall');
+      await expectLater(WebtritCallkeepPlatform.instance.reportConnectedOutgoingCall('call-1'), completes);
+    });
+
+    test('reportUpdateCall completes', () async {
+      _mockVoid('$_prefix.PHostApi.reportUpdateCall');
+      await expectLater(WebtritCallkeepPlatform.instance.reportUpdateCall('call-1', null, null, null, null), completes);
+    });
+
+    test('reportEndCall completes', () async {
+      _mockVoid('$_prefix.PHostApi.reportEndCall');
+      await expectLater(
+        WebtritCallkeepPlatform.instance.reportEndCall('call-1', 'Alice', CallkeepEndCallReason.remoteEnded),
+        completes,
+      );
+    });
+
+    test('startCall returns null when no error', () async {
+      _mockValue('$_prefix.PHostApi.startCall', null);
+      final result = await WebtritCallkeepPlatform.instance.startCall(
+        'call-1',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+        false,
+      );
+      expect(result, isNull);
+    });
+
+    test('startCall returns CallkeepCallRequestError.unknown', () async {
+      _mockPigeon('$_prefix.PHostApi.startCall', PCallRequestError(value: PCallRequestErrorEnum.unknown));
+      final result = await WebtritCallkeepPlatform.instance.startCall(
+        'call-1',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+        false,
+      );
+      expect(result, CallkeepCallRequestError.unknown);
+    });
+
+    test('startCall returns CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered', () async {
+      _mockPigeon(
+        '$_prefix.PHostApi.startCall',
+        PCallRequestError(value: PCallRequestErrorEnum.selfManagedPhoneAccountNotRegistered),
+      );
+      final result = await WebtritCallkeepPlatform.instance.startCall(
+        'call-1',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+        false,
+      );
+      expect(result, CallkeepCallRequestError.selfManagedPhoneAccountNotRegistered);
+    });
+
+    test('startCall returns CallkeepCallRequestError.timeout', () async {
+      _mockPigeon('$_prefix.PHostApi.startCall', PCallRequestError(value: PCallRequestErrorEnum.timeout));
+      final result = await WebtritCallkeepPlatform.instance.startCall(
+        'call-1',
+        const CallkeepHandle(type: CallkeepHandleType.number, value: '555'),
+        null,
+        false,
+        false,
+      );
+      expect(result, CallkeepCallRequestError.timeout);
+    });
+
+    test('answerCall returns null when no error', () async {
+      _mockValue('$_prefix.PHostApi.answerCall', null);
+      expect(await WebtritCallkeepPlatform.instance.answerCall('call-1'), isNull);
+    });
+
+    test('answerCall returns CallkeepCallRequestError.unknownCallUuid', () async {
+      _mockPigeon('$_prefix.PHostApi.answerCall', PCallRequestError(value: PCallRequestErrorEnum.unknownCallUuid));
+      expect(await WebtritCallkeepPlatform.instance.answerCall('call-1'), CallkeepCallRequestError.unknownCallUuid);
+    });
+
+    test('endCall returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.endCall', null);
+      expect(await WebtritCallkeepPlatform.instance.endCall('call-1'), isNull);
+    });
+
+    test('endCall returns CallkeepCallRequestError.internal', () async {
+      _mockPigeon('$_prefix.PHostApi.endCall', PCallRequestError(value: PCallRequestErrorEnum.internal));
+      expect(await WebtritCallkeepPlatform.instance.endCall('call-1'), CallkeepCallRequestError.internal);
+    });
+
+    test('setHeld returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.setHeld', null);
+      expect(await WebtritCallkeepPlatform.instance.setHeld('call-1', true), isNull);
+    });
+
+    test('setMuted returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.setMuted', null);
+      expect(await WebtritCallkeepPlatform.instance.setMuted('call-1', true), isNull);
+    });
+
+    test('setSpeaker returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.setSpeaker', null);
+      expect(await WebtritCallkeepPlatform.instance.setSpeaker('call-1', false), isNull);
+    });
+
+    test('sendDTMF returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.sendDTMF', null);
+      expect(await WebtritCallkeepPlatform.instance.sendDTMF('call-1', '5'), isNull);
+    });
+
+    test('setAudioDevice returns null when successful', () async {
+      _mockValue('$_prefix.PHostApi.setAudioDevice', null);
+      final result = await WebtritCallkeepPlatform.instance.setAudioDevice(
+        'call-1',
+        CallkeepAudioDevice(type: CallkeepAudioDeviceType.bluetooth, id: 'bt-1', name: 'Headset'),
+      );
+      expect(result, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostPermissionsApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostPermissionsApi', () {
+    test('getFullScreenIntentPermissionStatus returns granted', () async {
+      _mockPigeon(
+        '$_prefix.PHostPermissionsApi.getFullScreenIntentPermissionStatus',
+        PSpecialPermissionStatusTypeEnum.granted,
+      );
+      expect(
+        await WebtritCallkeepPlatform.instance.getFullScreenIntentPermissionStatus(),
+        CallkeepSpecialPermissionStatus.granted,
+      );
+    });
+
+    test('getFullScreenIntentPermissionStatus returns denied', () async {
+      _mockPigeon(
+        '$_prefix.PHostPermissionsApi.getFullScreenIntentPermissionStatus',
+        PSpecialPermissionStatusTypeEnum.denied,
+      );
+      expect(
+        await WebtritCallkeepPlatform.instance.getFullScreenIntentPermissionStatus(),
+        CallkeepSpecialPermissionStatus.denied,
+      );
+    });
+
+    test('getFullScreenIntentPermissionStatus returns unknown', () async {
+      _mockPigeon(
+        '$_prefix.PHostPermissionsApi.getFullScreenIntentPermissionStatus',
+        PSpecialPermissionStatusTypeEnum.unknown,
+      );
+      expect(
+        await WebtritCallkeepPlatform.instance.getFullScreenIntentPermissionStatus(),
+        CallkeepSpecialPermissionStatus.unknown,
+      );
+    });
+
+    test('openFullScreenIntentSettings completes', () async {
+      _mockVoid('$_prefix.PHostPermissionsApi.openFullScreenIntentSettings');
+      await expectLater(WebtritCallkeepPlatform.instance.openFullScreenIntentSettings(), completes);
+    });
+
+    test('openSettings completes', () async {
+      _mockVoid('$_prefix.PHostPermissionsApi.openSettings');
+      await expectLater(WebtritCallkeepPlatform.instance.openSettings(), completes);
+    });
+
+    test('getBatteryMode returns unrestricted', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getBatteryMode', PCallkeepAndroidBatteryMode.unrestricted);
+      expect(await WebtritCallkeepPlatform.instance.getBatteryMode(), CallkeepAndroidBatteryMode.unrestricted);
+    });
+
+    test('getBatteryMode returns optimized', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getBatteryMode', PCallkeepAndroidBatteryMode.optimized);
+      expect(await WebtritCallkeepPlatform.instance.getBatteryMode(), CallkeepAndroidBatteryMode.optimized);
+    });
+
+    test('getBatteryMode returns restricted', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getBatteryMode', PCallkeepAndroidBatteryMode.restricted);
+      expect(await WebtritCallkeepPlatform.instance.getBatteryMode(), CallkeepAndroidBatteryMode.restricted);
+    });
+
+    test('requestPermissions maps readPhoneState to granted', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        '$_prefix.PHostPermissionsApi.requestPermissions',
+        (message) async => _codec.encodeMessage([
+          [
+            PPermissionResult(
+              permission: PCallkeepPermission.readPhoneState,
+              status: PSpecialPermissionStatusTypeEnum.granted,
+            ),
+          ],
+        ]),
+      );
+      final results = await WebtritCallkeepPlatform.instance.requestPermissions([CallkeepPermission.readPhoneState]);
+      expect(results[CallkeepPermission.readPhoneState], CallkeepSpecialPermissionStatus.granted);
+    });
+
+    test('requestPermissions with two permissions returns both mapped', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        '$_prefix.PHostPermissionsApi.requestPermissions',
+        (message) async => _codec.encodeMessage([
+          [
+            PPermissionResult(
+              permission: PCallkeepPermission.readPhoneState,
+              status: PSpecialPermissionStatusTypeEnum.granted,
+            ),
+            PPermissionResult(
+              permission: PCallkeepPermission.readPhoneNumbers,
+              status: PSpecialPermissionStatusTypeEnum.denied,
+            ),
+          ],
+        ]),
+      );
+      final results = await WebtritCallkeepPlatform.instance.requestPermissions([
+        CallkeepPermission.readPhoneState,
+        CallkeepPermission.readPhoneNumbers,
+      ]);
+      expect(results[CallkeepPermission.readPhoneState], CallkeepSpecialPermissionStatus.granted);
+      expect(results[CallkeepPermission.readPhoneNumbers], CallkeepSpecialPermissionStatus.denied);
+    });
+
+    test('checkPermissionsStatus maps results correctly', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        '$_prefix.PHostPermissionsApi.checkPermissionsStatus',
+        (message) async => _codec.encodeMessage([
+          [
+            PPermissionResult(
+              permission: PCallkeepPermission.readPhoneNumbers,
+              status: PSpecialPermissionStatusTypeEnum.unknown,
+            ),
+          ],
+        ]),
+      );
+      final results = await WebtritCallkeepPlatform.instance.checkPermissionsStatus([
+        CallkeepPermission.readPhoneNumbers,
+      ]);
+      expect(results[CallkeepPermission.readPhoneNumbers], CallkeepSpecialPermissionStatus.unknown);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostConnectionsApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostConnectionsApi', () {
+    test('getConnection returns null when channel replies null', () async {
+      _mockValue('$_prefix.PHostConnectionsApi.getConnection', null);
+      expect(await WebtritCallkeepPlatform.instance.getConnection('call-1'), isNull);
+    });
+
+    test('getConnection returns CallkeepConnection', () async {
+      _mockPigeon(
+        '$_prefix.PHostConnectionsApi.getConnection',
+        PCallkeepConnection(
+          callId: 'call-1',
+          state: PCallkeepConnectionState.stateActive,
+          disconnectCause: PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.unknown, reason: null),
+        ),
+      );
+      final result = await WebtritCallkeepPlatform.instance.getConnection('call-1');
+      expect(result, isNotNull);
+      expect(result!.callId, 'call-1');
+      expect(result.state, CallkeepConnectionState.stateActive);
+    });
+
+    test('getConnections returns empty list', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        '$_prefix.PHostConnectionsApi.getConnections',
+        (message) async => _codec.encodeMessage([<PCallkeepConnection>[]]),
+      );
+      final result = await WebtritCallkeepPlatform.instance.getConnections();
+      expect(result, isEmpty);
+    });
+
+    test('getConnections returns two connections', () async {
+      final conn1 = PCallkeepConnection(
+        callId: 'c1',
+        state: PCallkeepConnectionState.stateRinging,
+        disconnectCause: PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.unknown, reason: null),
+      );
+      final conn2 = PCallkeepConnection(
+        callId: 'c2',
+        state: PCallkeepConnectionState.stateActive,
+        disconnectCause: PCallkeepDisconnectCause(type: PCallkeepDisconnectCauseType.unknown, reason: null),
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        '$_prefix.PHostConnectionsApi.getConnections',
+        (message) async => _codec.encodeMessage([
+          [conn1, conn2],
+        ]),
+      );
+      final result = await WebtritCallkeepPlatform.instance.getConnections();
+      expect(result.length, 2);
+      expect(result[0].callId, 'c1');
+      expect(result[0].state, CallkeepConnectionState.stateRinging);
+      expect(result[1].callId, 'c2');
+      expect(result[1].state, CallkeepConnectionState.stateActive);
+    });
+
+    test('cleanConnections completes', () async {
+      _mockVoid('$_prefix.PHostConnectionsApi.cleanConnections');
+      await expectLater(WebtritCallkeepPlatform.instance.cleanConnections(), completes);
+    });
+
+    test('updateActivitySignalingStatus with connect completes', () async {
+      _mockVoid('$_prefix.PHostConnectionsApi.updateActivitySignalingStatus');
+      await expectLater(
+        WebtritCallkeepPlatform.instance.updateActivitySignalingStatus(CallkeepSignalingStatus.connect),
+        completes,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostSoundApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostSoundApi', () {
+    test('playRingbackSound completes', () async {
+      _mockVoid('$_prefix.PHostSoundApi.playRingbackSound');
+      await expectLater(WebtritCallkeepPlatform.instance.playRingbackSound(), completes);
+    });
+
+    test('stopRingbackSound completes', () async {
+      _mockVoid('$_prefix.PHostSoundApi.stopRingbackSound');
+      await expectLater(WebtritCallkeepPlatform.instance.stopRingbackSound(), completes);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostActivityControlApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostActivityControlApi', () {
+    test('showOverLockscreen(true) completes', () async {
+      _mockVoid('$_prefix.PHostActivityControlApi.showOverLockscreen');
+      await expectLater(WebtritCallkeepPlatform.instance.showOverLockscreen(true), completes);
+    });
+
+    test('showOverLockscreen defaults to true', () async {
+      _mockVoid('$_prefix.PHostActivityControlApi.showOverLockscreen');
+      await expectLater(WebtritCallkeepPlatform.instance.showOverLockscreen(), completes);
+    });
+
+    test('wakeScreenOnShow completes', () async {
+      _mockVoid('$_prefix.PHostActivityControlApi.wakeScreenOnShow');
+      await expectLater(WebtritCallkeepPlatform.instance.wakeScreenOnShow(), completes);
+    });
+
+    test('sendToBackground returns true', () async {
+      _mockValue('$_prefix.PHostActivityControlApi.sendToBackground', true);
+      expect(await WebtritCallkeepPlatform.instance.sendToBackground(), true);
+    });
+
+    test('sendToBackground returns false', () async {
+      _mockValue('$_prefix.PHostActivityControlApi.sendToBackground', false);
+      expect(await WebtritCallkeepPlatform.instance.sendToBackground(), false);
+    });
+
+    test('isDeviceLocked returns false', () async {
+      _mockValue('$_prefix.PHostActivityControlApi.isDeviceLocked', false);
+      expect(await WebtritCallkeepPlatform.instance.isDeviceLocked(), false);
+    });
+
+    test('isDeviceLocked returns true', () async {
+      _mockValue('$_prefix.PHostActivityControlApi.isDeviceLocked', true);
+      expect(await WebtritCallkeepPlatform.instance.isDeviceLocked(), true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PHostDiagnosticsApi
+  // ---------------------------------------------------------------------------
+
+  group('WebtritCallkeepAndroid — PHostDiagnosticsApi', () {
+    test('getDiagnosticReport returns typed map', () async {
+      _mockValue('$_prefix.PHostDiagnosticsApi.getDiagnosticReport', {'key': 'value', 'count': 42});
+      final report = await WebtritCallkeepPlatform.instance.getDiagnosticReport();
+      expect(report, isA<Map<String, dynamic>>());
+      expect(report['key'], 'value');
+      expect(report['count'], 42);
+    });
+
+    test('getDiagnosticReport returns empty map', () async {
+      _mockValue('$_prefix.PHostDiagnosticsApi.getDiagnosticReport', <String, Object?>{});
+      final report = await WebtritCallkeepPlatform.instance.getDiagnosticReport();
+      expect(report, isEmpty);
+    });
+  });
+}

--- a/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
+++ b/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_relative_lib_imports
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';

--- a/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
+++ b/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: avoid_relative_lib_imports
 
-import 'dart:typed_data';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';

--- a/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
+++ b/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
@@ -6,10 +6,8 @@ import 'package:webtrit_callkeep_android/src/common/callkeep.pigeon.dart';
 import 'package:webtrit_callkeep_android/webtrit_callkeep_android.dart';
 import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
 
-import 'src/common/test_callkeep.pigeon.dart' as test_pigeon;
-
 const _prefix = 'dev.flutter.pigeon.webtrit_callkeep_android';
-const _codec = test_pigeon.testPigeonCodec;
+final _codec = PHostApi.pigeonChannelCodec;
 
 void _mockVoid(String channel) {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(


### PR DESCRIPTION
## Summary

- Add `converters_test.dart`: covers all 27 extension methods in `converters.dart` (Pigeon <-> platform-interface type conversions)
- Add `webtrit_callkeep_android_api_test.dart`: covers all `WebtritCallkeepAndroid` public methods across `PHostApi`, `PHostPermissionsApi`, `PHostConnectionsApi`, `PHostSoundApi`, `PHostActivityControlApi`, and `PHostDiagnosticsApi`
- Add `delegate_relay_test.dart`: covers all four relay classes (`_CallkeepDelegateRelay`, `_LogsDelegateRelay`, `_PushRegistryDelegateRelay`, `_CallkeepBackgroundServiceDelegateRelay`) by simulating inbound Pigeon messages via `handlePlatformMessage`
- Use `PHostApi.pigeonChannelCodec` (already public in the production Pigeon file) to encode Pigeon objects in mock channel responses — no generated files modified

## Test plan

- [ ] `flutter test test/converters_test.dart` -- 202 tests pass
- [ ] `flutter test test/webtrit_callkeep_android_api_test.dart` -- passes
- [ ] `flutter test test/delegate_relay_test.dart` -- passes
- [ ] `flutter analyze lib test` -- no issues