### PR TITLE
chore(android): remove stale TODO comments from ForegroundService and ActiveCallService

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -52,8 +52,6 @@ class ActiveCallService : Service() {
             getForegroundServiceTypes(callsMetadata),
         )
 
-        // TODO: maybe FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK is needed as well
-
         return START_STICKY
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -420,7 +420,6 @@ class ForegroundService :
         error: Throwable?,
     ) = failedCallsStore.add(metadata, source, error?.message)
 
-    // TODO: Move logic to the PhoneConnectionService
     override fun reportNewIncomingCall(
         callId: String,
         handle: PHandle,


### PR DESCRIPTION
## Summary

Remove two TODO comments that are no longer valid after the dual-process migration (PR #200).

**ForegroundService.kt** — `// TODO: Move logic to the PhoneConnectionService`

Added in PR #72 when both services ran in the same process. After the migration the intent is already fulfilled: actual Telecom logic lives in PhoneConnectionService via IPC through the CallkeepCore facade. The remaining logic in ForegroundService (tracker checks, Pigeon callbacks, pendingIncomingCallbacks) must stay in the main process and cannot be moved to :callkeep_core.

**ActiveCallService.kt** — `// TODO: maybe FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK is needed as well`

FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK is for music/media playback apps. For VoIP, PHONE_CALL covers audio routing. Adding it is not needed and would trigger unnecessary Google Play review.

## Test plan

- [ ] All Kotlin unit tests pass (`./gradlew test`)
- [ ] All Flutter unit tests pass (`flutter test`)