### PR TITLE
fix(android): align tearDown guards with onDestroy to prevent duplicate performEndCall

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -22,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap
  * state without crossing a process boundary. The main process never reads
  * [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.connectionManager]
  * directly — that object lives in the `:callkeep_core` JVM and is empty in the main process.
- * All state transitions arrive via IPC broadcasts from `:callkeep_core`.
+ * Call state is mirrored via a combination of main-process updates (pending registration and
+ * local guards) and IPC broadcasts from `:callkeep_core` for lifecycle transitions.
  */
 class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // callId -> metadata for all known, non-terminated calls

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -19,10 +19,10 @@ import java.util.concurrent.ConcurrentHashMap
  * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.OngoingCall]          -> promote outgoing
  *
  * This allows [ForegroundService] and [com.webtrit.callkeep.ConnectionsApi] to query connection
- * state without crossing a process boundary. In the current single-process setup the tracker
- * avoids tightly coupling to [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.connectionManager].
- * When the `:callkeep_core` process split lands (PR-9b), only the broadcast wiring needs to
- * change — all callers of this tracker remain unchanged.
+ * state without crossing a process boundary. The main process never reads
+ * [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.connectionManager]
+ * directly — that object lives in the `:callkeep_core` JVM and is empty in the main process.
+ * All state transitions arrive via IPC broadcasts from `:callkeep_core`.
  */
 class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // callId -> metadata for all known, non-terminated calls

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -668,8 +668,9 @@ class ForegroundService :
         // PhoneConnection was never created (no DidPushIncomingCall received yet).
         val unconnectedPending = core.drainUnconnectedPendingCallIds()
 
-        // Step 3: Notify Flutter for active connections. Mark in directNotified
-        // BEFORE calling connection.hungUp() so the async HungUp broadcast is suppressed.
+        // Step 3: Notify Flutter for active connections. Mark directNotified
+        // BEFORE CallkeepCore/ConnectionService tears down the underlying connections so
+        // that any async HungUp broadcast emitted during that teardown phase is suppressed.
         // Also mark terminated + endCallDispatched so that any endCall() arriving during
         // the tearDown window does not re-fire performEndCall or dispatch a duplicate
         // startHungUpCall IPC.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -656,6 +656,8 @@ class ForegroundService :
             logger.w("tearDown: resolving pending incoming callback for callId=$callId with CALL_REJECTED_BY_SYSTEM")
             core.markDirectNotified(callId)
             core.removePending(callId)
+            core.markTerminated(callId)
+            core.markEndCallDispatched(callId)
             resolvePendingIncomingCallback(
                 callId,
                 Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
@@ -668,8 +670,13 @@ class ForegroundService :
 
         // Step 3: Notify Flutter for active connections. Mark in directNotified
         // BEFORE calling connection.hungUp() so the async HungUp broadcast is suppressed.
+        // Also mark terminated + endCallDispatched so that any endCall() arriving during
+        // the tearDown window does not re-fire performEndCall or dispatch a duplicate
+        // startHungUpCall IPC.
         activeCallIds.forEach { callId ->
             core.markDirectNotified(callId)
+            core.markTerminated(callId)
+            core.markEndCallDispatched(callId)
             flutterDelegateApi?.performEndCall(callId) {}
         }
 
@@ -678,8 +685,12 @@ class ForegroundService :
         // broadcast from connection.hungUp() (Step 5) is suppressed — this happens when
         // the deferred-answer path caused CS to create a PhoneConnection via reserveAnswer
         // even though DidPushIncomingCall had not yet arrived and the callId was still pending.
+        // Also mark terminated + endCallDispatched to match the onDestroy path and prevent
+        // a duplicate startHungUpCall IPC if endCall() arrives during the tearDown window.
         unconnectedPending.forEach { callId ->
             core.markDirectNotified(callId)
+            core.markTerminated(callId)
+            core.markEndCallDispatched(callId)
             flutterDelegateApi?.performEndCall(callId) {}
         }
 


### PR DESCRIPTION
## Problem

In `ForegroundService.tearDown()`, three steps fire `performEndCall` for calls that are being torn down:

- **Step 1b** — pending incoming callbacks still awaiting Telecom confirmation
- **Step 3** — active (promoted) connections
- **Step 4** — unconnected pending calls (registered with Telecom, PhoneConnection not yet created)

All three called `markDirectNotified(callId)` but did NOT call `markTerminated` or `markEndCallDispatched`. This left a consistency window between `markDirectNotified` and `core.clear()` (after `TearDownComplete` ack) where an `endCall()` arriving from Flutter could:

1. See `isTerminated=false` — skips the duplicate guard branch
2. See `markEndCallDispatched=false` — fires `performEndCall` a second time **OR**
3. Reach `startHungUpCall(metadata)` — dispatches a redundant IPC to `:callkeep_core` during an already in-progress tearDown

The `onDestroy` path already handled this correctly (called all three guards). `tearDown` was inconsistent with it.

## Fix

Add `markTerminated(callId)` and `markEndCallDispatched(callId)` alongside `markDirectNotified(callId)` in tearDown steps 1b, 3, and 4 — matching the pattern already in `onDestroy`.

With this fix, if `endCall()` arrives during the tearDown window:
- `isTerminated=true` → enters the guard branch
- `markEndCallDispatched` returns false (already set) → `isFirstEndCall=false` → no re-fire, no duplicate IPC

The `HungUp` broadcasts from `TearDownConnections` are still suppressed by `consumeDirectNotified` in `handleCSReportDeclineCall/HungUp` as before.

Also updates the stale comment in `MainProcessConnectionTracker` that referenced the `:callkeep_core` process split as a future event (PR-9b) — the split has since been completed.

## Test plan

- [ ] Normal tearDown (logout): no duplicate `performEndCall` in Flutter logs.
- [ ] tearDown with an active call: call ends cleanly, no double end notification.
- [ ] tearDown with a pending call (push notification not yet confirmed by Telecom): resolves with `callRejectedBySystem`, no subsequent `performEndCall`.
- [ ] `endCall()` during tearDown window does not produce a duplicate delegate callback.