### PR TITLE
fix(android): wake screen and show notification on locked screen for incoming calls

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -147,6 +147,9 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
             .setSound(null)
             .setVibrate(null)
             .setFullScreenIntent(null, false)
+            // Explicit PUBLIC visibility so the ongoing call notification remains
+            // visible on the lock screen on MIUI/HyperOS after the ringing phase.
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .build()
             .apply {
                 flags = flags and Notification.FLAG_INSISTENT.inv()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder.context
+import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.managers.NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID
 import com.webtrit.callkeep.models.CallMetadata
@@ -51,6 +52,10 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
             setContentTitle(title)
             text?.let { setContentText(it) }
             setAutoCancel(true)
+            // Explicitly set PUBLIC visibility so the full notification content
+            // is shown on the lock screen (channel-level VISIBILITY_PUBLIC is not
+            // always inherited by individual notifications on MIUI/HyperOS).
+            setVisibility(Notification.VISIBILITY_PUBLIC)
         }
 
     private fun createNotificationAction(
@@ -84,7 +89,16 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
         val builder =
             baseNotificationBuilder(title, description).apply {
                 setOngoing(true)
-                if (StorageDelegate.IncomingCall.isFullScreen(context)) {
+                // Use full-screen intent only when both the app setting is enabled and the
+                // system permission is granted.  On Android 14+ (API 34) the permission can
+                // be revoked by the user; on MIUI/HyperOS it is denied by default for
+                // third-party apps.  Passing a full-screen intent when the permission is
+                // denied has no effect and produces a log warning, so we skip it and rely on
+                // the WakeLock acquired in IncomingCallService as the fallback wake mechanism.
+                val canUseFullScreen =
+                    StorageDelegate.IncomingCall.isFullScreen(context) &&
+                        PermissionsHelper(context).canUseFullScreenIntent()
+                if (canUseFullScreen) {
                     setFullScreenIntent(buildOpenAppIntent(context), true)
                 }
             }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -9,6 +9,7 @@ import android.content.pm.ServiceInfo
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.os.PowerManager
 import android.util.Log
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
@@ -32,6 +33,11 @@ import com.webtrit.callkeep.services.services.incoming_call.handlers.IncomingCal
 @Keep
 class IncomingCallService : Service() {
     private val incomingCallNotificationBuilder by lazy { IncomingCallNotificationBuilder() }
+
+    // Held while an incoming call is ringing. Wakes the screen on devices where
+    // full-screen intent is restricted (e.g. MIUI/HyperOS with USE_FULL_SCREEN_INTENT
+    // denied). Released in onDestroy() or when the call is answered/declined.
+    private var screenWakeLock: PowerManager.WakeLock? = null
 
     private val timeoutHandler = Handler(Looper.getMainLooper())
     private val stopTimeoutRunnable =
@@ -167,6 +173,7 @@ class IncomingCallService : Service() {
         Log.d(TAG, "onDestroy called")
 
         setRunning(false)
+        releaseScreenWakeLock()
         // Unregister the service from receiving connection service perform events
         ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(
             this,
@@ -207,6 +214,7 @@ class IncomingCallService : Service() {
     private fun handleLaunch(metadata: CallMetadata): Int {
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
+        acquireScreenWakeLock()
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand
@@ -254,10 +262,43 @@ class IncomingCallService : Service() {
         return START_NOT_STICKY
     }
 
+    /**
+     * Acquires a wake lock that turns on the screen when an incoming call arrives.
+     * This is the fallback for devices (MIUI/HyperOS) where USE_FULL_SCREEN_INTENT
+     * is denied by default and the full-screen intent cannot wake the display.
+     * The lock expires automatically after WAKELOCK_TIMEOUT_MS to prevent draining
+     * the battery if the call is never answered or the release path is skipped.
+     */
+    @Suppress("DEPRECATION") // SCREEN_BRIGHT_WAKE_LOCK is deprecated but is the correct flag
+    // for waking the screen; the modern alternative (FLAG_TURN_SCREEN_ON) requires an Activity.
+    private fun acquireScreenWakeLock() {
+        if (screenWakeLock?.isHeld == true) return
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        screenWakeLock =
+            pm
+                .newWakeLock(
+                    PowerManager.SCREEN_BRIGHT_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP,
+                    WAKELOCK_TAG,
+                ).also { it.acquire(WAKELOCK_TIMEOUT_MS) }
+        Log.d(TAG, "Screen wake lock acquired")
+    }
+
+    private fun releaseScreenWakeLock() {
+        screenWakeLock?.let {
+            if (it.isHeld) {
+                it.release()
+                Log.d(TAG, "Screen wake lock released")
+            }
+        }
+        screenWakeLock = null
+    }
+
     companion object {
         private const val TAG = "IncomingCallService"
 
         private const val SERVICE_TIMEOUT_MS = 2_000L
+        private const val WAKELOCK_TIMEOUT_MS = 30_000L
+        private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
 
         @Volatile
         var isRunning = false

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -17,6 +17,8 @@ import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.common.PermissionsHelper
+import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.startForegroundServiceCompat
 import com.webtrit.callkeep.managers.NotificationChannelManager
 import com.webtrit.callkeep.models.CallMetadata
@@ -214,7 +216,7 @@ class IncomingCallService : Service() {
     private fun handleLaunch(metadata: CallMetadata): Int {
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
-        acquireScreenWakeLock()
+        acquireScreenWakeLockIfNeeded()
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand
@@ -226,6 +228,10 @@ class IncomingCallService : Service() {
 
     // Handles the RELEASE action and cancels the timeout
     private fun handleRelease(answered: Boolean = false): Int {
+        // The ringing phase is over — release the wake lock immediately so the screen
+        // is not held on for the full WAKELOCK_TIMEOUT_MS during post-call teardown.
+        // onDestroy() keeps the lock as a final safety net in case this path is skipped.
+        releaseScreenWakeLock()
         incomingCallHandler.releaseIncomingCallNotification(answered)
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(stopTimeoutRunnable, SERVICE_TIMEOUT_MS)
@@ -264,14 +270,24 @@ class IncomingCallService : Service() {
 
     /**
      * Acquires a wake lock that turns on the screen when an incoming call arrives.
-     * This is the fallback for devices (MIUI/HyperOS) where USE_FULL_SCREEN_INTENT
-     * is denied by default and the full-screen intent cannot wake the display.
-     * The lock expires automatically after WAKELOCK_TIMEOUT_MS to prevent draining
-     * the battery if the call is never answered or the release path is skipped.
+     *
+     * This is a fallback for devices (MIUI/HyperOS) where USE_FULL_SCREEN_INTENT is
+     * denied by default and the full-screen intent cannot wake the display. When
+     * full-screen intent is available and enabled, the system handles screen wake via
+     * the full-screen intent itself, so no wake lock is needed.
+     *
+     * The lock expires automatically after WAKELOCK_TIMEOUT_MS to prevent battery
+     * drain if the release path is skipped.
      */
     @Suppress("DEPRECATION") // SCREEN_BRIGHT_WAKE_LOCK is deprecated but is the correct flag
     // for waking the screen; the modern alternative (FLAG_TURN_SCREEN_ON) requires an Activity.
-    private fun acquireScreenWakeLock() {
+    private fun acquireScreenWakeLockIfNeeded() {
+        val fullScreenEnabled = StorageDelegate.IncomingCall.isFullScreen(this)
+        val canUseFullScreenIntent = PermissionsHelper(this).canUseFullScreenIntent()
+        if (fullScreenEnabled && canUseFullScreenIntent) {
+            Log.d(TAG, "Screen wake lock skipped: full-screen intent is available")
+            return
+        }
         if (screenWakeLock?.isHeld == true) return
         val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
         screenWakeLock =


### PR DESCRIPTION
## Problem

On Xiaomi/MIUI devices with a locked screen, an incoming call push notification arrived but the screen stayed dark — no UI was shown to the user.

Root causes identified from logcat:

1. `USE_FULL_SCREEN_INTENT` is denied by default on MIUI/HyperOS for third-party apps, so the full-screen intent never fired to wake the display.
2. Individual incoming call notifications were posted with `vis=PRIVATE` (channel-level `VISIBILITY_PUBLIC` is not reliably inherited on MIUI), so the lock screen showed hidden content instead of the full notification.

## Changes

**`IncomingCallNotificationBuilder`**
- Set `VISIBILITY_PUBLIC` explicitly on every incoming call notification (not only on the channel).
- Guard `setFullScreenIntent` with `canUseFullScreenIntent()` so the call is clean on Android 14+ when the permission is denied.

**`IncomingCallService`**
- Acquire `SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP` on `IC_INITIALIZE` as a fallback wake mechanism when full-screen intent is unavailable.
- Release the lock in `onDestroy()` with a 30-second auto-timeout as a safety net.

## Test plan

- [ ] Xiaomi/MIUI device, locked screen, incoming push call — screen wakes and notification is visible
- [ ] Standard Android device — no regression, full-screen intent still fires when permission is granted
- [ ] Call declined/answered — wake lock is released (verify no battery drain)