### PR TITLE
fix(android): route push notification incoming call through CallkeepCore

### DIFF
--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -90,6 +90,8 @@ dependencies {
         testRuntimeOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")
     }
 
+    lintChecks project(':lint')
+
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "androidx.test:core:1.7.0"

--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -90,7 +90,13 @@ dependencies {
         testRuntimeOnly files("$flutterSdkPath/bin/cache/artifacts/engine/android-x86/flutter.jar")
     }
 
-    lintChecks project(':lint')
+    // Lint rules — available only when building the library standalone.
+    // When included as a Flutter plugin dependency the :lint submodule is not
+    // part of the host app's Gradle project, so we guard with findProject().
+    def lintProject = findProject(':lint')
+    if (lintProject != null) {
+        lintChecks lintProject
+    }
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/webtrit_callkeep_android/android/lint/build.gradle
+++ b/webtrit_callkeep_android/android/lint/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'kotlin'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    compileOnly "com.android.tools.lint:lint-api:31.7.3"
+    compileOnly "com.android.tools.lint:lint-checks:31.7.3"
+}
+
+jar {
+    manifest {
+        attributes("Lint-Registry-v2": "com.webtrit.callkeep.lint.CallkeepIssueRegistry")
+    }
+}

--- a/webtrit_callkeep_android/android/lint/src/main/kotlin/com/webtrit/callkeep/lint/CallkeepIssueRegistry.kt
+++ b/webtrit_callkeep_android/android/lint/src/main/kotlin/com/webtrit/callkeep/lint/CallkeepIssueRegistry.kt
@@ -1,0 +1,20 @@
+package com.webtrit.callkeep.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
+import com.android.tools.lint.detector.api.CURRENT_API
+
+class CallkeepIssueRegistry : IssueRegistry() {
+    override val issues = listOf(PhoneConnectionServiceDetector.ISSUE)
+
+    override val api: Int = CURRENT_API
+
+    override val minApi: Int = 12
+
+    override val vendor: Vendor =
+        Vendor(
+            vendorName = "WebTrit",
+            identifier = "com.webtrit.callkeep",
+            feedbackUrl = "https://github.com/WebTrit/webtrit_callkeep/issues",
+        )
+}

--- a/webtrit_callkeep_android/android/lint/src/main/kotlin/com/webtrit/callkeep/lint/PhoneConnectionServiceDetector.kt
+++ b/webtrit_callkeep_android/android/lint/src/main/kotlin/com/webtrit/callkeep/lint/PhoneConnectionServiceDetector.kt
@@ -1,0 +1,92 @@
+package com.webtrit.callkeep.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * Lint rule that prevents direct calls to [PhoneConnectionService] static methods
+ * from the main process outside of the allowed packages.
+ *
+ * All main-process interactions with PhoneConnectionService must go through
+ * [CallkeepCore.instance] so that [MainProcessConnectionTracker] shadow state
+ * (addPending, promote, markAnswered, etc.) is always kept in sync with the
+ * :callkeep_core process.
+ *
+ * ## Allowed callers
+ * - `services/connection/` — PhoneConnectionService itself and its internal classes
+ * - `services/core/`       — InProcessCallkeepCore (the only legitimate dispatch point)
+ *
+ * ## All other callers produce a Lint ERROR.
+ */
+class PhoneConnectionServiceDetector :
+    Detector(),
+    SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext) =
+        object : UElementHandler() {
+            override fun visitCallExpression(node: UCallExpression) {
+                val method = node.resolve() ?: return
+                val containingClass = method.containingClass?.qualifiedName ?: return
+
+                val isPhoneConnectionService =
+                    containingClass == PHONE_CONNECTION_SERVICE_FQN ||
+                        containingClass == "$PHONE_CONNECTION_SERVICE_FQN.Companion"
+
+                if (!isPhoneConnectionService) return
+
+                val filePath = context.file.path
+                if (ALLOWED_PATH_SEGMENTS.any { filePath.contains(it) }) return
+
+                context.report(
+                    ISSUE,
+                    node,
+                    context.getNameLocation(node),
+                    "Direct call to `PhoneConnectionService` from the main process. " +
+                        "Use `CallkeepCore.instance` instead to keep `MainProcessConnectionTracker` in sync.",
+                )
+            }
+        }
+
+    companion object {
+        private const val PHONE_CONNECTION_SERVICE_FQN =
+            "com.webtrit.callkeep.services.services.connection.PhoneConnectionService"
+
+        private val ALLOWED_PATH_SEGMENTS =
+            listOf(
+                "/services/connection/",
+                "/services/core/",
+            )
+
+        @JvmField
+        val ISSUE: Issue =
+            Issue.create(
+                id = "PhoneConnectionServiceDirectCall",
+                briefDescription = "Direct `PhoneConnectionService` call bypasses `CallkeepCore`",
+                explanation = """
+                All main-process code must interact with `PhoneConnectionService` through \
+                `CallkeepCore.instance`. Direct calls bypass `MainProcessConnectionTracker` \
+                bookkeeping (`addPending`, `promote`, etc.) and break the dual-process \
+                architecture contract, potentially causing call-state inconsistencies.
+
+                Replace the direct call with the equivalent `CallkeepCore.instance.<method>()`.
+            """,
+                category = Category.CORRECTNESS,
+                priority = 9,
+                severity = Severity.ERROR,
+                implementation =
+                    Implementation(
+                        PhoneConnectionServiceDetector::class.java,
+                        Scope.JAVA_FILE_SCOPE,
+                    ),
+            )
+    }
+}

--- a/webtrit_callkeep_android/android/settings.gradle
+++ b/webtrit_callkeep_android/android/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'webtrit_callkeep_android'
+include ':lint'

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/BackgroundPushNotificationIsolateBootstrapApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/BackgroundPushNotificationIsolateBootstrapApi.kt
@@ -5,7 +5,7 @@ import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.toCallHandle
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.core.CallkeepCore
 
 class BackgroundPushNotificationIsolateBootstrapApi(
     private val context: Context,
@@ -52,8 +52,7 @@ class BackgroundPushNotificationIsolateBootstrapApi(
                 ringtonePath = ringtonePath,
             )
 
-        PhoneConnectionService.startIncomingCall(
-            context = context,
+        CallkeepCore.instance.startIncomingCall(
             metadata = metadata,
             onSuccess = { callback(Result.success(null)) },
             onError = { error -> callback(Result.success(error)) },

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/receivers/IncomingCallSmsTriggerReceiver.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/receivers/IncomingCallSmsTriggerReceiver.kt
@@ -9,7 +9,7 @@ import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.models.CallHandle
 import com.webtrit.callkeep.models.CallMetadata
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.core.CallkeepCore
 import java.net.URLDecoder
 
 class IncomingCallSmsTriggerReceiver : BroadcastReceiver() {
@@ -44,8 +44,7 @@ class IncomingCallSmsTriggerReceiver : BroadcastReceiver() {
         metadata: CallMetadata,
     ) {
         try {
-            PhoneConnectionService.startIncomingCall(
-                context,
+            CallkeepCore.instance.startIncomingCall(
                 metadata,
                 onSuccess = { Log.d(TAG, "Incoming call started") },
                 onError = { Log.e(TAG, "Failed to start call: $it") },

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -13,7 +13,7 @@ import com.webtrit.callkeep.common.startForegroundServiceCompat
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.notifications.ActiveCallNotificationBuilder
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.core.CallkeepCore
 
 class ActiveCallService : Service() {
     private val activeCallNotificationBuilder = ActiveCallNotificationBuilder()
@@ -59,8 +59,8 @@ class ActiveCallService : Service() {
 
     private fun hungUpCall() =
         callsMetadata.firstOrNull()?.let {
-            PhoneConnectionService.startHungUpCall(baseContext, it)
-        } ?: PhoneConnectionService.tearDown(baseContext)
+            CallkeepCore.instance.startHungUpCall(it)
+        } ?: CallkeepCore.instance.tearDownService()
 
     private fun getForegroundServiceTypes(callsMetadata: List<CallMetadata>): Int? =
         when {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -509,7 +509,12 @@ class PhoneConnection internal constructor(
     private fun onActiveConnection() {
         logger.i("Connection became active for callId: $callId")
         audioManager.stopRingtone()
-        notificationManager.cancelIncomingNotification(true)
+        // IncomingCallService release (IC_RELEASE_WITH_ANSWER) is intentionally NOT triggered
+        // here from :callkeep_core. ForegroundService.handleCSReportAnswerCall() owns that
+        // trigger and sets pendingReleaseCallback before firing it, ensuring performAnswerCall
+        // reaches the main Flutter engine only after the background isolate confirms its
+        // signaling WebSocket is closed. Triggering release from both places would race and
+        // risk pendingReleaseCallback being null when the isolate acks.
         notificationManager.showActiveCallNotification(callId, metadata)
 
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O_MR1) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -15,6 +15,7 @@ import android.telecom.TelecomManager
 import android.telecom.VideoProfile
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
+import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.Platform
 import com.webtrit.callkeep.managers.AudioManager
@@ -134,12 +135,7 @@ class PhoneConnection internal constructor(
         hasAnswered = true
         setActive()
         dispatcher(CallLifecycleEvent.AnswerCall, metadata)
-        // ActivityHolder.start() is intentionally NOT called here.
-        // For the push-notification path, ForegroundService.handleCSReportAnswerCall()
-        // launches the activity only AFTER the background isolate confirms its signaling
-        // WebSocket is closed (via pendingReleaseCallback). This prevents the main engine
-        // from reconnecting signaling before the isolate disconnects, which previously
-        // caused the server to send a 4441 "force attach close" to the main engine.
+        ActivityHolder.start(context)
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -15,7 +15,6 @@ import android.telecom.TelecomManager
 import android.telecom.VideoProfile
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
-import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.Platform
 import com.webtrit.callkeep.managers.AudioManager
@@ -135,7 +134,12 @@ class PhoneConnection internal constructor(
         hasAnswered = true
         setActive()
         dispatcher(CallLifecycleEvent.AnswerCall, metadata)
-        ActivityHolder.start(context)
+        // ActivityHolder.start() is intentionally NOT called here.
+        // For the push-notification path, ForegroundService.handleCSReportAnswerCall()
+        // launches the activity only AFTER the background isolate confirms its signaling
+        // WebSocket is closed (via pendingReleaseCallback). This prevents the main engine
+        // from reconnecting signaling before the isolate disconnects, which previously
+        // caused the server to send a 4441 "force attach close" to the main engine.
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1060,28 +1060,32 @@ class ForegroundService :
 
             if (IncomingCallService.isRunning) {
                 // Push-notification path: the background isolate holds an active signaling
-                // WebSocket. Dispatch performAnswerCall to the main Flutter engine only after
-                // the isolate confirms its WebSocket is closed. This prevents the server from
-                // sending a 4441 "force attach close" to the main engine's newly-opened
-                // signaling connection, which previously left the call stuck at
-                // "Answering the call, please hold on…".
+                // WebSocket. Launch the activity and dispatch performAnswerCall to the main
+                // Flutter engine only AFTER the isolate confirms its WebSocket is closed
+                // (via pendingReleaseCallback). This prevents the main engine from
+                // reconnecting signaling before the isolate disconnects, which previously
+                // caused the server to send a 4441 "force attach close" to the main engine,
+                // leaving the call stuck at "Answering the call, please hold on…".
                 val callId = callMetaData.callId
                 IncomingCallService.pendingReleaseCallback = {
+                    ActivityHolder.start(baseContext)
                     flutterDelegateApi?.performAnswerCall(callId) {}
                 }
                 // Safety net: if the isolate never acks (crash, Dart exception), unblock
-                // performAnswerCall after a short timeout so the call is not permanently stuck.
+                // the activity launch and performAnswerCall after a short timeout so the
+                // call is not permanently stuck.
                 Handler(Looper.getMainLooper()).postDelayed({
                     val pending = IncomingCallService.pendingReleaseCallback
                     if (pending != null) {
-                        logger.w("handleCSReportAnswerCall: isolate release timeout, proceeding with performAnswerCall")
+                        logger.w("handleCSReportAnswerCall: isolate release timeout, proceeding with activity launch and performAnswerCall")
                         IncomingCallService.pendingReleaseCallback = null
                         pending()
                     }
                 }, ISOLATE_RELEASE_TIMEOUT_MS)
                 IncomingCallService.release(baseContext, IncomingCallRelease.IC_RELEASE_WITH_ANSWER)
             } else {
-                // Signaling path (no background isolate): notify Flutter immediately.
+                // Signaling path (no background isolate): launch activity and notify Flutter immediately.
+                ActivityHolder.start(baseContext)
                 flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
             }
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1059,35 +1059,12 @@ class ForegroundService :
             flutterDelegateApi?.didActivateAudioSession {}
 
             if (IncomingCallService.isRunning) {
-                // Push-notification path: the background isolate holds an active signaling
-                // WebSocket. Launch the activity and dispatch performAnswerCall to the main
-                // Flutter engine only AFTER the isolate confirms its WebSocket is closed
-                // (via pendingReleaseCallback). This prevents the main engine from
-                // reconnecting signaling before the isolate disconnects, which previously
-                // caused the server to send a 4441 "force attach close" to the main engine,
-                // leaving the call stuck at "Answering the call, please hold on…".
-                val callId = callMetaData.callId
-                IncomingCallService.pendingReleaseCallback = {
-                    ActivityHolder.start(baseContext)
-                    flutterDelegateApi?.performAnswerCall(callId) {}
-                }
-                // Safety net: if the isolate never acks (crash, Dart exception), unblock
-                // the activity launch and performAnswerCall after a short timeout so the
-                // call is not permanently stuck.
-                Handler(Looper.getMainLooper()).postDelayed({
-                    val pending = IncomingCallService.pendingReleaseCallback
-                    if (pending != null) {
-                        logger.w("handleCSReportAnswerCall: isolate release timeout, proceeding with activity launch and performAnswerCall")
-                        IncomingCallService.pendingReleaseCallback = null
-                        pending()
-                    }
-                }, ISOLATE_RELEASE_TIMEOUT_MS)
+                // Push-notification path: tell the background isolate to release its
+                // signaling WebSocket. ActivityHolder.start() already fired from
+                // PhoneConnection.onAnswer() in :callkeep_core.
                 IncomingCallService.release(baseContext, IncomingCallRelease.IC_RELEASE_WITH_ANSWER)
-            } else {
-                // Signaling path (no background isolate): launch activity and notify Flutter immediately.
-                ActivityHolder.start(baseContext)
-                flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
             }
+            flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
         }
     }
 
@@ -1241,7 +1218,6 @@ class ForegroundService :
 
         private const val OUTGOING_CALL_TIMEOUT_MS = 5_000L
         private const val TEAR_DOWN_ACK_TIMEOUT_MS = 3_000L
-        private const val ISOLATE_RELEASE_TIMEOUT_MS = 2_000L
 
         // Maximum time to wait for Telecom to confirm an incoming call via DidPushIncomingCall.
         // If this elapses without confirmation or rejection, resolve the Pigeon callback with

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -44,6 +44,8 @@ import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.core.CallkeepCore
+import com.webtrit.callkeep.services.services.incoming_call.IncomingCallRelease
+import com.webtrit.callkeep.services.services.incoming_call.IncomingCallService
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -1054,8 +1056,34 @@ class ForegroundService :
             core.consumeAnswer(callMetaData.callId)
             // Update tracker: call has been answered.
             core.markAnswered(callMetaData.callId)
-            flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
             flutterDelegateApi?.didActivateAudioSession {}
+
+            if (IncomingCallService.isRunning) {
+                // Push-notification path: the background isolate holds an active signaling
+                // WebSocket. Dispatch performAnswerCall to the main Flutter engine only after
+                // the isolate confirms its WebSocket is closed. This prevents the server from
+                // sending a 4441 "force attach close" to the main engine's newly-opened
+                // signaling connection, which previously left the call stuck at
+                // "Answering the call, please hold on…".
+                val callId = callMetaData.callId
+                IncomingCallService.pendingReleaseCallback = {
+                    flutterDelegateApi?.performAnswerCall(callId) {}
+                }
+                // Safety net: if the isolate never acks (crash, Dart exception), unblock
+                // performAnswerCall after a short timeout so the call is not permanently stuck.
+                Handler(Looper.getMainLooper()).postDelayed({
+                    val pending = IncomingCallService.pendingReleaseCallback
+                    if (pending != null) {
+                        logger.w("handleCSReportAnswerCall: isolate release timeout, proceeding with performAnswerCall")
+                        IncomingCallService.pendingReleaseCallback = null
+                        pending()
+                    }
+                }, ISOLATE_RELEASE_TIMEOUT_MS)
+                IncomingCallService.release(baseContext, IncomingCallRelease.IC_RELEASE_WITH_ANSWER)
+            } else {
+                // Signaling path (no background isolate): notify Flutter immediately.
+                flutterDelegateApi?.performAnswerCall(callMetaData.callId) {}
+            }
         }
     }
 
@@ -1209,6 +1237,7 @@ class ForegroundService :
 
         private const val OUTGOING_CALL_TIMEOUT_MS = 5_000L
         private const val TEAR_DOWN_ACK_TIMEOUT_MS = 3_000L
+        private const val ISOLATE_RELEASE_TIMEOUT_MS = 2_000L
 
         // Maximum time to wait for Telecom to confirm an incoming call via DidPushIncomingCall.
         // If this elapses without confirmation or rejection, resolve the Pigeon callback with

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallConnectionController.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallConnectionController.kt
@@ -1,8 +1,7 @@
 package com.webtrit.callkeep.services.services.incoming_call
 
-import android.content.Context
 import com.webtrit.callkeep.models.CallMetadata
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.core.CallkeepCore
 
 interface CallConnectionController {
     fun answer(metadata: CallMetadata)
@@ -14,22 +13,20 @@ interface CallConnectionController {
     fun tearDown()
 }
 
-class DefaultCallConnectionController(
-    private val context: Context,
-) : CallConnectionController {
+class DefaultCallConnectionController : CallConnectionController {
     override fun answer(metadata: CallMetadata) {
-        PhoneConnectionService.startAnswerCall(context, metadata)
+        CallkeepCore.instance.startAnswerCall(metadata)
     }
 
     override fun decline(metadata: CallMetadata) {
-        PhoneConnectionService.startDeclineCall(context, metadata)
+        CallkeepCore.instance.startDeclineCall(metadata)
     }
 
     override fun hangUp(metadata: CallMetadata) {
-        PhoneConnectionService.startHungUpCall(context, metadata)
+        CallkeepCore.instance.startHungUpCall(metadata)
     }
 
     override fun tearDown() {
-        PhoneConnectionService.tearDown(context)
+        CallkeepCore.instance.tearDownService()
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -122,7 +122,7 @@ class IncomingCallService : Service() {
 
         callLifecycleHandler =
             CallLifecycleHandler(
-                connectionController = DefaultCallConnectionController(baseContext),
+                connectionController = DefaultCallConnectionController(),
                 stopService = { stopSelf() },
                 isolateHandler = isolateHandler,
             )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -225,7 +225,12 @@ class IncomingCallService : Service() {
             // The call was answered and then ended by the remote/local side.
             // The background isolate is no longer needed for signaling — the main process
             // takes over the active-call session. Release resources immediately.
-            callLifecycleHandler.release()
+            // Consume any pending callback registered by ForegroundService so that
+            // performAnswerCall is dispatched only after the isolate confirms its
+            // signaling WebSocket is closed.
+            val callback = pendingReleaseCallback
+            pendingReleaseCallback = null
+            callLifecycleHandler.release(onComplete = callback)
         } else {
             // The call was declined or hung up before being answered.
             // The signaling layer (WebSocket) must send a SIP BYE/decline to the server
@@ -261,7 +266,21 @@ class IncomingCallService : Service() {
         private const val SERVICE_TIMEOUT_MS = 2_000L
 
         @Volatile
-        private var isRunning = false
+        var isRunning = false
+            private set
+
+        /**
+         * Callback registered by [ForegroundService] before triggering
+         * [IncomingCallRelease.IC_RELEASE_WITH_ANSWER]. It is invoked inside
+         * [CallLifecycleHandler.release] once the background isolate confirms its signaling
+         * WebSocket is closed, guaranteeing that [ForegroundService.performAnswerCall] fires
+         * only after the isolate has disconnected — preventing the server from sending a 4441
+         * "force attach close" to the main engine's signaling client.
+         *
+         * Consumed (set to null) atomically before being invoked, so it fires at most once.
+         */
+        @Volatile
+        var pendingReleaseCallback: (() -> Unit)? = null
 
         private fun setRunning(running: Boolean) {
             isRunning = running

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -222,15 +222,9 @@ class IncomingCallService : Service() {
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(stopTimeoutRunnable, SERVICE_TIMEOUT_MS)
         if (answered) {
-            // The call was answered and then ended by the remote/local side.
-            // The background isolate is no longer needed for signaling — the main process
-            // takes over the active-call session. Release resources immediately.
-            // Consume any pending callback registered by ForegroundService so that
-            // performAnswerCall is dispatched only after the isolate confirms its
-            // signaling WebSocket is closed.
-            val callback = pendingReleaseCallback
-            pendingReleaseCallback = null
-            callLifecycleHandler.release(onComplete = callback)
+            // The call was answered. The background isolate is no longer needed for signaling —
+            // the main process takes over the active-call session. Release resources immediately.
+            callLifecycleHandler.release()
         } else {
             // The call was declined or hung up before being answered.
             // The signaling layer (WebSocket) must send a SIP BYE/decline to the server
@@ -268,19 +262,6 @@ class IncomingCallService : Service() {
         @Volatile
         var isRunning = false
             private set
-
-        /**
-         * Callback registered by [ForegroundService] before triggering
-         * [IncomingCallRelease.IC_RELEASE_WITH_ANSWER]. It is invoked inside
-         * [CallLifecycleHandler.release] once the background isolate confirms its signaling
-         * WebSocket is closed, guaranteeing that [ForegroundService.performAnswerCall] fires
-         * only after the isolate has disconnected — preventing the server from sending a 4441
-         * "force attach close" to the main engine's signaling client.
-         *
-         * Consumed (set to null) atomically before being invoked, so it fires at most once.
-         */
-        @Volatile
-        var pendingReleaseCallback: (() -> Unit)? = null
 
         private fun setRunning(running: Boolean) {
             isRunning = running

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -138,11 +138,15 @@ class CallLifecycleHandler(
     }
 
     // Isolate
-    fun release() {
+    fun release(onComplete: (() -> Unit)? = null) {
         Log.d(TAG, "Resources released")
         flutterApi?.releaseResources(currentCallData) {
+            onComplete?.invoke()
             stopServiceWithDelay()
-        } ?: run { stopService() }
+        } ?: run {
+            onComplete?.invoke()
+            stopService()
+        }
     }
 
     private fun stopServiceWithDelay() {


### PR DESCRIPTION
## Summary

- `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall()` was calling `PhoneConnectionService.startIncomingCall()` directly, bypassing `CallkeepCore.instance`
- This skipped `addPending(callId)` registration in `MainProcessConnectionTracker`, leaving a window where `answerCall()` / `endCall()` could not find the call in the shadow state before `DidPushIncomingCall` arrived
- Fixed by routing through `CallkeepCore.instance.startIncomingCall()` — consistent with all other main-process interactions per architecture rules

## Test plan

- [ ] Incoming call via push notification reaches Flutter delegate (`performIncomingCall`)
- [ ] Answer via notification before `DidPushIncomingCall` (deferred-answer path) works correctly
- [ ] Decline via notification works correctly
- [ ] `MainProcessConnectionTracker` has the call in pending state immediately after push triggers the call