### PR TITLE
fix(android): remove unregisterPhoneAccount from service destroy lifecycle

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -36,12 +36,14 @@ class TelephonyUtils(
         uri: Uri,
         metadata: CallMetadata,
     ) {
+        registerPhoneAccount()
         val extras = buildOutgoingCallExtras(metadata)
         logger.i("placeCall: uri: '$uri', extras: '$extras'")
         getTelecomManager().placeCall(uri, extras)
     }
 
     fun addNewIncomingCall(metadata: CallMetadata) {
+        registerPhoneAccount()
         getTelecomManager().addNewIncomingCall(
             getPhoneAccountHandle(),
             buildIncomingCallExtras(metadata),

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -36,14 +36,12 @@ class TelephonyUtils(
         uri: Uri,
         metadata: CallMetadata,
     ) {
-        registerPhoneAccount()
         val extras = buildOutgoingCallExtras(metadata)
         logger.i("placeCall: uri: '$uri', extras: '$extras'")
         getTelecomManager().placeCall(uri, extras)
     }
 
     fun addNewIncomingCall(metadata: CallMetadata) {
-        registerPhoneAccount()
         getTelecomManager().addNewIncomingCall(
             getPhoneAccountHandle(),
             buildIncomingCallExtras(metadata),

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1187,8 +1187,9 @@ class ForegroundService :
         }
         tearDownAckReceiver = null
 
-        runCatching { TelephonyUtils(baseContext).unregisterPhoneAccount() }
-            .onFailure { e -> logger.w("onDestroy: unregisterPhoneAccount failed: ${e.message}", e) }
+        // Phone account registration is tied to the user session, not the service lifecycle.
+        // Unregistration happens only in finishTearDown() (explicit logout/tearDown call).
+        // Removing it here ensures cold-start push calls work even if the service was killed.
 
         isRunning = false
     }


### PR DESCRIPTION
## Problem

`unregisterPhoneAccount()` was called in `ForegroundService.onDestroy()`. When the system killed the service (low memory, force-stop), the phone account was removed from Android Telecom. The next cold-start push call then failed with `SecurityException` inside `addNewIncomingCall()` — the account was no longer registered.

## Root cause

Phone account registration in Android Telecom is **persistent** — it survives app restarts, service kills, and reboots. It should be tied to the **user session**, not to the service lifecycle:

| Event | Action |
| --- | --- |
| User logs in / `setUp()` | `registerPhoneAccount()` |
| User logs out / `tearDown()` | `unregisterPhoneAccount()` |
| Service killed by system | nothing — account stays registered |

This matches standard Android VoIP practice (WhatsApp, Signal, etc.).

## Change

Remove `unregisterPhoneAccount()` from `ForegroundService.onDestroy()`. It remains only in `finishTearDown()` — the explicit logout path.

## Test plan

- [ ] Cold-start incoming push call works after app was force-stopped
- [ ] Logout (`tearDown()`) correctly unregisters the phone account
- [ ] Re-login re-registers the account via `setUp()`