### PR TITLE
fix(android): initialize AssetCacheManager in :callkeep_core process

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -14,6 +14,7 @@ import android.telecom.PhoneAccountHandle
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.common.ActivityHolder
+import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.TelephonyUtils
@@ -49,6 +50,11 @@ class PhoneConnectionService : ConnectionService() {
         // Initialize ContextHolder for the :callkeep_core process. Each OS process has its own
         // JVM, so ContextHolder.init() called in the main process has no effect here.
         ContextHolder.init(applicationContext)
+        // Initialize AssetCacheManager for the :callkeep_core process so that
+        // PhoneConnection.onShowIncomingCallUi() can resolve the custom ringtone asset
+        // path via AssetCacheManager.getAsset(). Without this, getRingtone() throws
+        // IllegalStateException and falls back to the system default ringtone.
+        AssetCacheManager.init(applicationContext)
         // Set the service state to true when the system starts the service.
         isRunning = true
         telephonyUtils = TelephonyUtils(applicationContext)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -52,8 +52,9 @@ class PhoneConnectionService : ConnectionService() {
         ContextHolder.init(applicationContext)
         // Initialize AssetCacheManager for the :callkeep_core process so that
         // PhoneConnection.onShowIncomingCallUi() can resolve the custom ringtone asset
-        // path via AssetCacheManager.getAsset(). Without this, getRingtone() throws
-        // IllegalStateException and falls back to the system default ringtone.
+        // path via AssetCacheManager.getAsset(). Without this, AssetCacheManager.getAsset()
+        // may throw IllegalStateException, which is caught inside getRingtone() and causes
+        // a fallback to the system default ringtone.
         AssetCacheManager.init(applicationContext)
         // Set the service state to true when the system starts the service.
         isRunning = true


### PR DESCRIPTION
## Problem

On incoming calls the system ringtone played instead of the custom ringtone configured via `PAndroidOptions.ringtoneSound`.

## Root cause

`AssetCacheManager.init()` was called only inside `WebtritCallkeepPlugin` which runs in the **main process**. `PhoneConnectionService` runs in the **`:callkeep_core` OS process** — a separate JVM where `AssetCacheManager` was never initialized.

Call flow in `:callkeep_core`:
```
PhoneConnection.onShowIncomingCallUi()
  -> AudioManager.startRingtone(metadata.ringtonePath)
    -> AssetCacheManager.getAsset(asset)
      -> throws IllegalStateException: "AssetCacheManager is not initialized"
    catch (e: Exception) -> getDefaultRingtone()  // system ringtone plays
```

The exception was silently swallowed by the catch block in `AudioManager.getRingtone()`, so there was no visible crash — only the wrong sound.

Confirmed in logcat:
```
E  java.lang.IllegalStateException: AssetCacheManager is not initialized. Call init() first.
   null
```

## Fix

Add `AssetCacheManager.init(applicationContext)` in `PhoneConnectionService.onCreate()`, alongside the existing `ContextHolder.init()` which already handles the same per-process initialization requirement.

## Test plan

- [ ] Incoming call — custom ringtone plays (not system ringtone)
- [ ] No `IllegalStateException` in logcat for `AssetCacheManager`
- [ ] Works when app is backgrounded / screen locked