### PR TITLE
refactor(android): centralize connection event delivery through CallkeepCore

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -1,11 +1,15 @@
 package com.webtrit.callkeep.services.core
 
 import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 
 /**
  * Single facade for all interactions with the `:callkeep_core` process.
@@ -97,6 +101,30 @@ interface CallkeepCore {
     fun markSignalingRegistered(callId: String)
 
     fun consumeSignalingRegistered(callId: String): Boolean
+
+    // -------------------------------------------------------------------------
+    // Connection event receivers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers [receiver] to receive the given [events] from [ConnectionServicePerformBroadcaster].
+     * Prefer this over calling [ConnectionServicePerformBroadcaster] directly so all registration
+     * goes through a single access point.
+     */
+    fun registerConnectionEvents(
+        context: Context,
+        events: List<ConnectionEvent>,
+        receiver: BroadcastReceiver,
+        exported: Boolean = true,
+    ): IntentFilter
+
+    /**
+     * Unregisters a [receiver] previously registered via [registerConnectionEvents].
+     */
+    fun unregisterConnectionEvents(
+        context: Context,
+        receiver: BroadcastReceiver,
+    )
 
     // -------------------------------------------------------------------------
     // CS commands

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -146,7 +146,7 @@ interface CallkeepCore {
         context: Context,
         events: List<ConnectionEvent>,
         receiver: BroadcastReceiver,
-        exported: Boolean = true,
+        exported: Boolean = false,
     ): IntentFilter
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -4,12 +4,26 @@ import android.Manifest
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
+import android.os.Bundle
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
+
+/**
+ * Receives connection events dispatched by [CallkeepCore].
+ *
+ * Register via [CallkeepCore.addConnectionEventListener]; unregister via
+ * [CallkeepCore.removeConnectionEventListener]. The callback is invoked on the main thread.
+ */
+fun interface ConnectionEventListener {
+    fun onConnectionEvent(
+        event: ConnectionEvent,
+        data: Bundle?,
+    )
+}
 
 /**
  * Single facade for all interactions with the `:callkeep_core` process.
@@ -107,9 +121,26 @@ interface CallkeepCore {
     // -------------------------------------------------------------------------
 
     /**
+     * Subscribes [listener] to receive connection events from [ConnectionServicePerformBroadcaster].
+     *
+     * The first registered listener triggers registration of a single global [BroadcastReceiver]
+     * that lives until the last listener unregisters. All subsequent listeners share that receiver.
+     * Safe to call multiple times with the same listener — duplicates are allowed by
+     * [java.util.concurrent.CopyOnWriteArrayList] semantics; callers must balance
+     * add/remove calls.
+     */
+    fun addConnectionEventListener(listener: ConnectionEventListener)
+
+    /**
+     * Unsubscribes [listener]. When the last listener is removed the global [BroadcastReceiver]
+     * is unregistered.
+     */
+    fun removeConnectionEventListener(listener: ConnectionEventListener)
+
+    /**
      * Registers [receiver] to receive the given [events] from [ConnectionServicePerformBroadcaster].
-     * Prefer this over calling [ConnectionServicePerformBroadcaster] directly so all registration
-     * goes through a single access point.
+     * Use this for temporary per-call receivers (e.g. waiting for one specific confirmation
+     * broadcast). For persistent subscriptions prefer [addConnectionEventListener].
      */
     fun registerConnectionEvents(
         context: Context,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -3,16 +3,21 @@ package com.webtrit.callkeep.services.core
 import android.Manifest
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
 import android.content.IntentFilter
+import android.os.Bundle
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
+import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * In-process implementation of [CallkeepCore].
@@ -31,6 +36,56 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
     // created early without risking a NullPointerException. ContextHolder.init() must
     // have been called before any CS command method is invoked (guaranteed by Application.onCreate).
     private val context get() = ContextHolder.context
+
+    // -------------------------------------------------------------------------
+    // Listener registry and lazy global BroadcastReceiver
+    // -------------------------------------------------------------------------
+
+    private val listeners = CopyOnWriteArrayList<ConnectionEventListener>()
+    private var globalReceiver: BroadcastReceiver? = null
+    private val receiverLock = Any()
+
+    override fun addConnectionEventListener(listener: ConnectionEventListener) {
+        listeners.add(listener)
+        synchronized(receiverLock) {
+            if (globalReceiver == null) {
+                globalReceiver =
+                    createGlobalReceiver().also { receiver ->
+                        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
+                            GLOBAL_LISTENER_EVENTS,
+                            context,
+                            receiver,
+                        )
+                    }
+            }
+        }
+    }
+
+    override fun removeConnectionEventListener(listener: ConnectionEventListener) {
+        listeners.remove(listener)
+        synchronized(receiverLock) {
+            if (listeners.isEmpty()) {
+                globalReceiver?.let { receiver ->
+                    runCatching {
+                        ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(context, receiver)
+                    }
+                }
+                globalReceiver = null
+            }
+        }
+    }
+
+    private fun createGlobalReceiver(): BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                ctx: Context?,
+                intent: Intent?,
+            ) {
+                val action = intent?.action ?: return
+                val event = GLOBAL_LISTENER_EVENTS.find { it.name == action } ?: return
+                listeners.forEach { it.onConnectionEvent(event, intent.extras) }
+            }
+        }
 
     // -------------------------------------------------------------------------
     // State queries
@@ -170,5 +225,27 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
 
     companion object {
         val instance: CallkeepCore = InProcessCallkeepCore()
+
+        /**
+         * Events delivered to all [ConnectionEventListener] subscribers.
+         *
+         * Covers the persistent global subscriptions used by [ForegroundService] and
+         * [IncomingCallService]. Per-call one-off receivers (OngoingCall, OutgoingFailure,
+         * TearDownComplete, IncomingFailure) are excluded — they stay as dynamic
+         * receivers registered via [registerConnectionEvents].
+         */
+        internal val GLOBAL_LISTENER_EVENTS: List<ConnectionEvent> =
+            listOf(
+                CallLifecycleEvent.DidPushIncomingCall,
+                CallLifecycleEvent.DeclineCall,
+                CallLifecycleEvent.HungUp,
+                CallLifecycleEvent.ConnectionNotFound,
+                CallLifecycleEvent.AnswerCall,
+                CallMediaEvent.AudioDeviceSet,
+                CallMediaEvent.AudioDevicesUpdate,
+                CallMediaEvent.AudioMuting,
+                CallMediaEvent.ConnectionHolding,
+                CallMediaEvent.SentDTMF,
+            )
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -55,6 +55,7 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
                             GLOBAL_LISTENER_EVENTS,
                             context,
                             receiver,
+                            exported = false,
                         )
                     }
             }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -1,12 +1,17 @@
 package com.webtrit.callkeep.services.core
 
 import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
+import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
 
 /**
@@ -93,6 +98,22 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
     override fun markSignalingRegistered(callId: String) = tracker.markSignalingRegistered(callId)
 
     override fun consumeSignalingRegistered(callId: String): Boolean = tracker.consumeSignalingRegistered(callId)
+
+    // -------------------------------------------------------------------------
+    // Connection event receivers
+    // -------------------------------------------------------------------------
+
+    override fun registerConnectionEvents(
+        context: Context,
+        events: List<ConnectionEvent>,
+        receiver: BroadcastReceiver,
+        exported: Boolean,
+    ): IntentFilter = ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(events, context, receiver, exported)
+
+    override fun unregisterConnectionEvents(
+        context: Context,
+        receiver: BroadcastReceiver,
+    ) = ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(context, receiver)
 
     // -------------------------------------------------------------------------
     // CS commands

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -43,6 +43,7 @@ import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 import com.webtrit.callkeep.services.core.CallkeepCore
+import com.webtrit.callkeep.services.core.ConnectionEventListener
 import com.webtrit.callkeep.services.services.incoming_call.IncomingCallRelease
 import com.webtrit.callkeep.services.services.incoming_call.IncomingCallService
 import java.util.concurrent.ConcurrentHashMap
@@ -68,7 +69,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Keep
 class ForegroundService :
     Service(),
-    PHostApi {
+    PHostApi,
+    ConnectionEventListener {
     private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
 
     // Stored as fields so onDestroy() can cancel the timeout and unregister the receiver
@@ -118,86 +120,62 @@ class ForegroundService :
             _flutterDelegateApi = value
         }
 
-    private val connectionServicePerformReceiver =
-        object : BroadcastReceiver() {
-            override fun onReceive(
-                context: Context?,
-                intent: Intent?,
-            ) {
-                val action = intent?.action
-                logger.d("connectionServicePerformReceiver onReceive: $action")
-                when (action) {
-                    CallLifecycleEvent.DidPushIncomingCall.name -> {
-                        handleCSReportDidPushIncomingCall(
-                            intent.extras,
-                        )
-                    }
-
-                    CallLifecycleEvent.DeclineCall.name -> {
-                        handleCSReportDeclineCall(intent.extras)
-                    }
-
-                    CallLifecycleEvent.HungUp.name -> {
-                        handleCSReportDeclineCall(intent.extras)
-                    }
-
-                    CallLifecycleEvent.ConnectionNotFound.name -> {
-                        handleCSReportDeclineCall(intent.extras)
-                    }
-
-                    CallLifecycleEvent.AnswerCall.name -> {
-                        handleCSReportAnswerCall(intent.extras)
-                    }
-
-                    CallMediaEvent.AudioDeviceSet.name -> {
-                        handleCSReportAudioDeviceSet(intent.extras)
-                    }
-
-                    CallMediaEvent.AudioDevicesUpdate.name -> {
-                        handleCsReportAudioDevicesUpdate(intent.extras)
-                    }
-
-                    CallMediaEvent.AudioMuting.name -> {
-                        handleCSReportAudioMuting(intent.extras)
-                    }
-
-                    CallMediaEvent.ConnectionHolding.name -> {
-                        handleCSReportConnectionHolding(intent.extras)
-                    }
-
-                    CallMediaEvent.SentDTMF.name -> {
-                        handleCSReportSentDTMF(intent.extras)
-                    }
-                }
+    override fun onConnectionEvent(
+        event: ConnectionEvent,
+        data: Bundle?,
+    ) {
+        logger.d("onConnectionEvent: ${event.name}")
+        when (event) {
+            CallLifecycleEvent.DidPushIncomingCall -> {
+                handleCSReportDidPushIncomingCall(data)
             }
+
+            CallLifecycleEvent.DeclineCall -> {
+                handleCSReportDeclineCall(data)
+            }
+
+            CallLifecycleEvent.HungUp -> {
+                handleCSReportDeclineCall(data)
+            }
+
+            CallLifecycleEvent.ConnectionNotFound -> {
+                handleCSReportDeclineCall(data)
+            }
+
+            CallLifecycleEvent.AnswerCall -> {
+                handleCSReportAnswerCall(data)
+            }
+
+            CallMediaEvent.AudioDeviceSet -> {
+                handleCSReportAudioDeviceSet(data)
+            }
+
+            CallMediaEvent.AudioDevicesUpdate -> {
+                handleCsReportAudioDevicesUpdate(data)
+            }
+
+            CallMediaEvent.AudioMuting -> {
+                handleCSReportAudioMuting(data)
+            }
+
+            CallMediaEvent.ConnectionHolding -> {
+                handleCSReportConnectionHolding(data)
+            }
+
+            CallMediaEvent.SentDTMF -> {
+                handleCSReportSentDTMF(data)
+            }
+
+            else -> { /* per-call events handled by dynamic receivers in startCall() */ }
         }
+    }
 
     override fun onBind(intent: Intent?): IBinder = binder
 
     override fun onCreate() {
         super.onCreate()
         logger.d("onCreate")
-        // Register only the events that connectionServicePerformReceiver actually handles.
-        // OngoingCall/OutgoingFailure go to per-call receivers in startCall().
-        // IncomingFailure is not handled here and is excluded to avoid noise.
-        val globalEvents: List<ConnectionEvent> =
-            listOf(
-                CallLifecycleEvent.DidPushIncomingCall,
-                CallLifecycleEvent.DeclineCall,
-                CallLifecycleEvent.HungUp,
-                CallLifecycleEvent.ConnectionNotFound,
-                CallLifecycleEvent.AnswerCall,
-                CallMediaEvent.AudioDeviceSet,
-                CallMediaEvent.AudioDevicesUpdate,
-                CallMediaEvent.AudioMuting,
-                CallMediaEvent.ConnectionHolding,
-                CallMediaEvent.SentDTMF,
-            )
-        core.registerConnectionEvents(
-            baseContext,
-            globalEvents,
-            connectionServicePerformReceiver,
-        )
+        core.addConnectionEventListener(this)
         isRunning = true
         // Ask :callkeep_core to re-fire AnswerCall for every connection that was already
         // answered before this service started (cold-start race: the user answers via the
@@ -1175,11 +1153,7 @@ class ForegroundService :
     override fun onDestroy() {
         super.onDestroy()
         logger.d("onDestroy")
-        // Unregister the service from receiving connection service perform events
-        core.unregisterConnectionEvents(
-            baseContext,
-            connectionServicePerformReceiver,
-        )
+        core.removeConnectionEventListener(this)
 
         pendingCallCleanupsByCallId.values.toList().forEach { it() }
         pendingCallCleanupsByCallId.clear()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -42,7 +42,6 @@ import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
-import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.incoming_call.IncomingCallRelease
 import com.webtrit.callkeep.services.services.incoming_call.IncomingCallService
@@ -64,7 +63,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * Lifecycle:
  * - Bound to the activity lifecycle: starts when activity is active, stops when unbound.
- * - Registers and unregisters itself with [ConnectionServicePerformBroadcaster] for communication.
+ * - Registers and unregisters itself via [com.webtrit.callkeep.services.core.CallkeepCore] for connection events.
  */
 @Keep
 class ForegroundService :
@@ -194,9 +193,9 @@ class ForegroundService :
                 CallMediaEvent.ConnectionHolding,
                 CallMediaEvent.SentDTMF,
             )
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            globalEvents,
+        core.registerConnectionEvents(
             baseContext,
+            globalEvents,
             connectionServicePerformReceiver,
         )
         isRunning = true
@@ -298,7 +297,7 @@ class ForegroundService :
             // is registered (i.e., between pendingCallCleanupsByCallId.put and registerConnectionPerformReceiver).
             receiver?.let {
                 try {
-                    ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, it)
+                    core.unregisterConnectionEvents(baseContext, it)
                 } catch (_: IllegalArgumentException) {
                 }
             }
@@ -367,9 +366,9 @@ class ForegroundService :
                 }
             }
 
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            listOf(CallLifecycleEvent.OngoingCall, CallLifecycleEvent.OutgoingFailure),
+        core.registerConnectionEvents(
             baseContext,
+            listOf(CallLifecycleEvent.OngoingCall, CallLifecycleEvent.OutgoingFailure),
             receiver!!,
             exported = false,
         )
@@ -713,7 +712,7 @@ class ForegroundService :
         tearDownTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
         tearDownAckReceiver?.let {
             runCatching {
-                ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, it)
+                core.unregisterConnectionEvents(baseContext, it)
             }
         }
 
@@ -725,7 +724,7 @@ class ForegroundService :
             tearDownTimeoutRunnable = null
             tearDownAckReceiver?.let {
                 runCatching {
-                    ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, it)
+                    core.unregisterConnectionEvents(baseContext, it)
                 }
             }
             tearDownAckReceiver = null
@@ -752,9 +751,9 @@ class ForegroundService :
                 }
             }
 
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            listOf(CallCommandEvent.TearDownComplete),
+        core.registerConnectionEvents(
             baseContext,
+            listOf(CallCommandEvent.TearDownComplete),
             tearDownAckReceiver!!,
             exported = false,
         )
@@ -1177,7 +1176,7 @@ class ForegroundService :
         super.onDestroy()
         logger.d("onDestroy")
         // Unregister the service from receiving connection service perform events
-        ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(
+        core.unregisterConnectionEvents(
             baseContext,
             connectionServicePerformReceiver,
         )
@@ -1207,7 +1206,7 @@ class ForegroundService :
         tearDownTimeoutRunnable = null
         tearDownAckReceiver?.let {
             runCatching {
-                ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, it)
+                core.unregisterConnectionEvents(baseContext, it)
             }
         }
         tearDownAckReceiver = null

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -2,10 +2,10 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.app.Notification
 import android.app.Service
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -26,14 +26,18 @@ import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.models.toPCallkeepIncomingCallData
 import com.webtrit.callkeep.notifications.IncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
+import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 import com.webtrit.callkeep.services.common.DefaultIsolateLaunchPolicy
 import com.webtrit.callkeep.services.core.CallkeepCore
+import com.webtrit.callkeep.services.core.ConnectionEventListener
 import com.webtrit.callkeep.services.services.incoming_call.handlers.CallLifecycleHandler
 import com.webtrit.callkeep.services.services.incoming_call.handlers.FlutterIsolateHandler
 import com.webtrit.callkeep.services.services.incoming_call.handlers.IncomingCallHandler
 
 @Keep
-class IncomingCallService : Service() {
+class IncomingCallService :
+    Service(),
+    ConnectionEventListener {
     private val incomingCallNotificationBuilder by lazy { IncomingCallNotificationBuilder() }
 
     // Held while an incoming call is ringing. Wakes the screen on devices where
@@ -54,31 +58,21 @@ class IncomingCallService : Service() {
 
     fun getCallLifecycleHandler(): CallLifecycleHandler = callLifecycleHandler
 
-    private val connectionService =
-        listOf(
-            CallLifecycleEvent.AnswerCall,
-        )
-
-    private val connectionServicePerformReceiver =
-        object : BroadcastReceiver() {
-            override fun onReceive(
-                context: Context?,
-                intent: Intent?,
-            ) {
-                val metadata = intent?.extras?.let(CallMetadata::fromBundleOrNull)
-
-                when (intent?.action) {
-                    // Listen connection service actions (and try to notify isolate if it background)
-                    CallLifecycleEvent.AnswerCall.name -> performAnswerCall(metadata!!)
-                    // DeclineCall and HungUp are handled via IC_RELEASE_WITH_DECLINE intent
-                    // (triggered from PhoneConnection.onDisconnect → cancelIncomingNotification).
-                    // Handling them here as well would cause a double performEndCall: once from
-                    // handleRelease and once from this receiver, racing to tear down the WebSocket
-                    // before the SIP BYE is sent. The IC_RELEASE_WITH_DECLINE path is the single
-                    // authoritative source for decline teardown.
-                }
-            }
+    override fun onConnectionEvent(
+        event: ConnectionEvent,
+        data: Bundle?,
+    ) {
+        // Only handle AnswerCall. DeclineCall and HungUp are handled via IC_RELEASE_WITH_DECLINE
+        // intent (triggered from PhoneConnection.onDisconnect -> cancelIncomingNotification).
+        // Handling them here as well would cause a double performEndCall: once from handleRelease
+        // and once from this listener, racing to tear down the WebSocket before the SIP BYE is
+        // sent. The IC_RELEASE_WITH_DECLINE path is the single authoritative source for decline
+        // teardown.
+        if (event == CallLifecycleEvent.AnswerCall) {
+            val metadata = data?.let(CallMetadata::fromBundleOrNull) ?: return
+            performAnswerCall(metadata)
         }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -108,12 +102,7 @@ class IncomingCallService : Service() {
 
         Log.d(TAG, "IncomingCallService created")
 
-        // Register the service to receive connection service perform events
-        CallkeepCore.instance.registerConnectionEvents(
-            this,
-            connectionService,
-            connectionServicePerformReceiver,
-        )
+        CallkeepCore.instance.addConnectionEventListener(this)
 
         isolateHandler =
             FlutterIsolateHandler(this@IncomingCallService, this@IncomingCallService) {
@@ -180,11 +169,7 @@ class IncomingCallService : Service() {
 
         setRunning(false)
         releaseScreenWakeLock()
-        // Unregister the service from receiving connection service perform events
-        CallkeepCore.instance.unregisterConnectionEvents(
-            this,
-            connectionServicePerformReceiver,
-        )
+        CallkeepCore.instance.removeConnectionEventListener(this)
 
         stopForeground(STOP_FOREGROUND_REMOVE)
         isolateHandler.cleanup()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -26,8 +26,8 @@ import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.models.toPCallkeepIncomingCallData
 import com.webtrit.callkeep.notifications.IncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
-import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.common.DefaultIsolateLaunchPolicy
+import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.incoming_call.handlers.CallLifecycleHandler
 import com.webtrit.callkeep.services.services.incoming_call.handlers.FlutterIsolateHandler
 import com.webtrit.callkeep.services.services.incoming_call.handlers.IncomingCallHandler
@@ -109,9 +109,9 @@ class IncomingCallService : Service() {
         Log.d(TAG, "IncomingCallService created")
 
         // Register the service to receive connection service perform events
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            connectionService,
+        CallkeepCore.instance.registerConnectionEvents(
             this,
+            connectionService,
             connectionServicePerformReceiver,
         )
 
@@ -181,7 +181,7 @@ class IncomingCallService : Service() {
         setRunning(false)
         releaseScreenWakeLock()
         // Unregister the service from receiving connection service perform events
-        ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(
+        CallkeepCore.instance.unregisterConnectionEvents(
             this,
             connectionServicePerformReceiver,
         )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -9,9 +9,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.os.PowerManager
 import androidx.annotation.Keep
 import androidx.lifecycle.Lifecycle
@@ -20,7 +18,6 @@ import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.PHandle
 import com.webtrit.callkeep.PHostBackgroundSignalingIsolateApi
-import com.webtrit.callkeep.common.CallDataConst
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.FlutterEngineHelper
 import com.webtrit.callkeep.common.Log
@@ -35,12 +32,9 @@ import com.webtrit.callkeep.models.toCallHandle
 import com.webtrit.callkeep.notifications.ForegroundCallNotificationBuilder
 import com.webtrit.callkeep.notifications.ForegroundCallNotificationBuilder.Companion.ACTION_RESTORE_NOTIFICATION
 import com.webtrit.callkeep.services.broadcaster.ActivityLifecycleBroadcaster
-import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.SignalingStatusBroadcaster
 import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.signaling.workers.SignalingServiceBootWorker
-import java.util.Collections
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A foreground service that manages the call state and Flutter background isolate.
@@ -294,151 +288,46 @@ class SignalingIsolateService :
     /**
      * Ends a single active call identified by [callId].
      *
-     * Sends a hang-up intent to [PhoneConnectionService] and then waits for a
-     * [CallLifecycleEvent.HungUp] or [CallLifecycleEvent.DeclineCall] broadcast that carries
-     * the same [callId] before resolving [callback] with success. This ensures Dart is not
-     * notified before the Telecom framework has actually torn down the connection.
-     *
-     * If no confirmation broadcast arrives within [END_CALL_TIMEOUT_MS] milliseconds the
-     * callback is resolved anyway and a warning is logged, so the Dart side is never left
-     * hanging indefinitely.
-     *
-     * [AtomicBoolean] guarantees the callback is invoked exactly once even when the broadcast
-     * and the timeout race each other.
-     *
-     * @param callId  Identifier of the call to terminate.
-     * @param callback Pigeon-generated callback; receives [Result.success] on completion.
+     * Dispatches a hang-up command to [PhoneConnectionService] and resolves [callback]
+     * immediately. Telecom teardown is asynchronous — [ForegroundService] receives the
+     * resulting HungUp broadcast and notifies the main Flutter isolate
+     * via performEndCall(). The background isolate does not need to
+     * wait for Telecom confirmation before resolving: the signaling layer (WebSocket/SIP)
+     * closes independently through its own lifecycle and does not depend on this callback.
      */
     override fun endCall(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        val handler = Handler(Looper.getMainLooper())
-        val resolved = AtomicBoolean(false)
-        lateinit var receiver: BroadcastReceiver
-
-        fun finish() {
-            if (!resolved.compareAndSet(false, true)) return
-            handler.removeCallbacksAndMessages(null)
-            try {
-                CallkeepCore.instance.unregisterConnectionEvents(baseContext, receiver)
-            } catch (
-                _: IllegalArgumentException,
-            ) {
-            }
-            callback(Result.success(Unit))
-        }
-
-        receiver =
-            object : BroadcastReceiver() {
-                override fun onReceive(
-                    context: Context?,
-                    intent: Intent?,
-                ) {
-                    val id = intent?.extras?.getString(CallDataConst.CALL_ID) ?: return
-                    if (id == callId) finish()
-                }
-            }
-
-        CallkeepCore.instance.registerConnectionEvents(
-            baseContext,
-            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
-            receiver,
-            exported = false,
-        )
-
-        handler.postDelayed({
-            Log.w(TAG, "endCall timeout waiting for confirmation, callId: $callId")
-            finish()
-        }, END_CALL_TIMEOUT_MS)
-
         CallkeepCore.instance.startHungUpCall(CallMetadata(callId = callId))
+        callback(Result.success(Unit))
     }
 
     /**
      * Tears down all active calls managed by [PhoneConnectionService].
      *
-     * Snapshots the currently tracked connections before issuing the teardown intent:
+     * When there are active or pending calls, [sendTearDownConnections] is used so that
+     * [PhoneConnectionService] calls hungUp() on every [PhoneConnection], which fires
+     * HungUp broadcasts that [ForegroundService] receives and forwards to the main Flutter
+     * isolate via performEndCall(). When there are no active calls, [tearDownService] resets
+     * service state for the next session.
      *
-     * - **No active connections** — teardown is sent and [callback] is resolved immediately,
-     *   since there are no broadcasts to wait for.
-     * - **One or more active connections** — a [BroadcastReceiver] is registered for
-     *   [CallLifecycleEvent.HungUp] / [CallLifecycleEvent.DeclineCall]. An [AtomicInteger]
-     *   counts down each arriving broadcast; [callback] is resolved once the counter reaches
-     *   zero, meaning every tracked connection has confirmed teardown.
-     *
-     * A [END_CALL_TIMEOUT_MS]-millisecond safety timeout resolves the callback and unregisters
-     * the receiver if not all confirmations arrive in time, logging how many were still pending.
-     *
-     * [AtomicBoolean] guarantees the callback is invoked exactly once regardless of whether
-     * the countdown or the timeout wins the race.
+     * The callback is resolved immediately after dispatching the teardown command. The
+     * signaling layer (WebSocket/SIP) closes independently through its own lifecycle and
+     * does not depend on Telecom teardown confirmation.
      *
      * @param callback Pigeon-generated callback; receives [Result.success] on completion.
      */
     override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
-        // Union promoted connections and pending calls to cover the broadcast-lag window:
-        // CS may have created a PhoneConnection and be about to send DidPushIncomingCall,
-        // but the core shadow has not yet received the broadcast and promoted the call.
-        // Including pending call IDs ensures we register a HungUp listener for them too;
-        // the 5-second safety timeout handles the case where CS had no connection for a
-        // pending ID (i.e. the call was truly still queued and tearDown clears it silently).
         val core = CallkeepCore.instance
         val allCallIds = core.getAll().map { it.callId }.toSet() + core.getPendingCallIds()
 
         if (allCallIds.isEmpty()) {
             core.tearDownService()
-            callback(Result.success(Unit))
-            return
+        } else {
+            core.sendTearDownConnections()
         }
-
-        val pendingIds = Collections.synchronizedSet(allCallIds.toMutableSet())
-        val handler = Handler(Looper.getMainLooper())
-        val resolved = AtomicBoolean(false)
-        lateinit var receiver: BroadcastReceiver
-
-        fun finish() {
-            if (!resolved.compareAndSet(false, true)) return
-            handler.removeCallbacksAndMessages(null)
-            try {
-                CallkeepCore.instance.unregisterConnectionEvents(baseContext, receiver)
-            } catch (
-                _: IllegalArgumentException,
-            ) {
-            }
-            callback(Result.success(Unit))
-        }
-
-        receiver =
-            object : BroadcastReceiver() {
-                override fun onReceive(
-                    context: Context?,
-                    intent: Intent?,
-                ) {
-                    val id = intent?.extras?.getString(CallDataConst.CALL_ID) ?: return
-                    if (pendingIds.remove(id) && pendingIds.isEmpty()) finish()
-                }
-            }
-
-        CallkeepCore.instance.registerConnectionEvents(
-            baseContext,
-            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
-            receiver,
-            exported = false,
-        )
-
-        handler.postDelayed({
-            Log.w(TAG, "endAllCalls timeout waiting for ${pendingIds.size} remaining confirmation(s)")
-            finish()
-        }, END_CALL_TIMEOUT_MS)
-
-        // When there are active or pending calls, sendTearDownConnections() must be used
-        // instead of tearDownService(), because it calls hungUp() on every PhoneConnection,
-        // which fires HungUp broadcasts.  ForegroundService receives those broadcasts and
-        // calls performEndCall() on the Flutter delegate, which is the expected behaviour.
-        // tearDownService() only updates sensor state and does not send HungUp broadcasts.
-        // The empty-call shortcut above may safely call tearDownService(), since there are
-        // no connections to notify.
-        CallkeepCore.instance.sendTearDownConnections()
+        callback(Result.success(Unit))
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -446,7 +335,6 @@ class SignalingIsolateService :
     companion object {
         private const val TAG = "SignalingIsolateService"
         private const val WAKE_LOCK_TAG = "com.webtrit.callkeep:SignalingIsolateService.Lock"
-        private const val END_CALL_TIMEOUT_MS = 5_000L
 
         var isRunning = false
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/signaling/SignalingIsolateService.kt
@@ -36,7 +36,6 @@ import com.webtrit.callkeep.notifications.ForegroundCallNotificationBuilder
 import com.webtrit.callkeep.notifications.ForegroundCallNotificationBuilder.Companion.ACTION_RESTORE_NOTIFICATION
 import com.webtrit.callkeep.services.broadcaster.ActivityLifecycleBroadcaster
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
-import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadcaster
 import com.webtrit.callkeep.services.broadcaster.SignalingStatusBroadcaster
 import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.signaling.workers.SignalingServiceBootWorker
@@ -322,7 +321,7 @@ class SignalingIsolateService :
             if (!resolved.compareAndSet(false, true)) return
             handler.removeCallbacksAndMessages(null)
             try {
-                ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, receiver)
+                CallkeepCore.instance.unregisterConnectionEvents(baseContext, receiver)
             } catch (
                 _: IllegalArgumentException,
             ) {
@@ -341,9 +340,9 @@ class SignalingIsolateService :
                 }
             }
 
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
+        CallkeepCore.instance.registerConnectionEvents(
             baseContext,
+            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
             receiver,
             exported = false,
         )
@@ -401,7 +400,7 @@ class SignalingIsolateService :
             if (!resolved.compareAndSet(false, true)) return
             handler.removeCallbacksAndMessages(null)
             try {
-                ConnectionServicePerformBroadcaster.unregisterConnectionPerformReceiver(baseContext, receiver)
+                CallkeepCore.instance.unregisterConnectionEvents(baseContext, receiver)
             } catch (
                 _: IllegalArgumentException,
             ) {
@@ -420,9 +419,9 @@ class SignalingIsolateService :
                 }
             }
 
-        ConnectionServicePerformBroadcaster.registerConnectionPerformReceiver(
-            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
+        CallkeepCore.instance.registerConnectionEvents(
             baseContext,
+            listOf(CallLifecycleEvent.HungUp, CallLifecycleEvent.DeclineCall),
             receiver,
             exported = false,
         )

--- a/webtrit_callkeep_android/docs/background-services.md
+++ b/webtrit_callkeep_android/docs/background-services.md
@@ -28,12 +28,31 @@ triggers the callkeep stack to register the call with Telecom.
   callback has already been registered.
 - Stopped by `BackgroundSignalingIsolateBootstrapApi.stopService()`.
 
-### Broadcast Receivers (internal)
+### Event Sources (internal)
+
+`SignalingIsolateService` receives two categories of intra-process events via its own
+`BroadcastReceiver` instances (not through `CallkeepCore`):
 
 - `signalingStatusReceiver` — listens for `SignalingStatusBroadcaster` events (e.g., signaling
   connected/disconnected) and forwards them to the Flutter isolate.
 - `lifecycleEventReceiver` — listens for `ActivityLifecycleBroadcaster` events so the isolate
   knows whether the foreground UI is active.
+
+These are intra-process broadcasts and are separate from `:callkeep_core` cross-process events.
+Replacing them with `SharedFlow`/`StateFlow` is deferred to a future iteration.
+
+### Pigeon Host API: `PHostBackgroundSignalingIsolateApi`
+
+Commands arriving from the background signaling Flutter isolate:
+
+| Method          | Behavior                                                                                   |
+|-----------------|--------------------------------------------------------------------------------------------|
+| `incomingCall`  | Builds `CallMetadata` and delegates to `CallkeepCore.startIncomingCall()`                  |
+| `endCall`       | Dispatches `CallkeepCore.startHungUpCall()` and resolves immediately                       |
+| `endAllCalls`   | Dispatches `tearDownService()` or `sendTearDownConnections()`; resolves immediately        |
+
+Both `endCall` and `endAllCalls` resolve their callbacks immediately after dispatching.
+The signaling layer (WebSocket/SIP) closes via its own lifecycle independently of Telecom teardown.
 
 ### Flutter Engine
 
@@ -59,6 +78,8 @@ registered by `BackgroundSignalingIsolateBootstrapApi.initializeSignalingService
 
 **Annotation**: `@Keep`
 
+**Implements**: `ConnectionEventListener`
+
 **Type**: One-shot foreground service (`foregroundServiceType=phoneCall`)
 
 ### Responsibility
@@ -77,10 +98,20 @@ Spawned when an FCM push notification (or SMS trigger) announces an incoming cal
       background message handler).
   - `NotificationManager.showIncomingCallNotification()` (from FCM handler code).
 - `onCreate()` — calls `startForeground()` with a placeholder notification immediately to avoid
-  Android's 10-second ANR window for foreground service start.
+  Android's 10-second ANR window for foreground service start; subscribes to `CallkeepCore`
+  events via `CallkeepCore.instance.addConnectionEventListener(this)`.
 - `onStartCommand()` — replaces placeholder with the actual incoming-call notification; delegates
   to `IncomingCallHandler` and `CallLifecycleHandler`.
+- `onDestroy()` — calls `CallkeepCore.instance.removeConnectionEventListener(this)`.
 - `release()` — stops the foreground service (called after call ends or timeout).
+
+### Connection Event Listener
+
+`IncomingCallService` implements `ConnectionEventListener` and receives events routed by
+`CallkeepCore`. It only acts on `AnswerCall` — when the system UI or the user taps answer,
+`PhoneConnectionService` fires `AnswerCall` which `onConnectionEvent()` forwards to
+`CallLifecycleHandler.performAnswerCall()`. `DeclineCall` and `HungUp` are handled via the
+`IC_RELEASE_WITH_DECLINE` intent path instead to avoid a double `performEndCall` race.
 
 ### Key Handlers (Composition)
 
@@ -147,3 +178,4 @@ the signaling connection is re-established automatically.
 - [pigeon-apis.md](pigeon-apis.md) — bootstrap API definitions
 - [notifications.md](notifications.md) — notification builders used by these services
 - [foreground-service.md](foreground-service.md) — coordinates with `ActiveCallService`
+- [callkeep-core.md](callkeep-core.md) — `ConnectionEventListener` API used by `IncomingCallService`

--- a/webtrit_callkeep_android/docs/callkeep-core.md
+++ b/webtrit_callkeep_android/docs/callkeep-core.md
@@ -8,13 +8,15 @@
 ## Responsibility
 
 `CallkeepCore` is the single facade used by the **main process** for all interactions with the
-`:callkeep_core` process. It combines two concerns:
+`:callkeep_core` process. It combines three concerns:
 
 1. **State queries** — reads the shadow call state held in `MainProcessConnectionTracker`.
 2. **Command dispatch** — sends `startService` intents or broadcasts to `PhoneConnectionService`.
+3. **Event routing** — receives all `:callkeep_core` broadcasts via a single internal receiver and
+   fans them out to registered `ConnectionEventListener` subscribers.
 
-All main-process code that needs to know call state or trigger a Telecom action goes through
-`CallkeepCore.instance`, never through `PhoneConnectionService` directly.
+All main-process code that needs to know call state, trigger a Telecom action, or subscribe to
+connection events goes through `CallkeepCore.instance`.
 
 ## Access Pattern
 
@@ -41,10 +43,39 @@ val meta = core.get(callId)
 State is backed by `MainProcessConnectionTracker`;
 see [connection-tracker.md](connection-tracker.md).
 
+## Connection Event Listener API
+
+`InProcessCallkeepCore` holds a single lazy `BroadcastReceiver` (`globalReceiver`) that listens
+to all `:callkeep_core` broadcasts. It is registered on the first `addConnectionEventListener`
+call and unregistered when the last listener is removed (ref-counted). All registered listeners
+receive events via `onConnectionEvent(event, data)` on the main thread.
+
+```kotlin
+// Subscribe (e.g. in Service.onCreate())
+CallkeepCore.instance.addConnectionEventListener(this)
+
+// Unsubscribe (e.g. in Service.onDestroy())
+CallkeepCore.instance.removeConnectionEventListener(this)
+```
+
+| Method                                | Description                                              |
+|---------------------------------------|----------------------------------------------------------|
+| `addConnectionEventListener(l)`       | Register a persistent global subscriber                  |
+| `removeConnectionEventListener(l)`    | Unregister; tears down globalReceiver when list is empty |
+| `registerConnectionEvents(...)`       | Register a temporary per-call dynamic receiver           |
+| `unregisterConnectionEvents(...)`     | Unregister a temporary receiver                          |
+
+**Global events** (routed to all `ConnectionEventListener` subscribers):
+`DidPushIncomingCall`, `DeclineCall`, `HungUp`, `ConnectionNotFound`, `AnswerCall`,
+`AudioDeviceSet`, `AudioDevicesUpdate`, `AudioMuting`, `ConnectionHolding`, `SentDTMF`.
+
+**Per-call dynamic receivers** (registered ad-hoc, not via listener):
+`OngoingCall`, `OutgoingFailure`, `IncomingFailure`, `TearDownComplete`.
+
 ## State Mutation API
 
-These are called **from broadcast handlers in `ForegroundService`** when `:callkeep_core` reports
-events. They update `MainProcessConnectionTracker`.
+These are called **from `onConnectionEvent()` in `ForegroundService`** when `:callkeep_core`
+reports events via `CallkeepCore`. They update `MainProcessConnectionTracker`.
 
 | Method                             | Triggered by                       | Effect                          |
 |------------------------------------|------------------------------------|---------------------------------|
@@ -92,6 +123,7 @@ These send intents / broadcasts to `PhoneConnectionService` in `:callkeep_core`.
 ## Related Components
 
 - [connection-tracker.md](connection-tracker.md) — state storage backend
-- [foreground-service.md](foreground-service.md) — calls mutation API from broadcast handlers
+- [foreground-service.md](foreground-service.md) — implements `ConnectionEventListener`, calls mutation API from `onConnectionEvent()`
+- [background-services.md](background-services.md) — `IncomingCallService` also implements `ConnectionEventListener`
 - [phone-connection-service.md](phone-connection-service.md) — receives commands dispatched here
-- [ipc-broadcasting.md](ipc-broadcasting.md) — broadcast events that drive state mutations
+- [ipc-broadcasting.md](ipc-broadcasting.md) — broadcast events routed through `globalReceiver`

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -4,7 +4,7 @@
 
 **Extends**: `Service`
 
-**Implements**: `PHostApi` (Pigeon-generated)
+**Implements**: `PHostApi` (Pigeon-generated), `ConnectionEventListener`
 
 **Annotation**: `@Keep` (must not be renamed or removed by ProGuard/R8)
 
@@ -14,8 +14,8 @@
 
 - Serves as a bound service that the Flutter activity binds to for its lifetime.
 - Implements the `PHostApi` Pigeon interface — all call-control commands from Dart arrive here.
-- Receives call lifecycle events from `:callkeep_core` via local broadcasts and forwards them to
-  the Flutter layer via `PDelegateFlutterApi`.
+- Implements `ConnectionEventListener` — receives call lifecycle events from `CallkeepCore` and
+  forwards them to the Flutter layer via `PDelegateFlutterApi`.
 - Manages phone account registration and notification channels.
 - Bridges Android Telecom (indirect, via `CallkeepCore`) with the Flutter/Dart world.
 
@@ -23,7 +23,8 @@
 
 ### `onCreate()`
 
-- Registers `connectionServicePerformReceiver` (broadcast receiver for `:callkeep_core` events).
+- Calls `CallkeepCore.instance.addConnectionEventListener(this)` to subscribe to all
+  `:callkeep_core` events routed through the core's single global receiver.
 - Sends `SyncConnectionState` command to `:callkeep_core` — if the service was killed and
   restarted, `:callkeep_core` re-emits current connection state so the main process catches up.
 
@@ -33,7 +34,7 @@
 
 ### `onDestroy()`
 
-- Unregisters the broadcast receiver.
+- Calls `CallkeepCore.instance.removeConnectionEventListener(this)` to unsubscribe.
 - Tears down audio and notification managers.
 
 ## Pigeon Host API Implementation (`PHostApi`)
@@ -68,9 +69,14 @@
 | `setAudioDevice(callId, device)` | `CallkeepCore.setAudioDevice()`                                                                                        |
 | `sendDTMF(callId, digit)`        | `CallkeepCore.startSendDtmf()`                                                                                         |
 
-## Broadcast Receiver: `connectionServicePerformReceiver`
+## Connection Event Listener: `onConnectionEvent()`
 
-Listens for events dispatched by `PhoneConnectionService` in `:callkeep_core`.
+Events arrive from `CallkeepCore` via `onConnectionEvent(event, data)`. `CallkeepCore` holds a
+single `globalReceiver` that receives all `:callkeep_core` broadcasts and fans them out to every
+registered `ConnectionEventListener`. `ForegroundService` does not register its own
+`BroadcastReceiver` directly.
+
+**Global events** (received via `ConnectionEventListener`):
 
 | Event                 | Handler                               | Main Action                                                              |
 |-----------------------|---------------------------------------|--------------------------------------------------------------------------|
@@ -78,16 +84,21 @@ Listens for events dispatched by `PhoneConnectionService` in `:callkeep_core`.
 | `AnswerCall`          | `handleCSReportAnswerCall()`          | `markAnswered()` in tracker, call `performAnswerCall()` on Dart delegate |
 | `DeclineCall`         | `handleCSReportDeclineCall()`         | `markTerminated()`, call `performEndCall()`                              |
 | `HungUp`              | `handleCSReportDeclineCall()`         | Same as DeclineCall                                                      |
-| `OngoingCall`         | `handleCSReportOngoingCall()`         | Promote outgoing call, notify Dart                                       |
-| `OutgoingFailure`     | `handleCSReportOutgoingFailure()`     | `markTerminated()`, notify Dart of failure                               |
-| `IncomingFailure`     | `handleCSReportIncomingFailure()`     | `markTerminated()`, notify Dart of failure                               |
 | `ConnectionNotFound`  | `handleCSConnectionNotFound()`        | Synthesize HungUp — `performEndCall()`                                   |
-| `TearDownComplete`    | Inline lambda                         | Completes the tearDown deferred                                          |
 | `AudioMuting`         | Inline                                | Call `performMuteCall()` on Dart delegate                                |
 | `AudioDeviceSet`      | Inline                                | Call `performSetAudioDevice()`                                           |
 | `AudioDevicesUpdate`  | Inline                                | Call `performUpdateAudioDevices()`                                       |
 | `ConnectionHolding`   | Inline                                | Call `performHoldCall()`                                                 |
 | `SentDTMF`            | Inline                                | Call `performSendDTMF()`                                                 |
+
+**Per-call dynamic receivers** (registered ad-hoc via `CallkeepCore.registerConnectionEvents()`):
+
+| Event             | Handler                           | Main Action                              |
+|-------------------|-----------------------------------|------------------------------------------|
+| `OngoingCall`     | `handleCSReportOngoingCall()`     | Promote outgoing call, notify Dart       |
+| `OutgoingFailure` | `handleCSReportOutgoingFailure()` | `markTerminated()`, notify Dart          |
+| `IncomingFailure` | `handleCSReportIncomingFailure()` | `markTerminated()`, notify Dart          |
+| `TearDownComplete`| Inline lambda                     | Completes the `tearDown()` deferred      |
 
 ## Duplicate-Notification Guards
 
@@ -103,4 +114,5 @@ these before dispatching:
 - [callkeep-core.md](callkeep-core.md) — all Telecom commands go through here
 - [connection-tracker.md](connection-tracker.md) — state mutated here on broadcast events
 - [pigeon-apis.md](pigeon-apis.md) — `PHostApi` and `PDelegateFlutterApi` definitions
-- [ipc-broadcasting.md](ipc-broadcasting.md) — events received by the broadcast receiver
+- [callkeep-core.md](callkeep-core.md) — `ConnectionEventListener` API and event routing
+- [ipc-broadcasting.md](ipc-broadcasting.md) — cross-process broadcast transport

--- a/webtrit_callkeep_android/docs/ipc-broadcasting.md
+++ b/webtrit_callkeep_android/docs/ipc-broadcasting.md
@@ -84,14 +84,22 @@ RECEIVER_NOT_EXPORTED)` on API 33+ and the equivalent on older versions.
 
 ## Receiver Locations
 
-| Receiver                                             | Listens For                                              |
-|------------------------------------------------------|----------------------------------------------------------|
-| `ForegroundService.connectionServicePerformReceiver` | All call lifecycle, media, and `TearDownComplete` events |
-| `PhoneConnectionService` broadcast receiver          | `NotifyPending` (only during setup)                      |
+| Receiver                                               | Listens For                                                                               |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `InProcessCallkeepCore.globalReceiver`                 | All global call lifecycle and media events; fans out to `ConnectionEventListener` subs    |
+| `ForegroundService` (via `ConnectionEventListener`)    | Global events routed by `CallkeepCore`                                                    |
+| `IncomingCallService` (via `ConnectionEventListener`)  | Global events routed by `CallkeepCore`                                                    |
+| Per-call dynamic receivers in `ForegroundService`      | `OngoingCall`, `OutgoingFailure`, `IncomingFailure`, `TearDownComplete`                   |
+| `PhoneConnectionService` broadcast receiver            | `NotifyPending` (only during setup)                                                       |
+
+`InProcessCallkeepCore` maintains a single `globalReceiver` registered via
+`ConnectionServicePerformBroadcaster`. Individual services no longer register their own receivers
+for `:callkeep_core` events — they subscribe through `CallkeepCore.addConnectionEventListener()`.
 
 ## Related Components
 
 - [phone-connection.md](phone-connection.md) — dispatches lifecycle/media events
 - [phone-connection-service.md](phone-connection-service.md) — dispatches `TearDownComplete`
-- [foreground-service.md](foreground-service.md) — receives all events, drives Dart notifications
+- [callkeep-core.md](callkeep-core.md) — routes events to `ConnectionEventListener` subscribers
+- [foreground-service.md](foreground-service.md) — implements `ConnectionEventListener`
 - [dual-process.md](dual-process.md) — overall IPC design


### PR DESCRIPTION
## Summary

- All connection event subscriptions now go through `CallkeepCore.addConnectionEventListener()` instead of individual services registering their own `BroadcastReceiver` instances against `ConnectionServicePerformBroadcaster`
- `InProcessCallkeepCore` holds a single lazy ref-counted `globalReceiver` that fans out events to all `ConnectionEventListener` subscribers
- `ForegroundService` and `IncomingCallService` implement `ConnectionEventListener` and subscribe/unsubscribe in `onCreate`/`onDestroy`
- `SignalingIsolateService.endCall` and `endAllCalls` simplified to fire-and-forget: dispatch through `CallkeepCore` and resolve callback immediately (signaling layer closes independently via its own lifecycle)
- Architecture documentation updated: `callkeep-core.md`, `foreground-service.md`, `ipc-broadcasting.md`, `background-services.md`

## Motivation

OEM devices (confirmed on Lenovo TB300FU, Android 13) suppress `sendBroadcast` calls at system_server level for intra-process communication. Centralizing event delivery through a single receiver in `CallkeepCore` reduces the number of registered receivers and isolates the problem to one place for a future iteration (replacing remaining intra-process broadcasts with `SharedFlow`/`StateFlow`).

## What changed

| Component | Before | After |
|-----------|--------|-------|
| `ForegroundService` | Own `BroadcastReceiver` registered directly | Implements `ConnectionEventListener`, subscribed via `CallkeepCore` |
| `IncomingCallService` | Own `BroadcastReceiver` registered directly | Implements `ConnectionEventListener`, subscribed via `CallkeepCore` |
| `SignalingIsolateService.endCall` | Per-call receiver + AtomicBoolean + 5s timeout | `startHungUpCall()` + immediate callback |
| `SignalingIsolateService.endAllCalls` | Per-call receiver + AtomicBoolean + 5s timeout | `tearDownService()` or `sendTearDownConnections()` + immediate callback |
| `InProcessCallkeepCore` | No listener support | Single `globalReceiver`, ref-counted, fans out to all listeners |

## Out of scope (future iteration)

`ActivityLifecycleBroadcaster` and `SignalingStatusBroadcaster` (intra-process, used only by `SignalingIsolateService`) are still broadcasts and will be replaced with `SharedFlow`/`StateFlow` separately.