### PR TITLE
fix(android): downgrade CALL_ID_ALREADY_EXISTS rejection log from warn to info

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -492,7 +492,12 @@ class ForegroundService :
                 flutterDelegateApi?.performAnswerCall(callId) {}
                 logger.i("reportNewIncomingCall: adopted already-answered call callId=$callId, fired performAnswerCall")
             } else {
-                logger.w("reportNewIncomingCall: rejecting callId=$callId, tracker state=${trackerError.value}")
+                // CALL_ID_ALREADY_EXISTS here is expected in the push+signaling combined flow:
+                // the push path registers the call first, and the signaling WebSocket arrives
+                // shortly after with the same callId. Logging at INFO avoids spurious
+                // Crashlytics exception reports in consuming apps that forward WARN to
+                // FirebaseCrashlytics.recordError().
+                logger.i("reportNewIncomingCall: rejecting duplicate callId=$callId, tracker state=${trackerError.value}")
             }
             callback(Result.success(trackerError))
             return


### PR DESCRIPTION
## Problem

In the push+signaling combined flow, every incoming call produced a spurious Crashlytics exception report in the consuming app:

```
----------------FIREBASE CRASHLYTICS----------------
Exception: [CK-ForegroundService] reportNewIncomingCall: rejecting callId=..., tracker state=CALL_ID_ALREADY_EXISTS
null
----------------------------------------------------
```

**Root cause:** The tracker-level rejection was logged at `WARN`. Consuming apps that forward callkeep `WARN` logs to `FirebaseCrashlytics.recordError()` treated it as a real exception.

**Why the rejection happens (expected behavior):** In the push+signaling combined flow the push path registers the call first via `DidPushIncomingCall`. The signaling WebSocket then calls `reportNewIncomingCall` with the same `callId` a moment later — the tracker correctly rejects it as a duplicate. This is not an error condition.

## Change

`ForegroundService.kt`: change `logger.w` to `logger.i` for the `CALL_ID_ALREADY_EXISTS` duplicate-rejection path. The comment explains why this is expected so the intent is clear.

## Test plan

- [ ] Incoming call via push+signaling — no Crashlytics exception reported
- [ ] Log still appears at INFO level for observability
- [ ] Genuinely unexpected errors (else branch) remain at ERROR level