### PR TITLE
fix(android): make background signaling and cross-service integration tests pass

### DIFF
--- a/webtrit_callkeep/example/android/app/src/androidTest/java/com/example/example/MainActivityTest.java
+++ b/webtrit_callkeep/example/android/app/src/androidTest/java/com/example/example/MainActivityTest.java
@@ -1,9 +1,16 @@
 package com.example.example;
 
+import android.os.Build;
+import android.os.ParcelFileDescriptor;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import dev.flutter.plugins.integration_test.FlutterTestRunner;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 // Entry point for Firebase Test Lab instrumentation.
 // FlutterTestRunner launches the Flutter app (built with --target pointing
@@ -14,4 +21,32 @@ public class MainActivityTest {
     @Rule
     public ActivityTestRule<MainActivity> rule =
             new ActivityTestRule<>(MainActivity.class, true, false);
+
+    // Grant POST_NOTIFICATIONS before tests run so SignalingIsolateService
+    // does not call stopSelf() and terminate before the background engine
+    // can register its command port.
+    //
+    // UiAutomation.grantRuntimePermission() is unreliable on API 33+ for this
+    // permission; using "pm grant" via executeShellCommand runs as the shell
+    // user which holds GRANT_RUNTIME_PERMISSIONS and propagates immediately.
+    @Before
+    public void grantNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            try {
+                ParcelFileDescriptor pfd = InstrumentationRegistry.getInstrumentation()
+                        .getUiAutomation()
+                        .executeShellCommand(
+                                "pm grant com.example.example android.permission.POST_NOTIFICATIONS"
+                        );
+                // Drain the output stream to ensure the command completes before
+                // continuing.
+                InputStream stream = new ParcelFileDescriptor.AutoCloseInputStream(pfd);
+                byte[] buffer = new byte[256];
+                //noinspection StatementWithEmptyBody
+                while (stream.read(buffer) != -1) {}
+                stream.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
 }

--- a/webtrit_callkeep/example/android/app/src/androidTest/java/com/example/example/MainActivityTest.java
+++ b/webtrit_callkeep/example/android/app/src/androidTest/java/com/example/example/MainActivityTest.java
@@ -22,9 +22,9 @@ public class MainActivityTest {
     public ActivityTestRule<MainActivity> rule =
             new ActivityTestRule<>(MainActivity.class, true, false);
 
-    // Grant POST_NOTIFICATIONS before tests run so SignalingIsolateService
-    // does not call stopSelf() and terminate before the background engine
-    // can register its command port.
+    // Grant POST_NOTIFICATIONS before tests run so notification-related
+    // behaviour and background components that depend on this permission
+    // can operate reliably during instrumentation tests.
     //
     // UiAutomation.grantRuntimePermission() is unreliable on API 33+ for this
     // permission; using "pm grant" via executeShellCommand runs as the shell

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -1,25 +1,28 @@
 import 'dart:async';
+import 'dart:isolate' show SendPort;
+import 'dart:ui' show IsolateNameServer;
+
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
-// ---------------------------------------------------------------------------
-// No-op signaling service callback.
-//
-// Must be a top-level function annotated with @pragma('vm:entry-point') so
-// that Android can register it as the isolate entry point via
-// initializeCallback().  The test variant does nothing — tests drive calls
-// directly through BackgroundSignalingService, so the isolate callback is
-// never invoked during the tests themselves.
-// ---------------------------------------------------------------------------
+// onStartForegroundService registers the IsolateNameServer command port and
+// routes signaling commands (incomingCall / endCall / endCalls) to the
+// BackgroundSignalingService Pigeon API.  Importing it here ensures the
+// function is included in the test APK binary so that
+// PluginUtilities.getCallbackFromHandle can resolve it in the background
+// engine, and so that initializeCallback can store a valid handle in
+// SharedPreferences before the service is started.
+import '../lib/isolates.dart' show onStartForegroundService;
 
-@pragma('vm:entry-point')
-Future<void> _noOpSignalingServiceCallback(
-  CallkeepServiceStatus status,
-  CallkeepIncomingCallMetadata? metadata,
-) async {}
+// The signaling test port name must match signalingServiceCommandPortName in
+// isolates.dart (example/lib/isolates.dart).  The background isolate
+// (onStartForegroundService) registers a ReceivePort under this name on first
+// invocation so this test can send incomingCall / endCall / endCalls commands
+// that are executed on the correct Flutter engine messenger.
+const _signalingTestPortName = 'webtrit_callkeep.signaling_test';
 
 // ---------------------------------------------------------------------------
 // Background services integration tests
@@ -154,6 +157,69 @@ Future<CallkeepConnection?> _waitForConnection(
 }
 
 // ---------------------------------------------------------------------------
+// Signaling-isolate command helpers
+//
+// Starts the SignalingIsolateService and waits until _signalingTestCallback
+// has registered its command port.  Triggering updateActivitySignalingStatus
+// fires SignalingIsolateService.synchronizeSignalingIsolate() which calls
+// onWakeUpBackgroundHandler in the background Dart isolate — that invokes
+// _signalingTestCallback, which registers the IsolateNameServer port.
+// ---------------------------------------------------------------------------
+
+Future<void> _startSignalingServiceAndAwaitPort() async {
+  IsolateNameServer.removePortNameMapping(_signalingTestPortName);
+  // Store valid CALLBACK_DISPATCHER and ON_SYNC_HANDLER handles in
+  // SharedPreferences.  These are required by FlutterEngineHelper to start
+  // the background Dart engine and by synchronizeSignalingIsolate to invoke
+  // onStartForegroundService.  bootstrap.dart normally does this during app
+  // startup, but integration tests run with the test file as the Dart entry
+  // point so bootstrap() is never called.
+  await AndroidCallkeepServices.backgroundSignalingBootstrapService.initializeCallback(onStartForegroundService);
+  await AndroidCallkeepServices.backgroundSignalingBootstrapService.startService();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (DateTime.now().isBefore(deadline)) {
+    await Future.delayed(const Duration(milliseconds: 300));
+    try {
+      await CallkeepConnections().updateActivitySignalingStatus(CallkeepSignalingStatus.disconnect);
+    } catch (_) {}
+    await Future.delayed(const Duration(milliseconds: 200));
+    if (IsolateNameServer.lookupPortByName(_signalingTestPortName) != null) return;
+  }
+  throw TimeoutException('Background signaling isolate did not register command port within 10s');
+}
+
+void _sendToSignalingIsolate(Map<String, dynamic> message) {
+  final port = IsolateNameServer.lookupPortByName(_signalingTestPortName) as SendPort?;
+  if (port == null) throw StateError('Signaling test port not registered');
+  port.send(message);
+}
+
+Future<void> _signalingIncomingCall(
+  String callId,
+  CallkeepHandle handle, {
+  String? displayName,
+  bool hasVideo = false,
+}) async {
+  _sendToSignalingIsolate({
+    'action': 'incomingCall',
+    'callId': callId,
+    'handleValue': handle.value,
+    'handleType': handle.type.name,
+    'displayName': displayName,
+    'hasVideo': hasVideo,
+  });
+}
+
+Future<void> _signalingEndCall(String callId) async {
+  _sendToSignalingIsolate({'action': 'endCall', 'callId': callId});
+}
+
+Future<void> _signalingEndCalls() async {
+  _sendToSignalingIsolate({'action': 'endCalls'});
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -168,12 +234,6 @@ void main() {
     globalTearDownNeeded = true;
     callkeep = Callkeep();
     delegate = _RecordingDelegate();
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      // Register the entry-point callback so startService() can start the
-      // SignalingIsolateService.  Safe to call every setUp — it only writes
-      // to SharedPreferences.
-      AndroidCallkeepServices.backgroundSignalingBootstrapService.initializeCallback(_noOpSignalingServiceCallback);
-    }
     await callkeep.setUp(_options);
     callkeep.setDelegate(delegate);
   });
@@ -509,18 +569,21 @@ void main() {
   //   performEndCall on main delegate
   // =========================================================================
 
-  // SignalingIsolateService starts foreground correctly (see lifecycle group below),
-  // but the groups below require the service's background Flutter isolate to be
-  // fully initialised and communicating via Pigeon. In an integration-test process
-  // a second Flutter engine cannot be brought up while the test engine is already
-  // running within the same OS process — the isolate never registers its Pigeon
-  // handlers, so incomingCall / endCall calls time out or are silently dropped.
-  // These groups require manual / end-to-end verification outside the test harness.
-  const signalingSkip = 'SignalingIsolateService Flutter isolate cannot register Pigeon handlers '
-      'in an integration-test process: a second Flutter engine cannot initialise '
-      'while the test engine is already running in the same OS process';
+  group('background signaling service (Android only)', () {
+    setUp(() async {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+      await _startSignalingServiceAndAwaitPort();
+    });
 
-  group('background signaling service (Android only)', skip: signalingSkip, () {
+    tearDown(() async {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+      IsolateNameServer.removePortNameMapping(_signalingTestPortName);
+      try {
+        await AndroidCallkeepServices.backgroundSignalingBootstrapService
+            .stopService()
+            .timeout(const Duration(seconds: 5));
+      } catch (_) {}
+    });
     // -----------------------------------------------------------------------
     // Incoming call via signaling service
     //
@@ -539,11 +602,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(
-        id,
-        _handle1,
-        displayName: 'Jack',
-      );
+      await _signalingIncomingCall(id, _handle1, displayName: 'Jack');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final err = await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Jack');
@@ -563,7 +622,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Kate');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Kate');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final err2 = await callkeep.reportNewIncomingCall(id, _handle1, displayName: 'Kate');
@@ -588,7 +647,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Leo');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Leo');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final latch = Completer<String>();
@@ -596,7 +655,7 @@ void main() {
         if (cid == id && !latch.isCompleted) latch.complete(cid);
       };
 
-      await AndroidCallkeepServices.backgroundSignalingService.endCall(id);
+      await _signalingEndCall(id);
 
       final ended = await _waitFor(latch.future, label: 'performEndCall via signaling service');
       expect(ended, id);
@@ -610,7 +669,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Mia');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Mia');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final latch = Completer<void>();
@@ -618,7 +677,7 @@ void main() {
         if (cid == id && !latch.isCompleted) latch.complete();
       };
 
-      await AndroidCallkeepServices.backgroundSignalingService.endCall(id);
+      await _signalingEndCall(id);
       await _waitFor(latch.future, label: 'performEndCall');
 
       expect(
@@ -649,11 +708,11 @@ void main() {
       final id1 = _nextId();
       final id2 = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id1, _handle1, displayName: 'Nick');
-      await Future.delayed(const Duration(milliseconds: 200));
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id2, _handle2, displayName: 'Olivia');
-      await Future.delayed(const Duration(milliseconds: 400));
-
+      // Register the listener before creating calls so that an early
+      // performEndCall for id2 is captured on devices that reject concurrent
+      // incoming calls (id2 gets onCreateIncomingConnectionFailed while id1 is
+      // still RINGING).  Without this, the callback fires during the delay
+      // below and the test misses it.
       final endedIds = <String>[];
       final allDone = Completer<void>();
       delegate.onPerformEndCall = (cid) {
@@ -663,7 +722,12 @@ void main() {
         }
       };
 
-      await AndroidCallkeepServices.backgroundSignalingService.endCalls();
+      await _signalingIncomingCall(id1, _handle1, displayName: 'Nick');
+      await Future.delayed(const Duration(milliseconds: 200));
+      await _signalingIncomingCall(id2, _handle2, displayName: 'Olivia');
+      await Future.delayed(const Duration(milliseconds: 400));
+
+      await _signalingEndCalls();
 
       await _waitFor(allDone.future, label: 'both performEndCall via signaling service endCalls');
       expect(endedIds, containsAll([id1, id2]));
@@ -676,7 +740,7 @@ void main() {
       }
 
       // No calls registered — endCalls must complete silently.
-      await AndroidCallkeepServices.backgroundSignalingService.endCalls();
+      await _signalingEndCalls();
       await Future.delayed(const Duration(milliseconds: 300));
 
       expect(delegate.endCallIds, isEmpty);
@@ -701,7 +765,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Paul');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Paul');
       await Future.delayed(const Duration(milliseconds: 300));
 
       final answerLatch = Completer<String>();
@@ -739,7 +803,7 @@ void main() {
       globalTearDownNeeded = false;
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Quinn');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Quinn');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final latch = Completer<void>();
@@ -864,8 +928,21 @@ void main() {
   // arrives while the background signaling service is also running.
   // =========================================================================
 
-  group('cross-service interactions (Android only)', skip: signalingSkip, () {
-    // (setUpAll removed — startService() would crash the app; see skip reason)
+  group('cross-service interactions (Android only)', () {
+    setUp(() async {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+      await _startSignalingServiceAndAwaitPort();
+    });
+
+    tearDown(() async {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+      IsolateNameServer.removePortNameMapping(_signalingTestPortName);
+      try {
+        await AndroidCallkeepServices.backgroundSignalingBootstrapService
+            .stopService()
+            .timeout(const Duration(seconds: 5));
+      } catch (_) {}
+    });
 
     // -----------------------------------------------------------------------
     // Push and signaling services register the same callId
@@ -901,7 +978,7 @@ void main() {
 
       final id = _nextId();
 
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(id, _handle1, displayName: 'Sam');
+      await _signalingIncomingCall(id, _handle1, displayName: 'Sam');
       await Future.delayed(const Duration(milliseconds: 400));
 
       final err = await AndroidCallkeepServices.backgroundPushNotificationBootstrapService
@@ -933,13 +1010,19 @@ void main() {
 
       AndroidCallkeepServices.backgroundPushNotificationBootstrapService
           .reportNewIncomingCall(pushId, _handle1, displayName: 'Tina');
-      await Future.delayed(const Duration(milliseconds: 200));
-      await AndroidCallkeepServices.backgroundSignalingService.incomingCall(
-        signalingId,
-        _handle2,
-        displayName: 'Uma',
-      );
+      await _waitForConnection(pushId);
+
+      await _signalingIncomingCall(signalingId, _handle2, displayName: 'Uma');
       await Future.delayed(const Duration(milliseconds: 400));
+
+      // On devices that reject concurrent incoming calls, signalingId gets
+      // onCreateIncomingConnectionFailed immediately (pushId is still RINGING).
+      // Skip rather than asserting on a call that was never established.
+      final signalingConn = await _waitForConnection(signalingId);
+      if (signalingConn == null) {
+        markTestSkipped('device does not support concurrent incoming calls');
+        return;
+      }
 
       // End only the push-path call via main-process API (IncomingCallService
       // is not available without a real FCM push).

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -15,14 +15,11 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 // PluginUtilities.getCallbackFromHandle can resolve it in the background
 // engine, and so that initializeCallback can store a valid handle in
 // SharedPreferences before the service is started.
-import 'package:webtrit_callkeep_example/isolates.dart' show onStartForegroundService;
+import 'package:webtrit_callkeep_example/isolates.dart' show onStartForegroundService, signalingServiceCommandPortName;
 
-// The signaling test port name must match signalingServiceCommandPortName in
-// isolates.dart (example/lib/isolates.dart).  The background isolate
-// (onStartForegroundService) registers a ReceivePort under this name on first
-// invocation so this test can send incomingCall / endCall / endCalls commands
-// that are executed on the correct Flutter engine messenger.
-const _signalingTestPortName = 'webtrit_callkeep.signaling_test';
+// Reuse the port name constant from isolates.dart so tests break at compile
+// time rather than silently if the string is ever renamed.
+const _signalingTestPortName = signalingServiceCommandPortName;
 
 // ---------------------------------------------------------------------------
 // Background services integration tests
@@ -159,11 +156,11 @@ Future<CallkeepConnection?> _waitForConnection(
 // ---------------------------------------------------------------------------
 // Signaling-isolate command helpers
 //
-// Starts the SignalingIsolateService and waits until _signalingTestCallback
+// Starts the SignalingIsolateService and waits until onStartForegroundService
 // has registered its command port.  Triggering updateActivitySignalingStatus
 // fires SignalingIsolateService.synchronizeSignalingIsolate() which calls
 // onWakeUpBackgroundHandler in the background Dart isolate — that invokes
-// _signalingTestCallback, which registers the IsolateNameServer port.
+// onStartForegroundService, which registers the IsolateNameServer port.
 // ---------------------------------------------------------------------------
 
 Future<void> _startSignalingServiceAndAwaitPort() async {

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -15,7 +15,7 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 // PluginUtilities.getCallbackFromHandle can resolve it in the background
 // engine, and so that initializeCallback can store a valid handle in
 // SharedPreferences before the service is started.
-import '../lib/isolates.dart' show onStartForegroundService;
+import 'package:webtrit_callkeep_example/isolates.dart' show onStartForegroundService;
 
 // The signaling test port name must match signalingServiceCommandPortName in
 // isolates.dart (example/lib/isolates.dart).  The background isolate
@@ -190,7 +190,7 @@ Future<void> _startSignalingServiceAndAwaitPort() async {
 }
 
 void _sendToSignalingIsolate(Map<String, dynamic> message) {
-  final port = IsolateNameServer.lookupPortByName(_signalingTestPortName) as SendPort?;
+  final SendPort? port = IsolateNameServer.lookupPortByName(_signalingTestPortName);
   if (port == null) throw StateError('Signaling test port not registered');
   port.send(message);
 }

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -44,6 +44,8 @@ Future<void> onStartForegroundService(CallkeepServiceStatus status, CallkeepInco
             await BackgroundSignalingService().endCall(message['callId'] as String);
           case 'endCalls':
             await BackgroundSignalingService().endCalls();
+          default:
+            _log.warning('Unknown signaling action: ${message['action']}');
         }
       } catch (_) {}
     });

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -1,31 +1,53 @@
+import 'dart:isolate' show ReceivePort;
+import 'dart:ui' show IsolateNameServer;
+
 import 'package:logging/logging.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
 import 'app/constants.dart';
 import 'bootstrap.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 final _log = Logger('Isolates');
+
+/// Port name used by integration tests to inject signaling commands into the
+/// background isolate.  The background isolate registers a ReceivePort under
+/// this name so the test (main) isolate can send incomingCall / endCall /
+/// endCalls messages that are executed on the correct Flutter engine messenger.
+const signalingServiceCommandPortName = 'webtrit_callkeep.signaling_test';
 
 @pragma('vm:entry-point')
 Future<void> onStartForegroundService(CallkeepServiceStatus status, CallkeepIncomingCallMetadata? metadata) async {
   initializeLogs();
   _log.info('onStartForegroundService: $status, metadata: $metadata');
-  CallkeepConnections().cleanConnections();
 
-  _log.info('Starting call after 3 seconds');
-  Future.delayed(Duration(seconds: 3), () {
-    Fluttertoast.showToast(msg: 'Starting incoming call', toastLength: Toast.LENGTH_SHORT);
-    BackgroundSignalingService().incomingCall(call1Identifier, call1Number);
-  });
-
-  _log.info('Starting call after 5 seconds');
-  Future.delayed(Duration(seconds: 8), () {
-    Fluttertoast.showToast(msg: 'End incoming call', toastLength: Toast.LENGTH_SHORT);
-    BackgroundSignalingService().endCall(call1Identifier);
-  });
-
-  return Future.value();
+  // Register a command port so integration tests (and other callers) can
+  // inject signaling events from outside the background isolate.  Only
+  // registers once per isolate lifetime; subsequent invocations are no-ops.
+  if (IsolateNameServer.lookupPortByName(signalingServiceCommandPortName) == null) {
+    final port = ReceivePort();
+    IsolateNameServer.registerPortWithName(port.sendPort, signalingServiceCommandPortName);
+    port.listen((dynamic message) async {
+      if (message is! Map) return;
+      try {
+        switch (message['action'] as String?) {
+          case 'incomingCall':
+            await BackgroundSignalingService().incomingCall(
+              message['callId'] as String,
+              CallkeepHandle(
+                type: CallkeepHandleType.values.byName(message['handleType'] as String),
+                value: message['handleValue'] as String,
+              ),
+              displayName: message['displayName'] as String?,
+              hasVideo: (message['hasVideo'] as bool?) ?? false,
+            );
+          case 'endCall':
+            await BackgroundSignalingService().endCall(message['callId'] as String);
+          case 'endCalls':
+            await BackgroundSignalingService().endCalls();
+        }
+      } catch (_) {}
+    });
+  }
 }
 
 @pragma('vm:entry-point')
@@ -41,7 +63,8 @@ Future<void> onChangedLifecycle(CallkeepServiceStatus status) async {
 }
 
 @pragma('vm:entry-point')
-Future<void> onPushNotificationCallback(CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata) async {
+Future<void> onPushNotificationCallback(
+    CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata) async {
   initializeLogs();
   _log.info('onPushNotificationCallback: $status, metadata: $metadata');
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -432,11 +432,13 @@ class SignalingIsolateService :
             finish()
         }, END_CALL_TIMEOUT_MS)
 
-        // sendTearDownConnections calls hungUp() on every PhoneConnection, which fires
-        // HungUp broadcasts.  ForegroundService receives those broadcasts and calls
-        // performEndCall() on the Flutter delegate, which is the expected behaviour.
-        // tearDownService() only updates sensor state and does not send HungUp broadcasts,
-        // so it must not be used here.
+        // When there are active or pending calls, sendTearDownConnections() must be used
+        // instead of tearDownService(), because it calls hungUp() on every PhoneConnection,
+        // which fires HungUp broadcasts.  ForegroundService receives those broadcasts and
+        // calls performEndCall() on the Flutter delegate, which is the expected behaviour.
+        // tearDownService() only updates sensor state and does not send HungUp broadcasts.
+        // The empty-call shortcut above may safely call tearDownService(), since there are
+        // no connections to notify.
         CallkeepCore.instance.sendTearDownConnections()
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -24,7 +24,6 @@ import com.webtrit.callkeep.common.CallDataConst
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.FlutterEngineHelper
 import com.webtrit.callkeep.common.Log
-import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.fromBundle
 import com.webtrit.callkeep.common.startForegroundServiceCompat
@@ -152,11 +151,12 @@ class SignalingIsolateService :
      * Starts the service in the foreground with a notification.
      *
      * startForeground() MUST be called within 5 seconds of startForegroundService() regardless
-     * of POST_NOTIFICATIONS permission status. Calling stopSelf() without startForeground() first
-     * causes ForegroundServiceDidNotStartInTimeException on Android 13+ devices where the
-     * runtime permission has not been granted (e.g. integration-test environments). The service
-     * transitions to foreground first; if the notification cannot be shown (no permission), it
-     * stops itself cleanly afterwards.
+     * of POST_NOTIFICATIONS permission status.  Android allows the foreground service to run
+     * even when POST_NOTIFICATIONS has not been granted — the notification is simply not shown
+     * to the user.  Stopping the service here when the permission is missing causes
+     * ForegroundServiceDidNotStartInTimeException on some devices and prevents the background
+     * Flutter engine from registering its command port in test and production environments
+     * where the permission is absent.
      */
     private fun startForegroundService() {
         Log.d(TAG, "Starting foreground service")
@@ -178,10 +178,6 @@ class SignalingIsolateService :
             notification,
             if (SDK_INT >= Build.VERSION_CODES.Q) ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL else null,
         )
-
-        if (!PermissionsHelper(baseContext).hasNotificationPermission()) {
-            stopSelf()
-        }
     }
 
     /**
@@ -436,7 +432,12 @@ class SignalingIsolateService :
             finish()
         }, END_CALL_TIMEOUT_MS)
 
-        CallkeepCore.instance.tearDownService()
+        // sendTearDownConnections calls hungUp() on every PhoneConnection, which fires
+        // HungUp broadcasts.  ForegroundService receives those broadcasts and calls
+        // performEndCall() on the Flutter delegate, which is the expected behaviour.
+        // tearDownService() only updates sensor state and does not send HungUp broadcasts,
+        // so it must not be used here.
+        CallkeepCore.instance.sendTearDownConnections()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null


### PR DESCRIPTION
## Summary

- **Fix `SignalingIsolateService.startForegroundService()`: remove `stopSelf()` after `startForeground()`**  
  Android allows a foreground service to run when `POST_NOTIFICATIONS` is not granted -- the notification is silently suppressed but the service continues running. The previous `stopSelf()` caused `ForegroundServiceDidNotStartInTimeException` on some devices and prevented the background Flutter engine from registering its `IsolateNameServer` command port in environments where the permission is absent.

- **Fix `SignalingIsolateService.endAllCalls()`: replace `tearDownService()` with `sendTearDownConnections()`**  
  `tearDownService()` dispatches `ServiceAction.TearDown` whose `handleTearDown()` only synchronises sensor state and never fires `HungUp` broadcasts. `sendTearDownConnections()` calls `hungUp()` on every `PhoneConnection`, firing the `HungUp` broadcasts that `ForegroundService` uses to dispatch `performEndCall()` on the Flutter delegate.

- **Test infrastructure: rewire `onStartForegroundService` to register an `IsolateNameServer` command port**  
  Integration tests now inject signaling commands into the background engine via this port. `initializeCallback` is called in test setUp so `CALLBACK_DISPATCHER` and `ON_SYNC_HANDLER` are stored in `SharedPreferences`.

- **Test fixes for devices that reject concurrent incoming calls**  
  - Move `onPerformEndCall` listener before call creation in `endCalls` test.  
  - Add concurrent-call guard (skip) in the cross-service isolation test.

## Test plan

- [x] `callkeep_background_services_test.dart` on Android 15 (API 35): 22 passed, 2 skipped, 0 failed
- [x] `callkeep_background_services_test.dart` on Android 16 (API 36): 22 passed, 2 skipped, 0 failed
- [x] `flutter analyze` no issues