### PR TITLE
fix(android): remove unsafe cast in ActiveCallNotificationBuilder

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
@@ -13,10 +13,10 @@ import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.services.services.active_call.ActiveCallService
 
 class ActiveCallNotificationBuilder : NotificationBuilder() {
-    private var callsMetaData = ArrayList<CallMetadata>()
+    private var callsMetaData: List<CallMetadata> = emptyList()
 
     fun setCallsMetaData(callsMetaData: List<CallMetadata>) {
-        this.callsMetaData = callsMetaData as ArrayList<CallMetadata>
+        this.callsMetaData = callsMetaData
     }
 
     override fun build(): Notification {


### PR DESCRIPTION
## Summary

- `setCallsMetaData(List<CallMetadata>)` was casting the incoming `List` to `ArrayList` with an unchecked cast. Passing any non-ArrayList implementation (e.g. `listOf()`, `Collections.unmodifiableList()`) would throw `ClassCastException` at runtime.
- Fix: change the field type from `ArrayList<CallMetadata>` to `List<CallMetadata>` and remove the cast entirely.

## Test plan

- [x] Kotlin compiles without warnings
- [x] `ActiveCallNotificationBuilder` builds notification correctly with any `List` implementation