### PR TITLE
fix(android): add standalone call mode for devices without android.software.telecom

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -27,6 +27,16 @@
         android:name="android.hardware.telephony"
         android:required="false" />
 
+    <!--
+        Declare android.software.telecom as optional so Play Store filters and device
+        compatibility checks correctly reflect that the app works without the Telecom
+        subsystem. On devices where this feature is absent, StandaloneCallService is used
+        instead of PhoneConnectionService for call management.
+    -->
+    <uses-feature
+        android:name="android.software.telecom"
+        android:required="false" />
+
     <application>
         <service
             android:name=".services.services.connection.PhoneConnectionService"
@@ -39,6 +49,19 @@
                 <action android:name="android.telecom.ConnectionService" />
             </intent-filter>
         </service>
+
+        <!--
+          Standalone call management service for devices without android.software.telecom.
+          Runs in the :callkeep_core process and dispatches the same ConnectionEvent broadcasts
+          as PhoneConnectionService, allowing the main process and Flutter layer to remain
+          unaware of which call path is active.
+        -->
+        <service
+            android:name=".services.services.connection.StandaloneCallService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="phoneCall"
+            android:process=":callkeep_core" />
 
         <service
             android:name=".services.services.signaling.SignalingIsolateService"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -95,5 +95,15 @@ class TelephonyUtils(
         private const val TAG = "TelephonyUtils"
 
         private val logger = Log(TAG)
+
+        /**
+         * Returns true if the device supports the Android Telecom framework
+         * (`android.software.telecom` system feature).
+         *
+         * Devices without this feature (e.g. some tablets, Android Go builds, certain OEM
+         * configurations) cannot use [TelecomManager] for call management. Callers should
+         * check this before registering a phone account or invoking any Telecom API.
+         */
+        fun isTelecomSupported(context: Context): Boolean = context.packageManager.hasSystemFeature("android.software.telecom")
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
@@ -118,7 +118,7 @@ class CallServiceRouter(
     fun tearDownService() =
         route(
             telecom = { PhoneConnectionService.tearDown(ctx) },
-            standalone = { StandaloneCallService.tearDown(ctx) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.CleanConnections, null) },
         )
 
     fun sendTearDownConnections() =

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
@@ -75,13 +75,17 @@ class CallServiceRouter(
             standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.EstablishCall, metadata) },
         )
 
-    fun startUpdateCall(metadata: CallMetadata) {
-        if (isTelecomSupported) PhoneConnectionService.startUpdateCall(ctx, metadata)
-    }
+    fun startUpdateCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startUpdateCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.UpdateCall, metadata) },
+        )
 
-    fun startSendDtmfCall(metadata: CallMetadata) {
-        if (isTelecomSupported) PhoneConnectionService.startSendDtmfCall(ctx, metadata)
-    }
+    fun startSendDtmfCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startSendDtmfCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.SendDtmf, metadata) },
+        )
 
     fun startMutingCall(metadata: CallMetadata) =
         route(
@@ -89,10 +93,11 @@ class CallServiceRouter(
             standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.Muting, metadata) },
         )
 
-    fun startHoldingCall(metadata: CallMetadata) {
-        // Hold is not supported in standalone mode.
-        if (isTelecomSupported) PhoneConnectionService.startHoldingCall(ctx, metadata)
-    }
+    fun startHoldingCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startHoldingCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.Holding, metadata) },
+        )
 
     fun startSpeaker(metadata: CallMetadata) =
         route(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
@@ -1,0 +1,165 @@
+package com.webtrit.callkeep.services.core
+
+import android.Manifest
+import android.content.Context
+import androidx.annotation.RequiresPermission
+import com.webtrit.callkeep.PIncomingCallError
+import com.webtrit.callkeep.common.TelephonyUtils
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+import com.webtrit.callkeep.services.services.connection.StandaloneServiceAction
+
+/**
+ * Single routing point between the Telecom-backed and standalone call management backends.
+ *
+ * On devices that support `android.software.telecom`, commands are forwarded to
+ * [PhoneConnectionService], which integrates with the Android Telecom framework.
+ * On devices that do not (e.g. some tablets, Android Go builds, certain OEM configs),
+ * commands are forwarded to [StandaloneCallService], which manages calls independently
+ * via [android.media.AudioManager].
+ *
+ * All callers (primarily [InProcessCallkeepCore]) go through this router and have no
+ * knowledge of which backend is active. Neither backend service needs routing logic —
+ * each is a pure implementation of its own call management strategy.
+ */
+class CallServiceRouter(
+    context: Context,
+) {
+    /** True when the device exposes `android.software.telecom`. Immutable after construction. */
+    val isTelecomSupported: Boolean = TelephonyUtils.isTelecomSupported(context)
+
+    private val ctx: Context = context.applicationContext
+
+    // -------------------------------------------------------------------------
+    // Call lifecycle
+    // -------------------------------------------------------------------------
+
+    fun startIncomingCall(
+        metadata: CallMetadata,
+        onSuccess: () -> Unit,
+        onError: (PIncomingCallError?) -> Unit,
+    ) = route(
+        telecom = { PhoneConnectionService.startIncomingCall(ctx, metadata, onSuccess, onError) },
+        standalone = { StandaloneCallService.startIncomingCall(ctx, metadata, onSuccess, onError) },
+    )
+
+    @RequiresPermission(Manifest.permission.CALL_PHONE)
+    fun startOutgoingCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startOutgoingCall(ctx, metadata) },
+            standalone = { StandaloneCallService.startOutgoingCall(ctx, metadata) },
+        )
+
+    fun startAnswerCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startAnswerCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.AnswerCall, metadata) },
+        )
+
+    fun startDeclineCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startDeclineCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.DeclineCall, metadata) },
+        )
+
+    fun startHungUpCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startHungUpCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.HungUpCall, metadata) },
+        )
+
+    fun startEstablishCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startEstablishCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.EstablishCall, metadata) },
+        )
+
+    fun startUpdateCall(metadata: CallMetadata) {
+        if (isTelecomSupported) PhoneConnectionService.startUpdateCall(ctx, metadata)
+    }
+
+    fun startSendDtmfCall(metadata: CallMetadata) {
+        if (isTelecomSupported) PhoneConnectionService.startSendDtmfCall(ctx, metadata)
+    }
+
+    fun startMutingCall(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startMutingCall(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.Muting, metadata) },
+        )
+
+    fun startHoldingCall(metadata: CallMetadata) {
+        // Hold is not supported in standalone mode.
+        if (isTelecomSupported) PhoneConnectionService.startHoldingCall(ctx, metadata)
+    }
+
+    fun startSpeaker(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.startSpeaker(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.Speaker, metadata) },
+        )
+
+    fun setAudioDevice(metadata: CallMetadata) =
+        route(
+            telecom = { PhoneConnectionService.setAudioDevice(ctx, metadata) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.AudioDeviceSet, metadata) },
+        )
+
+    // -------------------------------------------------------------------------
+    // Service lifecycle
+    // -------------------------------------------------------------------------
+
+    fun tearDownService() =
+        route(
+            telecom = { PhoneConnectionService.tearDown(ctx) },
+            standalone = { StandaloneCallService.tearDown(ctx) },
+        )
+
+    fun sendTearDownConnections() =
+        route(
+            telecom = { PhoneConnectionService.sendTearDownConnections(ctx) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.TearDownConnections, null) },
+        )
+
+    fun sendReserveAnswer(callId: String) =
+        route(
+            telecom = { PhoneConnectionService.sendReserveAnswer(ctx, callId) },
+            standalone = {
+                StandaloneCallService.communicate(
+                    ctx,
+                    StandaloneServiceAction.ReserveAnswer,
+                    CallMetadata(callId = callId),
+                )
+            },
+        )
+
+    fun sendCleanConnections() =
+        route(
+            telecom = { PhoneConnectionService.sendCleanConnections(ctx) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.CleanConnections, null) },
+        )
+
+    fun sendSyncAudioState() =
+        route(
+            telecom = { PhoneConnectionService.sendSyncAudioState(ctx) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.SyncAudioState, null) },
+        )
+
+    fun sendSyncConnectionState() =
+        route(
+            telecom = { PhoneConnectionService.sendSyncConnectionState(ctx) },
+            standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.SyncConnectionState, null) },
+        )
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private inline fun route(
+        telecom: () -> Unit,
+        standalone: () -> Unit,
+    ) {
+        if (isTelecomSupported) telecom() else standalone()
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -7,17 +7,16 @@ import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.models.CallMetadata
-import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
 
 /**
  * In-process implementation of [CallkeepCore].
  *
  * - **State** is delegated to [MainProcessConnectionTracker] (shadow registry in the main process).
- * - **Commands** are delegated to [PhoneConnectionService] static helpers, which dispatch
- *   explicit `startService` intents or broadcasts to `:callkeep_core`.
+ * - **Commands** are routed through [CallServiceRouter], which selects between
+ *   [com.webtrit.callkeep.services.services.connection.PhoneConnectionService] (Telecom path)
+ *   and [com.webtrit.callkeep.services.services.connection.StandaloneCallService] (no-Telecom path).
  *
- * After the process split, replace this with a broadcast/binder-backed implementation by
- * changing only [CallkeepCore.instance] — no call sites change.
+ * All call sites are unaware of which backend is active — routing is entirely internal to [CallServiceRouter].
  */
 class InProcessCallkeepCore private constructor() : CallkeepCore {
     private val tracker: ConnectionTracker = MainProcessConnectionTracker.instance
@@ -26,6 +25,8 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
     // created early without risking a NullPointerException. ContextHolder.init() must
     // have been called before any CS command method is invoked (guaranteed by Application.onCreate).
     private val context get() = ContextHolder.context
+
+    private val router: CallServiceRouter by lazy { CallServiceRouter(context) }
 
     // -------------------------------------------------------------------------
     // State queries
@@ -99,53 +100,53 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
     // -------------------------------------------------------------------------
 
     @RequiresPermission(Manifest.permission.CALL_PHONE)
-    override fun startOutgoingCall(metadata: CallMetadata) = PhoneConnectionService.startOutgoingCall(context, metadata)
+    override fun startOutgoingCall(metadata: CallMetadata) = router.startOutgoingCall(metadata)
 
     override fun startIncomingCall(
         metadata: CallMetadata,
         onSuccess: () -> Unit,
         onError: (PIncomingCallError?) -> Unit,
     ) {
-        // Register as pending before handing off to Telecom so that answerCall() can
+        // Register as pending before handing off to the backend so that answerCall() can
         // find the call via core.isPending() during the broadcast-lag window, regardless
         // of which entry point initiated the incoming call (ForegroundService,
         // SignalingIsolateService, BackgroundPushNotificationIsolateBootstrapApi, etc.).
         // addPending() is idempotent — safe to call even if the caller already did so.
         tracker.addPending(metadata.callId)
-        PhoneConnectionService.startIncomingCall(context, metadata, onSuccess, onError)
+        router.startIncomingCall(metadata, onSuccess, onError)
     }
 
-    override fun startAnswerCall(metadata: CallMetadata) = PhoneConnectionService.startAnswerCall(context, metadata)
+    override fun startAnswerCall(metadata: CallMetadata) = router.startAnswerCall(metadata)
 
-    override fun startDeclineCall(metadata: CallMetadata) = PhoneConnectionService.startDeclineCall(context, metadata)
+    override fun startDeclineCall(metadata: CallMetadata) = router.startDeclineCall(metadata)
 
-    override fun startHungUpCall(metadata: CallMetadata) = PhoneConnectionService.startHungUpCall(context, metadata)
+    override fun startHungUpCall(metadata: CallMetadata) = router.startHungUpCall(metadata)
 
-    override fun startEstablishCall(metadata: CallMetadata) = PhoneConnectionService.startEstablishCall(context, metadata)
+    override fun startEstablishCall(metadata: CallMetadata) = router.startEstablishCall(metadata)
 
-    override fun startUpdateCall(metadata: CallMetadata) = PhoneConnectionService.startUpdateCall(context, metadata)
+    override fun startUpdateCall(metadata: CallMetadata) = router.startUpdateCall(metadata)
 
-    override fun startSendDtmfCall(metadata: CallMetadata) = PhoneConnectionService.startSendDtmfCall(context, metadata)
+    override fun startSendDtmfCall(metadata: CallMetadata) = router.startSendDtmfCall(metadata)
 
-    override fun startMutingCall(metadata: CallMetadata) = PhoneConnectionService.startMutingCall(context, metadata)
+    override fun startMutingCall(metadata: CallMetadata) = router.startMutingCall(metadata)
 
-    override fun startHoldingCall(metadata: CallMetadata) = PhoneConnectionService.startHoldingCall(context, metadata)
+    override fun startHoldingCall(metadata: CallMetadata) = router.startHoldingCall(metadata)
 
-    override fun startSpeaker(metadata: CallMetadata) = PhoneConnectionService.startSpeaker(context, metadata)
+    override fun startSpeaker(metadata: CallMetadata) = router.startSpeaker(metadata)
 
-    override fun setAudioDevice(metadata: CallMetadata) = PhoneConnectionService.setAudioDevice(context, metadata)
+    override fun setAudioDevice(metadata: CallMetadata) = router.setAudioDevice(metadata)
 
-    override fun tearDownService() = PhoneConnectionService.tearDown(context)
+    override fun tearDownService() = router.tearDownService()
 
-    override fun sendTearDownConnections() = PhoneConnectionService.sendTearDownConnections(context)
+    override fun sendTearDownConnections() = router.sendTearDownConnections()
 
-    override fun sendReserveAnswer(callId: String) = PhoneConnectionService.sendReserveAnswer(context, callId)
+    override fun sendReserveAnswer(callId: String) = router.sendReserveAnswer(callId)
 
-    override fun sendCleanConnections() = PhoneConnectionService.sendCleanConnections(context)
+    override fun sendCleanConnections() = router.sendCleanConnections()
 
-    override fun sendSyncAudioState() = PhoneConnectionService.sendSyncAudioState(context)
+    override fun sendSyncAudioState() = router.sendSyncAudioState()
 
-    override fun sendSyncConnectionState() = PhoneConnectionService.sendSyncConnectionState(context)
+    override fun sendSyncConnectionState() = router.sendSyncConnectionState()
 
     companion object {
         val instance: CallkeepCore = InProcessCallkeepCore()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -486,6 +486,10 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.AnswerCall, metadata)
+                return
+            }
             communicate(context, ServiceAction.AnswerCall, metadata)
         }
 
@@ -493,20 +497,29 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            communicate(context, ServiceAction.EstablishCall, metadata)
+            if (TelephonyUtils.isTelecomSupported(context)) {
+                communicate(context, ServiceAction.EstablishCall, metadata)
+            }
+            // No-op in standalone mode: outgoing calls are not supported without Telecom.
         }
 
         fun startUpdateCall(
             context: Context,
             metadata: CallMetadata,
         ) {
-            communicate(context, ServiceAction.UpdateCall, metadata)
+            if (TelephonyUtils.isTelecomSupported(context)) {
+                communicate(context, ServiceAction.UpdateCall, metadata)
+            }
         }
 
         fun startDeclineCall(
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.DeclineCall, metadata)
+                return
+            }
             communicate(context, ServiceAction.DeclineCall, metadata)
         }
 
@@ -514,6 +527,10 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.HungUpCall, metadata)
+                return
+            }
             communicate(context, ServiceAction.HungUpCall, metadata)
         }
 
@@ -521,13 +538,19 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            communicate(context, ServiceAction.SendDTMF, metadata)
+            if (TelephonyUtils.isTelecomSupported(context)) {
+                communicate(context, ServiceAction.SendDTMF, metadata)
+            }
         }
 
         fun startMutingCall(
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.Muting, metadata)
+                return
+            }
             communicate(context, ServiceAction.Muting, metadata)
         }
 
@@ -535,13 +558,20 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            communicate(context, ServiceAction.Holding, metadata)
+            if (TelephonyUtils.isTelecomSupported(context)) {
+                communicate(context, ServiceAction.Holding, metadata)
+            }
+            // Hold is not supported in standalone mode.
         }
 
         fun startSpeaker(
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.Speaker, metadata)
+                return
+            }
             communicate(context, ServiceAction.Speaker, metadata)
         }
 
@@ -549,10 +579,18 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.AudioDeviceSet, metadata)
+                return
+            }
             communicate(context, ServiceAction.AudioDeviceSet, metadata)
         }
 
         fun tearDown(context: Context) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.tearDown(context)
+                return
+            }
             communicate(context, ServiceAction.TearDown, null)
         }
 
@@ -568,6 +606,10 @@ class PhoneConnectionService : ConnectionService() {
          * and reply with [CallCommandEvent.TearDownComplete].
          */
         fun sendTearDownConnections(context: Context) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.TearDownConnections, null)
+                return
+            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.TearDownConnections.action
@@ -609,6 +651,14 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             callId: String,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(
+                    context,
+                    StandaloneServiceAction.ReserveAnswer,
+                    CallMetadata(callId = callId),
+                )
+                return
+            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.ReserveAnswer.action
@@ -626,6 +676,10 @@ class PhoneConnectionService : ConnectionService() {
          * registered without a permission are effectively exported.
          */
         fun sendCleanConnections(context: Context) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.CleanConnections, null)
+                return
+            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.CleanConnections.action
@@ -641,6 +695,10 @@ class PhoneConnectionService : ConnectionService() {
          * Used by [ForegroundService.onDelegateSet] to restore Flutter UI after hot restart.
          */
         fun sendSyncAudioState(context: Context) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.SyncAudioState, null)
+                return
+            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.SyncAudioState.action
@@ -657,6 +715,10 @@ class PhoneConnectionService : ConnectionService() {
          * when it starts after the AnswerCall broadcast was originally emitted (cold-start race).
          */
         fun sendSyncConnectionState(context: Context) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.communicate(context, StandaloneServiceAction.SyncConnectionState, null)
+                return
+            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.SyncConnectionState.action
@@ -677,6 +739,11 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                throw UnsupportedOperationException(
+                    "Outgoing calls are not supported on devices without android.software.telecom",
+                )
+            }
             Log.i(TAG, "onOutgoingCall, callId: ${metadata.callId}")
 
             val uri: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, metadata.number, null)
@@ -719,6 +786,11 @@ class PhoneConnectionService : ConnectionService() {
             onError: (PIncomingCallError?) -> Unit,
         ) {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
+
+            if (!TelephonyUtils.isTelecomSupported(context)) {
+                StandaloneCallService.startIncomingCall(context, metadata, onSuccess, onError)
+                return
+            }
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
                 try {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -486,10 +486,6 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.AnswerCall, metadata)
-                return
-            }
             communicate(context, ServiceAction.AnswerCall, metadata)
         }
 
@@ -497,29 +493,20 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (TelephonyUtils.isTelecomSupported(context)) {
-                communicate(context, ServiceAction.EstablishCall, metadata)
-            }
-            // No-op in standalone mode: outgoing calls are not supported without Telecom.
+            communicate(context, ServiceAction.EstablishCall, metadata)
         }
 
         fun startUpdateCall(
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (TelephonyUtils.isTelecomSupported(context)) {
-                communicate(context, ServiceAction.UpdateCall, metadata)
-            }
+            communicate(context, ServiceAction.UpdateCall, metadata)
         }
 
         fun startDeclineCall(
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.DeclineCall, metadata)
-                return
-            }
             communicate(context, ServiceAction.DeclineCall, metadata)
         }
 
@@ -527,10 +514,6 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.HungUpCall, metadata)
-                return
-            }
             communicate(context, ServiceAction.HungUpCall, metadata)
         }
 
@@ -538,19 +521,13 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (TelephonyUtils.isTelecomSupported(context)) {
-                communicate(context, ServiceAction.SendDTMF, metadata)
-            }
+            communicate(context, ServiceAction.SendDTMF, metadata)
         }
 
         fun startMutingCall(
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.Muting, metadata)
-                return
-            }
             communicate(context, ServiceAction.Muting, metadata)
         }
 
@@ -558,20 +535,13 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (TelephonyUtils.isTelecomSupported(context)) {
-                communicate(context, ServiceAction.Holding, metadata)
-            }
-            // Hold is not supported in standalone mode.
+            communicate(context, ServiceAction.Holding, metadata)
         }
 
         fun startSpeaker(
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.Speaker, metadata)
-                return
-            }
             communicate(context, ServiceAction.Speaker, metadata)
         }
 
@@ -579,18 +549,10 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.AudioDeviceSet, metadata)
-                return
-            }
             communicate(context, ServiceAction.AudioDeviceSet, metadata)
         }
 
         fun tearDown(context: Context) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.tearDown(context)
-                return
-            }
             communicate(context, ServiceAction.TearDown, null)
         }
 
@@ -606,10 +568,6 @@ class PhoneConnectionService : ConnectionService() {
          * and reply with [CallCommandEvent.TearDownComplete].
          */
         fun sendTearDownConnections(context: Context) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.TearDownConnections, null)
-                return
-            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.TearDownConnections.action
@@ -651,14 +609,6 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             callId: String,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(
-                    context,
-                    StandaloneServiceAction.ReserveAnswer,
-                    CallMetadata(callId = callId),
-                )
-                return
-            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.ReserveAnswer.action
@@ -676,10 +626,6 @@ class PhoneConnectionService : ConnectionService() {
          * registered without a permission are effectively exported.
          */
         fun sendCleanConnections(context: Context) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.CleanConnections, null)
-                return
-            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.CleanConnections.action
@@ -695,10 +641,6 @@ class PhoneConnectionService : ConnectionService() {
          * Used by [ForegroundService.onDelegateSet] to restore Flutter UI after hot restart.
          */
         fun sendSyncAudioState(context: Context) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.SyncAudioState, null)
-                return
-            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.SyncAudioState.action
@@ -715,10 +657,6 @@ class PhoneConnectionService : ConnectionService() {
          * when it starts after the AnswerCall broadcast was originally emitted (cold-start race).
          */
         fun sendSyncConnectionState(context: Context) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.communicate(context, StandaloneServiceAction.SyncConnectionState, null)
-                return
-            }
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
                     action = ServiceAction.SyncConnectionState.action
@@ -739,11 +677,6 @@ class PhoneConnectionService : ConnectionService() {
             context: Context,
             metadata: CallMetadata,
         ) {
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                throw UnsupportedOperationException(
-                    "Outgoing calls are not supported on devices without android.software.telecom",
-                )
-            }
             Log.i(TAG, "onOutgoingCall, callId: ${metadata.callId}")
 
             val uri: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, metadata.number, null)
@@ -786,11 +719,6 @@ class PhoneConnectionService : ConnectionService() {
             onError: (PIncomingCallError?) -> Unit,
         ) {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
-
-            if (!TelephonyUtils.isTelecomSupported(context)) {
-                StandaloneCallService.startIncomingCall(context, metadata, onSuccess, onError)
-                return
-            }
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
                 try {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -40,7 +40,6 @@ import com.webtrit.callkeep.services.services.foreground.ForegroundService
  */
 class PhoneConnectionService : ConnectionService() {
     private lateinit var phoneConnectionServiceDispatcher: PhoneConnectionServiceDispatcher
-    private lateinit var telephonyUtils: TelephonyUtils
 
     private val dispatcher: ConnectionServicePerformBroadcaster.DispatchHandle =
         ConnectionServicePerformBroadcaster.handle
@@ -58,7 +57,6 @@ class PhoneConnectionService : ConnectionService() {
         AssetCacheManager.init(applicationContext)
         // Set the service state to true when the system starts the service.
         isRunning = true
-        telephonyUtils = TelephonyUtils(applicationContext)
 
         val activityWakelockManager = ActivityWakelockManager(ActivityHolder)
         val proximitySensorManager =

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -46,29 +46,24 @@ class StandaloneCallService : Service() {
     private val dispatcher = ConnectionServicePerformBroadcaster.handle
     private val audioManager by lazy { getSystemService(AUDIO_SERVICE) as AudioManager }
 
+    // Tracks whether startForeground() has been called in this service instance.
+    // startForeground() is deferred until an actual call is handled so that lifecycle-only
+    // commands (SyncConnectionState, SyncAudioState, etc.) do not post a foreground
+    // notification when there is no call in progress.
+    private var isForeground = false
+
     override fun onCreate() {
         super.onCreate()
         ContextHolder.init(applicationContext)
         AssetCacheManager.init(applicationContext)
+        // Register notification channels here as well as in ForegroundService.setUp().
+        // StandaloneCallService runs in the :callkeep_core process and may start before
+        // setUp() is invoked from the Flutter layer (e.g. when SyncConnectionState is
+        // dispatched during app startup). Without this call, startForeground() would
+        // crash with CannotPostForegroundServiceNotificationException because the
+        // channel does not yet exist in the system.
+        NotificationChannelManager.registerNotificationChannels(applicationContext)
         isRunning = true
-
-        // Satisfy Android's 5-second startForeground() requirement immediately.
-        // The actual visible incoming-call notification is shown by IncomingCallService in the
-        // main process. This is a minimal placeholder required only to keep the :callkeep_core
-        // process alive for the duration of the call.
-        val placeholder =
-            Notification
-                .Builder(this, NotificationChannelManager.FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setCategory(NotificationCompat.CATEGORY_CALL)
-                .setOngoing(true)
-                .build()
-        startForegroundServiceCompat(
-            this,
-            NOTIFICATION_ID,
-            placeholder,
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
-        )
         Log.i(TAG, "onCreate")
     }
 
@@ -108,6 +103,13 @@ class StandaloneCallService : Service() {
             Log.e(TAG, "Exception $e with action: ${intent?.action}")
         }
 
+        // If no calls are active or pending after processing, there is nothing to keep alive.
+        // This handles the case where a lifecycle-only command (SyncConnectionState,
+        // SyncAudioState, CleanConnections) starts the service when no call is in progress.
+        if (callMetadataMap.isEmpty() && pendingAnswers.isEmpty()) {
+            stopSelf()
+        }
+
         return START_NOT_STICKY
     }
 
@@ -116,6 +118,7 @@ class StandaloneCallService : Service() {
     override fun onDestroy() {
         Log.i(TAG, "onDestroy")
         isRunning = false
+        isForeground = false
         stopForeground(STOP_FOREGROUND_REMOVE)
         super.onDestroy()
     }
@@ -124,8 +127,37 @@ class StandaloneCallService : Service() {
     // Command handlers
     // -------------------------------------------------------------------------
 
+    /**
+     * Promotes the service to a foreground service the first time a real call is handled.
+     *
+     * Called from [handleIncomingCall] and [handleOutgoingCall] — the only two handlers that
+     * are triggered by [startForegroundService]. All other commands arrive via [startService]
+     * and do not require a foreground notification.
+     *
+     * The actual visible call notification is shown by [IncomingCallService] in the main
+     * process. This placeholder keeps the :callkeep_core process alive for the call duration.
+     */
+    private fun promoteToForeground() {
+        if (isForeground) return
+        val placeholder =
+            Notification
+                .Builder(this, NotificationChannelManager.FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                .setOngoing(true)
+                .build()
+        startForegroundServiceCompat(
+            this,
+            NOTIFICATION_ID,
+            placeholder,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
+        )
+        isForeground = true
+    }
+
     private fun handleIncomingCall(metadata: CallMetadata) {
         Log.i(TAG, "handleIncomingCall: callId=${metadata.callId}")
+        promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
         answeredCallIds.remove(metadata.callId)
         // Notify the main process that the call has been registered. ForegroundService listens
@@ -137,6 +169,7 @@ class StandaloneCallService : Service() {
 
     private fun handleOutgoingCall(metadata: CallMetadata) {
         Log.i(TAG, "handleOutgoingCall: callId=${metadata.callId}")
+        promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
         answeredCallIds.remove(metadata.callId)
         // Notify the main process that the outgoing call is in progress, mirroring the

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -92,6 +92,9 @@ class StandaloneCallService : Service() {
                 StandaloneServiceAction.AnswerCall -> metadata?.let { handleAnswerCall(it) }
                 StandaloneServiceAction.DeclineCall -> metadata?.let { handleDeclineCall(it) }
                 StandaloneServiceAction.HungUpCall -> metadata?.let { handleHungUpCall(it) }
+                StandaloneServiceAction.UpdateCall -> metadata?.let { handleUpdateCall(it) }
+                StandaloneServiceAction.SendDtmf -> metadata?.let { handleSendDtmf(it) }
+                StandaloneServiceAction.Holding -> metadata?.let { handleHolding(it) }
                 StandaloneServiceAction.TearDownConnections -> handleTearDownConnections()
                 StandaloneServiceAction.CleanConnections -> handleCleanConnections()
                 StandaloneServiceAction.ReserveAnswer -> metadata?.callId?.let { handleReserveAnswer(it) }
@@ -186,6 +189,33 @@ class StandaloneCallService : Service() {
         Log.i(TAG, "handleHungUpCall: callId=${metadata.callId}")
         endCall(metadata)
         dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, metadata.toBundle())
+    }
+
+    private fun handleUpdateCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleUpdateCall: callId=${metadata.callId}")
+        val updated = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
+        callMetadataMap[metadata.callId] = updated
+    }
+
+    private fun handleSendDtmf(metadata: CallMetadata) {
+        val dtmf = metadata.dualToneMultiFrequency ?: return
+        Log.i(TAG, "handleSendDtmf: callId=${metadata.callId}, dtmf=$dtmf")
+        val updated = (callMetadataMap[metadata.callId] ?: metadata).copy(dualToneMultiFrequency = dtmf)
+        callMetadataMap[metadata.callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.SentDTMF, updated.toBundle())
+    }
+
+    private fun handleHolding(metadata: CallMetadata) {
+        val onHold = metadata.hasHold ?: return
+        Log.i(TAG, "handleHolding: callId=${metadata.callId}, onHold=$onHold")
+        if (onHold) {
+            audioManager.mode = AudioManager.MODE_NORMAL
+        } else {
+            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        }
+        val updated = (callMetadataMap[metadata.callId] ?: metadata).copy(hasHold = onHold)
+        callMetadataMap[metadata.callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.ConnectionHolding, updated.toBundle())
     }
 
     private fun handleTearDownConnections() {
@@ -461,6 +491,9 @@ enum class StandaloneServiceAction {
     AnswerCall,
     DeclineCall,
     HungUpCall,
+    UpdateCall,
+    SendDtmf,
+    Holding,
     TearDownConnections,
     CleanConnections,
     ReserveAnswer,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -1,0 +1,421 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.app.Notification
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.media.AudioManager
+import android.os.IBinder
+import androidx.annotation.Keep
+import androidx.core.app.NotificationCompat
+import com.webtrit.callkeep.PIncomingCallError
+import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.AssetCacheManager
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.common.startForegroundServiceCompat
+import com.webtrit.callkeep.managers.NotificationChannelManager
+import com.webtrit.callkeep.models.AudioDevice
+import com.webtrit.callkeep.models.AudioDeviceType
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
+import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
+import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
+import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Standalone call management service for devices that do not expose the
+ * `android.software.telecom` system feature (e.g. some tablets, Android Go builds,
+ * certain custom OEM configurations).
+ *
+ * On devices with Telecom support, [PhoneConnectionService] (a [android.telecom.ConnectionService])
+ * handles call management through the Android Telecom framework. On devices without Telecom,
+ * this service acts as an independent call manager — tracking call state, managing audio
+ * routing directly via [AudioManager], and dispatching the same [ConnectionEvent] broadcasts
+ * that [PhoneConnectionService] produces in the Telecom path. This means [ForegroundService]
+ * and the Flutter layer do not need to be aware of which path is active.
+ *
+ * The service runs in the `:callkeep_core` process, mirroring [PhoneConnectionService].
+ * It is started as a foreground service on the first incoming call and stopped when all
+ * calls have ended or a teardown command is received.
+ */
+@Keep
+class StandaloneCallService : Service() {
+    private val dispatcher = ConnectionServicePerformBroadcaster.handle
+    private val audioManager by lazy { getSystemService(AUDIO_SERVICE) as AudioManager }
+
+    override fun onCreate() {
+        super.onCreate()
+        ContextHolder.init(applicationContext)
+        AssetCacheManager.init(applicationContext)
+        isRunning = true
+
+        // Satisfy Android's 5-second startForeground() requirement immediately.
+        // The actual visible incoming-call notification is shown by IncomingCallService in the
+        // main process. This is a minimal placeholder required only to keep the :callkeep_core
+        // process alive for the duration of the call.
+        val placeholder =
+            Notification
+                .Builder(this, NotificationChannelManager.FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                .setOngoing(true)
+                .build()
+        startForegroundServiceCompat(
+            this,
+            NOTIFICATION_ID,
+            placeholder,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
+        )
+        Log.i(TAG, "onCreate")
+    }
+
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        val action =
+            intent?.action?.let { StandaloneServiceAction.from(it) } ?: run {
+                Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
+                return START_NOT_STICKY
+            }
+        val metadata = intent.extras?.let { CallMetadata.fromBundle(it) }
+
+        try {
+            when (action) {
+                StandaloneServiceAction.IncomingCall -> metadata?.let { handleIncomingCall(it) }
+                StandaloneServiceAction.AnswerCall -> metadata?.let { handleAnswerCall(it) }
+                StandaloneServiceAction.DeclineCall -> metadata?.let { handleDeclineCall(it) }
+                StandaloneServiceAction.HungUpCall -> metadata?.let { handleHungUpCall(it) }
+                StandaloneServiceAction.TearDownConnections -> handleTearDownConnections()
+                StandaloneServiceAction.CleanConnections -> handleCleanConnections()
+                StandaloneServiceAction.ReserveAnswer -> metadata?.callId?.let { handleReserveAnswer(it) }
+                StandaloneServiceAction.Muting -> metadata?.let { handleMuting(it) }
+                StandaloneServiceAction.Speaker -> metadata?.let { handleSpeaker(it) }
+                StandaloneServiceAction.AudioDeviceSet -> metadata?.let { handleAudioDeviceSet(it) }
+                StandaloneServiceAction.SyncAudioState -> handleSyncAudioState()
+                StandaloneServiceAction.SyncConnectionState -> handleSyncConnectionState()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception $e with action: ${intent?.action}")
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        Log.i(TAG, "onDestroy")
+        isRunning = false
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    // -------------------------------------------------------------------------
+    // Command handlers
+    // -------------------------------------------------------------------------
+
+    private fun handleIncomingCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleIncomingCall: callId=${metadata.callId}")
+        callMetadataMap[metadata.callId] = metadata
+        answeredCallIds.remove(metadata.callId)
+        // Notify the main process that the call has been registered. ForegroundService listens
+        // for this broadcast to resolve its pendingIncomingCallbacks entry and promote the call
+        // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
+        // path in the Telecom-enabled flow.
+        dispatcher.dispatch(baseContext, CallLifecycleEvent.DidPushIncomingCall, metadata.toBundle())
+    }
+
+    private fun handleAnswerCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleAnswerCall: callId=${metadata.callId}")
+        val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
+        callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
+        answeredCallIds.add(metadata.callId)
+        pendingAnswers.remove(metadata.callId)
+
+        activateAudio()
+        fireInitialAudioState(metadata.callId)
+
+        dispatcher.dispatch(
+            baseContext,
+            CallLifecycleEvent.AnswerCall,
+            callMetadataMap[metadata.callId]!!.toBundle(),
+        )
+    }
+
+    private fun handleDeclineCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleDeclineCall: callId=${metadata.callId}")
+        endCall(metadata)
+        dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, metadata.toBundle())
+    }
+
+    private fun handleHungUpCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleHungUpCall: callId=${metadata.callId}")
+        endCall(metadata)
+        dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, metadata.toBundle())
+    }
+
+    private fun handleTearDownConnections() {
+        Log.i(TAG, "handleTearDownConnections: cleaning up ${callMetadataMap.size} calls")
+        callMetadataMap.keys.toList().forEach { callId ->
+            val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
+            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, meta.toBundle())
+        }
+        callMetadataMap.clear()
+        answeredCallIds.clear()
+        pendingAnswers.clear()
+        deactivateAudio(force = true)
+        dispatcher.dispatch(baseContext, CallCommandEvent.TearDownComplete)
+        stopSelf()
+    }
+
+    private fun handleCleanConnections() {
+        Log.i(TAG, "handleCleanConnections: clearing state")
+        callMetadataMap.clear()
+        answeredCallIds.clear()
+        pendingAnswers.clear()
+        deactivateAudio(force = true)
+    }
+
+    /**
+     * Handles a deferred answer reservation for [callId].
+     *
+     * If the call has already been registered via [handleIncomingCall], answer it immediately.
+     * If not yet registered (narrow race: ReserveAnswer arrived before IncomingCall was processed),
+     * record the reservation so [handleIncomingCall] can apply it when it fires.
+     */
+    private fun handleReserveAnswer(callId: String) {
+        Log.i(TAG, "handleReserveAnswer: callId=$callId")
+        val meta = callMetadataMap[callId]
+        if (meta != null) {
+            handleAnswerCall(meta)
+        } else {
+            pendingAnswers.add(callId)
+        }
+    }
+
+    private fun handleMuting(metadata: CallMetadata) {
+        val muted = metadata.hasMute ?: return
+        Log.i(TAG, "handleMuting: callId=${metadata.callId}, muted=$muted")
+        audioManager.isMicrophoneMute = muted
+        val updated =
+            (callMetadataMap[metadata.callId] ?: metadata).copy(hasMute = muted)
+        callMetadataMap[metadata.callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.AudioMuting, updated.toBundle())
+    }
+
+    private fun handleSpeaker(metadata: CallMetadata) {
+        val speaker = metadata.hasSpeaker ?: return
+        Log.i(TAG, "handleSpeaker: callId=${metadata.callId}, speaker=$speaker")
+        @Suppress("DEPRECATION")
+        audioManager.isSpeakerphoneOn = speaker
+        val deviceType = if (speaker) AudioDeviceType.SPEAKER else AudioDeviceType.EARPIECE
+        val updated =
+            (callMetadataMap[metadata.callId] ?: metadata).copy(
+                hasSpeaker = speaker,
+                audioDevice = AudioDevice(deviceType),
+            )
+        callMetadataMap[metadata.callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.AudioDeviceSet, updated.toBundle())
+    }
+
+    private fun handleAudioDeviceSet(metadata: CallMetadata) {
+        val device = metadata.audioDevice ?: return
+        Log.i(TAG, "handleAudioDeviceSet: callId=${metadata.callId}, device=${device.type}")
+        val isSpeaker = device.type == AudioDeviceType.SPEAKER
+        @Suppress("DEPRECATION")
+        audioManager.isSpeakerphoneOn = isSpeaker
+        val updated =
+            (callMetadataMap[metadata.callId] ?: metadata).copy(
+                hasSpeaker = isSpeaker,
+                audioDevice = device,
+            )
+        callMetadataMap[metadata.callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.AudioDeviceSet, updated.toBundle())
+    }
+
+    private fun handleSyncAudioState() {
+        Log.i(TAG, "handleSyncAudioState: re-emitting audio state for answered calls")
+        answeredCallIds.forEach { callId -> fireInitialAudioState(callId) }
+    }
+
+    private fun handleSyncConnectionState() {
+        Log.i(TAG, "handleSyncConnectionState: re-emitting AnswerCall for answered calls")
+        answeredCallIds.forEach { callId ->
+            val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
+            dispatcher.dispatch(baseContext, CallLifecycleEvent.AnswerCall, meta.toBundle())
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Audio helpers
+    // -------------------------------------------------------------------------
+
+    private fun activateAudio() {
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+    }
+
+    private fun deactivateAudio(force: Boolean = false) {
+        if (force || callMetadataMap.isEmpty()) {
+            audioManager.mode = AudioManager.MODE_NORMAL
+        }
+    }
+
+    /**
+     * Fires [CallMediaEvent.AudioDevicesUpdate] and [CallMediaEvent.AudioDeviceSet] with
+     * the available and currently selected audio device for [callId].
+     *
+     * Reported devices are limited to earpiece and speaker. Bluetooth and wired headset
+     * detection requires an [android.media.AudioDeviceCallback] listener which can be
+     * added in a follow-up when needed.
+     */
+    private fun fireInitialAudioState(callId: String) {
+        val metadata = callMetadataMap[callId] ?: return
+        val availableDevices =
+            listOf(
+                AudioDevice(AudioDeviceType.EARPIECE),
+                AudioDevice(AudioDeviceType.SPEAKER),
+            )
+        val currentDevice = metadata.audioDevice ?: AudioDevice(AudioDeviceType.EARPIECE)
+        val updated = metadata.copy(audioDevices = availableDevices, audioDevice = currentDevice)
+        callMetadataMap[callId] = updated
+        dispatcher.dispatch(baseContext, CallMediaEvent.AudioDevicesUpdate, updated.toBundle())
+        dispatcher.dispatch(baseContext, CallMediaEvent.AudioDeviceSet, updated.toBundle())
+    }
+
+    private fun endCall(metadata: CallMetadata) {
+        callMetadataMap.remove(metadata.callId)
+        answeredCallIds.remove(metadata.callId)
+        pendingAnswers.remove(metadata.callId)
+        if (callMetadataMap.isEmpty()) {
+            deactivateAudio()
+            stopSelf()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Companion (static dispatch interface, mirrors PhoneConnectionService)
+    // -------------------------------------------------------------------------
+
+    companion object {
+        private const val TAG = "StandaloneCallService"
+
+        // Arbitrary notification ID that does not collide with main-process notification IDs.
+        private const val NOTIFICATION_ID = 97
+
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
+        // Call state shared within the :callkeep_core process JVM.
+        // Written on the main thread (onStartCommand); read from static dispatch methods
+        // called on the main process thread, hence ConcurrentHashMap.
+        internal val callMetadataMap: ConcurrentHashMap<String, CallMetadata> = ConcurrentHashMap()
+        internal val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+        internal val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+        /**
+         * Starts an incoming call in standalone mode.
+         *
+         * Reuses [ConnectionManager.validateConnectionAddition] (which operates on the
+         * main-process [PhoneConnectionService.connectionManager] instance) for deduplication,
+         * matching the same validation path used by [PhoneConnectionService.startIncomingCall].
+         */
+        fun startIncomingCall(
+            context: Context,
+            metadata: CallMetadata,
+            onSuccess: () -> Unit,
+            onError: (PIncomingCallError?) -> Unit,
+        ) {
+            ConnectionManager.validateConnectionAddition(
+                metadata = metadata,
+                onSuccess = {
+                    val intent =
+                        Intent(context, StandaloneCallService::class.java).apply {
+                            action = StandaloneServiceAction.IncomingCall.action
+                            putExtras(metadata.toBundle())
+                        }
+                    try {
+                        context.startForegroundService(intent)
+                        onSuccess()
+                    } catch (e: Exception) {
+                        Log.e(TAG, "startIncomingCall: startForegroundService failed for callId=${metadata.callId}", e)
+                        PhoneConnectionService.connectionManager.removePending(metadata.callId)
+                        onError(null)
+                    }
+                },
+                onError = { error -> onError(error) },
+            )
+        }
+
+        /**
+         * Dispatches [action] to the running [StandaloneCallService] via [startService].
+         *
+         * If [StandaloneCallService] is not currently running (e.g. the OS killed the process
+         * between the incoming call and the command), the call is silently dropped and, for
+         * teardown commands, a [CallCommandEvent.TearDownComplete] ack is synthesised so that
+         * [ForegroundService] does not wait indefinitely on its timeout.
+         */
+        fun communicate(
+            context: Context,
+            action: StandaloneServiceAction,
+            metadata: CallMetadata?,
+        ) {
+            val intent =
+                Intent(context, StandaloneCallService::class.java).apply {
+                    this.action = action.action
+                    metadata?.toBundle()?.let { putExtras(it) }
+                }
+            try {
+                context.startService(intent)
+            } catch (e: Exception) {
+                Log.w(TAG, "communicate: startService failed for action=${action.name}: $e")
+                // Synthesise a TearDownComplete ack so ForegroundService.tearDown() does not
+                // block on a timeout when the service is no longer alive.
+                if (action == StandaloneServiceAction.TearDownConnections) {
+                    ConnectionServicePerformBroadcaster.handle.dispatch(
+                        context,
+                        CallCommandEvent.TearDownComplete,
+                    )
+                }
+            }
+        }
+
+        fun tearDown(context: Context) {
+            communicate(context, StandaloneServiceAction.TearDownConnections, null)
+        }
+    }
+}
+
+/**
+ * Action strings used for routing commands inside [StandaloneCallService.onStartCommand].
+ *
+ * Mirrors [ServiceAction] but scoped exclusively to [StandaloneCallService] so that
+ * intents targeting the standalone path cannot accidentally be routed into
+ * [PhoneConnectionService.onStartCommand] and vice versa.
+ */
+enum class StandaloneServiceAction {
+    IncomingCall,
+    AnswerCall,
+    DeclineCall,
+    HungUpCall,
+    TearDownConnections,
+    CleanConnections,
+    ReserveAnswer,
+    Muting,
+    Speaker,
+    AudioDeviceSet,
+    SyncAudioState,
+    SyncConnectionState,
+    ;
+
+    val action: String get() = "callkeep_standalone_$name"
+
+    companion object {
+        fun from(action: String?): StandaloneServiceAction? = entries.find { it.action == action }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -64,6 +64,10 @@ class StandaloneCallService : Service() {
         // channel does not yet exist in the system.
         NotificationChannelManager.registerNotificationChannels(applicationContext)
         isRunning = true
+        // Satisfy Android's 5-second startForeground() requirement immediately.
+        // promoteToForeground() is a no-op once isForeground is true, so calling it here
+        // does not interfere with the call-handling paths that call it later.
+        promoteToForeground()
         Log.i(TAG, "onCreate")
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -87,6 +87,8 @@ class StandaloneCallService : Service() {
         try {
             when (action) {
                 StandaloneServiceAction.IncomingCall -> metadata?.let { handleIncomingCall(it) }
+                StandaloneServiceAction.OutgoingCall -> metadata?.let { handleOutgoingCall(it) }
+                StandaloneServiceAction.EstablishCall -> metadata?.let { handleEstablishCall(it) }
                 StandaloneServiceAction.AnswerCall -> metadata?.let { handleAnswerCall(it) }
                 StandaloneServiceAction.DeclineCall -> metadata?.let { handleDeclineCall(it) }
                 StandaloneServiceAction.HungUpCall -> metadata?.let { handleHungUpCall(it) }
@@ -128,6 +130,33 @@ class StandaloneCallService : Service() {
         // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
         // path in the Telecom-enabled flow.
         dispatcher.dispatch(baseContext, CallLifecycleEvent.DidPushIncomingCall, metadata.toBundle())
+    }
+
+    private fun handleOutgoingCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleOutgoingCall: callId=${metadata.callId}")
+        callMetadataMap[metadata.callId] = metadata
+        answeredCallIds.remove(metadata.callId)
+        // Notify the main process that the outgoing call is in progress, mirroring the
+        // OngoingCall broadcast that PhoneConnectionService fires after onCreateOutgoingConnection.
+        // ForegroundService listens for this to promote the call to STATE_DIALING and call performStartCall.
+        dispatcher.dispatch(baseContext, CallLifecycleEvent.OngoingCall, metadata.toBundle())
+    }
+
+    private fun handleEstablishCall(metadata: CallMetadata) {
+        Log.i(TAG, "handleEstablishCall: callId=${metadata.callId}")
+        val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
+        callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
+        answeredCallIds.add(metadata.callId)
+        pendingAnswers.remove(metadata.callId)
+
+        activateAudio()
+        fireInitialAudioState(metadata.callId)
+
+        dispatcher.dispatch(
+            baseContext,
+            CallLifecycleEvent.AnswerCall,
+            callMetadataMap[metadata.callId]!!.toBundle(),
+        )
     }
 
     private fun handleAnswerCall(metadata: CallMetadata) {
@@ -353,6 +382,33 @@ class StandaloneCallService : Service() {
         }
 
         /**
+         * Starts an outgoing call in standalone mode.
+         *
+         * Fires the service with [StandaloneServiceAction.OutgoingCall], which stores the call
+         * metadata and broadcasts [CallLifecycleEvent.OngoingCall] back to the main process so
+         * that [ForegroundService] can promote the call and notify the Flutter layer.
+         *
+         * The call is established (audio activated, [CallLifecycleEvent.AnswerCall] fired) when
+         * the app later calls [startEstablishCall] via [StandaloneServiceAction.EstablishCall].
+         */
+        fun startOutgoingCall(
+            context: Context,
+            metadata: CallMetadata,
+        ) {
+            val intent =
+                Intent(context, StandaloneCallService::class.java).apply {
+                    action = StandaloneServiceAction.OutgoingCall.action
+                    putExtras(metadata.toBundle())
+                }
+            try {
+                context.startForegroundService(intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "startOutgoingCall: startForegroundService failed for callId=${metadata.callId}", e)
+                throw e
+            }
+        }
+
+        /**
          * Dispatches [action] to the running [StandaloneCallService] via [startService].
          *
          * If [StandaloneCallService] is not currently running (e.g. the OS killed the process
@@ -400,6 +456,8 @@ class StandaloneCallService : Service() {
  */
 enum class StandaloneServiceAction {
     IncomingCall,
+    OutgoingCall,
+    EstablishCall,
     AnswerCall,
     DeclineCall,
     HungUpCall,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -100,7 +100,7 @@ class StandaloneCallService : Service() {
                 StandaloneServiceAction.SyncConnectionState -> handleSyncConnectionState()
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Exception $e with action: ${intent?.action}")
+            Log.e(TAG, "Exception with action: ${intent?.action}", e)
         }
 
         // If no calls are active or pending after processing, there is nothing to keep alive.
@@ -165,6 +165,12 @@ class StandaloneCallService : Service() {
         // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
         // path in the Telecom-enabled flow.
         dispatcher.dispatch(baseContext, CallLifecycleEvent.DidPushIncomingCall, metadata.toBundle())
+
+        // If an answer was reserved before this call was registered (ReserveAnswer arrived first),
+        // consume the pending reservation and immediately trigger the answer flow.
+        if (pendingAnswers.remove(metadata.callId)) {
+            handleAnswerCall(metadata)
+        }
     }
 
     private fun handleOutgoingCall(metadata: CallMetadata) {
@@ -354,6 +360,9 @@ class StandaloneCallService : Service() {
     private fun deactivateAudio(force: Boolean = false) {
         if (force || callMetadataMap.isEmpty()) {
             audioManager.mode = AudioManager.MODE_NORMAL
+            @Suppress("DEPRECATION")
+            audioManager.isSpeakerphoneOn = false
+            audioManager.isMicrophoneMute = false
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -213,6 +213,12 @@ class ForegroundService :
         callback: (Result<Unit>) -> Unit,
     ) {
         logger.i("setUp")
+        if (!TelephonyUtils.isTelecomSupported(baseContext)) {
+            logger.i("setUp: android.software.telecom not available on this device — skipping phone account registration, using standalone call mode")
+            applySetupOptions(options)
+            callback(Result.success(Unit))
+            return
+        }
         registerPhoneAccountWithRetry(options, callback, attempt = 0)
     }
 
@@ -239,6 +245,12 @@ class ForegroundService :
 
         logger.i("setUp: registerPhoneAccount succeeded${if (attempt > 0) " on attempt ${attempt + 1}" else ""}")
 
+        applySetupOptions(options)
+
+        callback.invoke(Result.success(Unit))
+    }
+
+    private fun applySetupOptions(options: POptions) {
         runCatching {
             // Registers all necessary notification channels for the application.
             // This includes channels for active calls, incoming calls, missed calls, and foreground calls.
@@ -253,8 +265,6 @@ class ForegroundService :
             options.android.ringbackSound?.let { StorageDelegate.Sound.initRingbackPath(baseContext, it) }
             options.android.incomingCallFullScreen?.let { StorageDelegate.IncomingCall.setFullScreen(baseContext, it) }
         }.onFailure { Log.w("CallKeep", "Android options init failed: ${it.message}", it) }
-
-        callback.invoke(Result.success(Unit))
     }
 
     override fun startCall(


### PR DESCRIPTION
## Summary

- Devices without `android.software.telecom` (e.g. Lenovo TB128FU / Android 13 tablets, Android Go builds, certain OEM configs) previously failed at `registerPhoneAccount()` on startup and dropped all incoming calls with a dead Pigeon channel error
- Introduces `StandaloneCallService` — a regular foreground service running in `:callkeep_core` — as an independent call manager for these devices
- Adds `TelephonyUtils.isTelecomSupported(context)` as a single feature-detection gate used throughout the routing layer
- `PhoneConnectionService` companion static methods route all call commands to `StandaloneCallService` when Telecom is unavailable; `ForegroundService.setUp()` skips phone account registration on the same condition

## What StandaloneCallService does

- Runs in `:callkeep_core` process alongside `PhoneConnectionService`
- Tracks call state (ringing / active / ended) without any Telecom API
- Manages audio routing directly via `AudioManager` (`MODE_IN_COMMUNICATION`, `isMicrophoneMute`, `isSpeakerphoneOn`)
- Reports earpiece + speaker as available audio devices on answer
- Dispatches `DidPushIncomingCall`, `AnswerCall`, `HungUp`, `TearDownComplete`, `AudioMuting`, `AudioDeviceSet`, `AudioDevicesUpdate` broadcasts — the same events `PhoneConnectionService` produces — so `ForegroundService` and Flutter require zero changes

## Limitations (follow-up scope)

- Outgoing calls are not supported without Telecom (`UnsupportedOperationException` returned as `INTERNAL` error)
- Bluetooth / wired-headset audio device detection is not implemented; only earpiece and speaker are reported
- Hold is not supported in standalone mode (commands are silently dropped)

## Test plan

- [ ] Build passes on Telecom-capable device — existing call flows unchanged
- [ ] On a device/emulator without `android.software.telecom`: app starts without `UnsupportedOperationException` in logs
- [ ] Incoming call shows notification with Answer/Decline buttons
- [ ] Answering the call activates audio (`MODE_IN_COMMUNICATION`)
- [ ] Declining / hanging up deactivates audio and fires `performEndCall` to Flutter
- [ ] Mute toggle and speaker toggle update `AudioManager` and fire the correct media event broadcasts
- [ ] `tearDown()` from Flutter completes without timeout