### PR TITLE
fix(android): remove redundant @Synchronized and restrict addConnection to internal

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -127,10 +127,7 @@ class ConnectionManager {
         }
     }
 
-    // TODO(Serdun): The current modifier is incorrect; this method is public but should be restricted.
-    // Consider limiting its accessibility to the connection service only.
-    @Synchronized
-    fun addConnection(
+    internal fun addConnection(
         callId: String,
         connection: PhoneConnection,
     ) {


### PR DESCRIPTION
## Summary

- Remove redundant `@Synchronized` annotation from `addConnection` in `ConnectionManager` — the method already holds `connectionResourceLock` inside the body, making the outer annotation a second, unrelated monitor on `this`
- Mark `addConnection` as `internal` — it is only called from `PhoneConnectionService` in the same package; the `public` visibility was previously flagged as incorrect in a TODO comment

## Test plan

- [ ] All Kotlin unit tests pass (`./gradlew test`)
- [ ] All Flutter unit tests pass (`flutter test`)