### PR TITLE
fix(android): always call startForeground() before permission check in SignalingIsolateService

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -760,7 +760,7 @@ void main() {
   //   app foregrounded → stopService (WebSocket torn down, isolate released)
   // =========================================================================
 
-  group('background signaling service lifecycle (Android only)', skip: signalingSkip, () {
+  group('background signaling service lifecycle (Android only)', () {
     // Ensure service is stopped after each lifecycle test so they don't
     // interfere with each other (some tests start but may not stop).
     tearDown(() async {

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -509,14 +509,16 @@ void main() {
   //   performEndCall on main delegate
   // =========================================================================
 
-  // SignalingIsolateService must call startForeground() within Android's
-  // 5-second deadline, but starting a new Flutter engine inside the service
-  // while the test engine is already running regularly exceeds that window,
-  // causing ForegroundServiceDidNotStartInTimeException which kills the app.
-  // These groups are skipped and must be verified via manual / end-to-end runs.
-  const signalingSkip = 'SignalingIsolateService cannot be started in an integration-test process: '
-      'startForegroundService() → Flutter engine init exceeds the 5-second '
-      'startForeground() deadline, causing ForegroundServiceDidNotStartInTimeException';
+  // SignalingIsolateService starts foreground correctly (see lifecycle group below),
+  // but the groups below require the service's background Flutter isolate to be
+  // fully initialised and communicating via Pigeon. In an integration-test process
+  // a second Flutter engine cannot be brought up while the test engine is already
+  // running within the same OS process — the isolate never registers its Pigeon
+  // handlers, so incomingCall / endCall calls time out or are silently dropped.
+  // These groups require manual / end-to-end verification outside the test harness.
+  const signalingSkip = 'SignalingIsolateService Flutter isolate cannot register Pigeon handlers '
+      'in an integration-test process: a second Flutter engine cannot initialise '
+      'while the test engine is already running in the same OS process';
 
   group('background signaling service (Android only)', skip: signalingSkip, () {
     // -----------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -150,6 +150,13 @@ class SignalingIsolateService :
 
     /**
      * Starts the service in the foreground with a notification.
+     *
+     * startForeground() MUST be called within 5 seconds of startForegroundService() regardless
+     * of POST_NOTIFICATIONS permission status. Calling stopSelf() without startForeground() first
+     * causes ForegroundServiceDidNotStartInTimeException on Android 13+ devices where the
+     * runtime permission has not been granted (e.g. integration-test environments). The service
+     * transitions to foreground first; if the notification cannot be shown (no permission), it
+     * stops itself cleanly afterwards.
      */
     private fun startForegroundService() {
         Log.d(TAG, "Starting foreground service")
@@ -165,14 +172,14 @@ class SignalingIsolateService :
         )
         val notification = notificationBuilder.build()
 
-        if (PermissionsHelper(baseContext).hasNotificationPermission()) {
-            startForegroundServiceCompat(
-                this,
-                ForegroundCallNotificationBuilder.NOTIFICATION_ID,
-                notification,
-                if (SDK_INT >= Build.VERSION_CODES.Q) ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL else null,
-            )
-        } else {
+        startForegroundServiceCompat(
+            this,
+            ForegroundCallNotificationBuilder.NOTIFICATION_ID,
+            notification,
+            if (SDK_INT >= Build.VERSION_CODES.Q) ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL else null,
+        )
+
+        if (!PermissionsHelper(baseContext).hasNotificationPermission()) {
             stopSelf()
         }
     }


### PR DESCRIPTION
## Summary

- `SignalingIsolateService.startForegroundService()` was calling `stopSelf()` without first calling `startForeground()` when `POST_NOTIFICATIONS` was not granted. Android requires `startForeground()` within 5 seconds of `startForegroundService()` — skipping it triggers `ForegroundServiceDidNotStartInTimeException` delivered via `ActivityThread.throwRemoteServiceException`, which crashes the app.
- Fix: always call `startForeground()` to satisfy the 5-second deadline, then call `stopSelf()` if the notification cannot be shown. This matches the pattern already used by `IncomingCallService`.
- Removes `skip: signalingSkip` from the `'background signaling service lifecycle'` test group — all 5 lifecycle tests (startService, idempotent start, stopService, stop-without-start, start-stop-start cycle) now pass on Android 15.

## Test plan

- [x] Run `integration_test/callkeep_background_services_test.dart` on Android 15 device — all lifecycle tests pass, skipped tests still skipped
- [ ] Verify on Android 16 device (the original crash device)