### PR TITLE
fix(android): cancel stop timeout in IncomingCallService.onDestroy

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -174,6 +174,10 @@ class IncomingCallService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "onDestroy called")
 
+        // Cancel the safety-net timeout so it does not fire after a graceful stop and
+        // report a false-alarm to Crashlytics.
+        timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+
         setRunning(false)
         releaseScreenWakeLock()
         // Unregister the service from receiving connection service perform events


### PR DESCRIPTION
## Problem

`IncomingCallService` posts a safety-net `stopTimeoutRunnable` (2000 ms) inside `handleRelease()`. The runnable was never cancelled in `onDestroy()`, so it fired ~2 s after any service stop — including graceful ones — and logged a false-alarm warning + reported a spurious exception to Firebase Crashlytics.

Confirmed from logcat (2026-03-25):

- `14:20:24.883` — `IC_RELEASE_WITH_ANSWER` processed, timeout posted
- `14:20:24.928` — `onDestroy` called (graceful stop, only ~45 ms later)
- `14:20:27.685` — timeout runnable fired, logged warning, hit Crashlytics

The service had already stopped normally. The Crashlytics report was a false alarm.

## Fix

Add `timeoutHandler.removeCallbacks(stopTimeoutRunnable)` at the start of `onDestroy()`.

This disarms the runnable on every graceful stop path (answer, decline, OS-initiated stop). The runnable still fires if `onDestroy` is never called — which is the only scenario it was meant to guard against.

## Changed files

- `IncomingCallService.kt` — 4 lines added