### PR TITLE
feat(example): add per-suite integration test runner scripts

### DIFF
--- a/webtrit_callkeep/example/run_integration_tests.sh
+++ b/webtrit_callkeep/example/run_integration_tests.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Run all integration test files on a device or in Chrome (web).
+# Orchestrator: run all integration test files on a device or in Chrome (web).
 #
 # Android (default):
-#   Each file is run in isolation because `flutter test integration_test/`
-#   launches all files in parallel, and concurrent setUp/tearDown calls share
-#   the same Android Telecom service, leading to duplicate connections and
-#   wedged state.
-#
-#   Between files the app is force-stopped and we wait until both OS processes
-#   (main + :callkeep_core) are confirmed dead before the next file starts.
+#   Each file is run in isolation via its dedicated script under tools/.
+#   Each script force-stops the app and waits for both OS processes
+#   (main + :callkeep_core) to be confirmed dead before and after the test,
+#   preventing duplicate Telecom connections and wedged state between files.
 #
 # Web:
 #   All test files are combined in integration_test/all_tests.dart and run in
@@ -22,11 +19,11 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHROMEDRIVER_PORT=4444
 
-# ---- Web mode ------------------------------------------------------------
+# ---- Web mode ----------------------------------------------------------------
 if [[ "${1:-}" == "--web" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   echo "  [web] Killing any existing chromedriver on port $CHROMEDRIVER_PORT..."
   lsof -ti tcp:$CHROMEDRIVER_PORT | xargs kill -9 2>/dev/null || true
   sleep 1
@@ -44,121 +41,48 @@ if [[ "${1:-}" == "--web" ]]; then
   exit $?
 fi
 
-# ---- Android mode --------------------------------------------------------
-DEVICE_FLAG=()
-ADB_SERIAL_FLAG=()
+# ---- Android mode ------------------------------------------------------------
+DEVICE_ARGS=()
 if [[ "${1:-}" == "-d" && -n "${2:-}" ]]; then
-  DEVICE_FLAG=(-d "$2")
-  ADB_SERIAL_FLAG=(-s "$2")
+  DEVICE_ARGS=(-d "$2")
 fi
 
-TESTS=(
-  integration_test/callkeep_client_scenarios_test.dart
-  integration_test/callkeep_connections_test.dart
-  integration_test/callkeep_delegate_edge_cases_test.dart
-  integration_test/callkeep_foreground_service_test.dart
-  integration_test/callkeep_lifecycle_test.dart
-  integration_test/callkeep_reportendcall_reasons_test.dart
-  integration_test/callkeep_state_machine_test.dart
-  integration_test/callkeep_stress_test.dart
-  integration_test/callkeep_call_scenarios_test.dart
-  # background_services_test runs last: it starts IncomingCallService which
-  # Android may restart after force-stop. Running it last avoids the 5-second
-  # ForegroundServiceDidNotStartInTimeException crash contaminating other files.
-  integration_test/callkeep_background_services_test.dart
+# Individual test scripts under tools/, in run order.
+# background_services runs last: it starts IncomingCallService which Android
+# may restart after force-stop, and running it last reduces the risk of
+# ForegroundServiceDidNotStartInTimeException crashes affecting other files.
+TEST_SCRIPTS=(
+  tools/run_callkeep_client_scenarios.sh
+  tools/run_callkeep_connections.sh
+  tools/run_callkeep_delegate_edge_cases.sh
+  tools/run_callkeep_foreground_service.sh
+  tools/run_callkeep_lifecycle.sh
+  tools/run_callkeep_reportendcall_reasons.sh
+  tools/run_callkeep_state_machine.sh
+  tools/run_callkeep_stress.sh
+  tools/run_callkeep_call_scenarios.sh
+  tools/run_callkeep_background_services.sh
 )
-
-APP_ID="com.example.example"
-
-# Inter-file cleanup: force-stop the app, free wedged Telecom connections,
-# then poll until both app processes are confirmed dead. This ensures the
-# next test file starts from a clean process state.
-#
-# Note: the app runs as two OS processes -- the main process ($APP_ID) and
-# the :callkeep_core service process ($APP_ID:callkeep_core). pidof only
-# matches exact process names, so we use `ps -A | grep` on the device to
-# detect both. The grep is run on the device so that only one adb round-trip
-# is needed per poll iteration.
-#
-# After process death we also poll `dumpsys telecom` until the mCalls section
-# no longer references our package. Telecom drains DISCONNECTING connections
-# asynchronously after force-stop; if the next test starts before Telecom
-# finishes, callkeep.setUp() fails and all tests report "did not complete [E]".
-cleanup_device() {
-  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell am force-stop "$APP_ID" 2>/dev/null || true
-  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell telecom cleanup-stuck-calls 2>/dev/null || true
-  while adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
-      "ps -A 2>/dev/null | grep -q '$APP_ID'" 2>/dev/null; do
-    sleep 1
-  done
-  # Poll dumpsys telecom until our app has no active connections.
-  # The current call state lives in the "mCalls:" section of the dump.
-  # When it is empty (no active connections from any app), our app's package
-  # will not appear between "mCalls:" and the next section header.
-  # Timeout after 30 s.
-  local deadline=$((SECONDS + 30))
-  while [[ $SECONDS -lt $deadline ]]; do
-    local dump
-    dump=$(adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
-      "dumpsys telecom 2>/dev/null" 2>/dev/null || true)
-    # Extract the mCalls section and check if our package appears in it.
-    # When no calls are active, this section is empty and APP_ID won't match.
-    local mcalls_section
-    mcalls_section=$(echo "$dump" | awk '/mCalls:/,/mCallAudioManager:/')
-    if ! echo "$mcalls_section" | grep -q "${APP_ID}"; then
-      break
-    fi
-    sleep 1
-  done
-  # Fixed safety margin for UiAutomation to release its session.
-  sleep 5
-}
-
-run_test_file() {
-  local test_file="$1"
-  # Retry once on infrastructure failures (WebSocket drop during loading).
-  # These are not test-logic failures -- they occur when the Flutter test
-  # runner cannot attach to the app after a long previous test file.
-  if flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"; then
-    return 0
-  fi
-  echo "  [retry] $test_file failed, cleaning up and retrying once..."
-  cleanup_device
-  flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"
-}
 
 PASS=0
 FAIL=0
-FAILED_FILES=()
+FAILED_SCRIPTS=()
 
-# Initial cleanup so the suite starts from a known state regardless of what
-# was running on the device before.
-echo "  [init] Cleaning up any stale app state..."
-cleanup_device
-echo "  [init] Device ready."
-
-for TEST_FILE in "${TESTS[@]}"; do
-  echo ""
-  echo "=========================================="
-  echo "Running: $TEST_FILE"
-  echo "=========================================="
-
-  if run_test_file "$TEST_FILE"; then
+for SCRIPT in "${TEST_SCRIPTS[@]}"; do
+  if "$SCRIPT_DIR/$SCRIPT" "${DEVICE_ARGS[@]+"${DEVICE_ARGS[@]}"}"; then
     PASS=$((PASS + 1))
   else
     FAIL=$((FAIL + 1))
-    FAILED_FILES+=("$TEST_FILE")
+    FAILED_SCRIPTS+=("$SCRIPT")
   fi
-
-  cleanup_device
 done
 
 echo ""
 echo "=========================================="
 echo "Results: $PASS passed, $FAIL failed"
-if [[ ${#FAILED_FILES[@]} -gt 0 ]]; then
-  echo "Failed files:"
-  for F in "${FAILED_FILES[@]}"; do
+if [[ ${#FAILED_SCRIPTS[@]} -gt 0 ]]; then
+  echo "Failed:"
+  for F in "${FAILED_SCRIPTS[@]}"; do
     echo "  - $F"
   done
   exit 1

--- a/webtrit_callkeep/example/run_integration_tests.sh
+++ b/webtrit_callkeep/example/run_integration_tests.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# Orchestrator: run all integration test files on a device or in Chrome (web).
+# Run all integration test files on a device or in Chrome (web).
 #
 # Android (default):
-#   Each file is run in isolation via its dedicated script under tools/.
-#   Each script force-stops the app and waits for both OS processes
-#   (main + :callkeep_core) to be confirmed dead before and after the test,
-#   preventing duplicate Telecom connections and wedged state between files.
+#   Each file is run in isolation because `flutter test integration_test/`
+#   launches all files in parallel, and concurrent setUp/tearDown calls share
+#   the same Android Telecom service, leading to duplicate connections and
+#   wedged state.
+#
+#   Between files the app is force-stopped and we wait until both OS processes
+#   (main + :callkeep_core) are confirmed dead before the next file starts.
 #
 # Web:
 #   All test files are combined in integration_test/all_tests.dart and run in
@@ -19,11 +22,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHROMEDRIVER_PORT=4444
 
-# ---- Web mode ----------------------------------------------------------------
+# ---- Web mode ------------------------------------------------------------
 if [[ "${1:-}" == "--web" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   echo "  [web] Killing any existing chromedriver on port $CHROMEDRIVER_PORT..."
   lsof -ti tcp:$CHROMEDRIVER_PORT | xargs kill -9 2>/dev/null || true
   sleep 1
@@ -41,48 +44,121 @@ if [[ "${1:-}" == "--web" ]]; then
   exit $?
 fi
 
-# ---- Android mode ------------------------------------------------------------
-DEVICE_ARGS=()
+# ---- Android mode --------------------------------------------------------
+DEVICE_FLAG=()
+ADB_SERIAL_FLAG=()
 if [[ "${1:-}" == "-d" && -n "${2:-}" ]]; then
-  DEVICE_ARGS=(-d "$2")
+  DEVICE_FLAG=(-d "$2")
+  ADB_SERIAL_FLAG=(-s "$2")
 fi
 
-# Individual test scripts under tools/, in run order.
-# background_services runs last: it starts IncomingCallService which Android
-# may restart after force-stop, and running it last reduces the risk of
-# ForegroundServiceDidNotStartInTimeException crashes affecting other files.
-TEST_SCRIPTS=(
-  tools/run_callkeep_client_scenarios.sh
-  tools/run_callkeep_connections.sh
-  tools/run_callkeep_delegate_edge_cases.sh
-  tools/run_callkeep_foreground_service.sh
-  tools/run_callkeep_lifecycle.sh
-  tools/run_callkeep_reportendcall_reasons.sh
-  tools/run_callkeep_state_machine.sh
-  tools/run_callkeep_stress.sh
-  tools/run_callkeep_call_scenarios.sh
-  tools/run_callkeep_background_services.sh
+TESTS=(
+  integration_test/callkeep_client_scenarios_test.dart
+  integration_test/callkeep_connections_test.dart
+  integration_test/callkeep_delegate_edge_cases_test.dart
+  integration_test/callkeep_foreground_service_test.dart
+  integration_test/callkeep_lifecycle_test.dart
+  integration_test/callkeep_reportendcall_reasons_test.dart
+  integration_test/callkeep_state_machine_test.dart
+  integration_test/callkeep_stress_test.dart
+  integration_test/callkeep_call_scenarios_test.dart
+  # background_services_test runs last: it starts IncomingCallService which
+  # Android may restart after force-stop. Running it last avoids the 5-second
+  # ForegroundServiceDidNotStartInTimeException crash contaminating other files.
+  integration_test/callkeep_background_services_test.dart
 )
+
+APP_ID="com.example.example"
+
+# Inter-file cleanup: force-stop the app, free wedged Telecom connections,
+# then poll until both app processes are confirmed dead. This ensures the
+# next test file starts from a clean process state.
+#
+# Note: the app runs as two OS processes -- the main process ($APP_ID) and
+# the :callkeep_core service process ($APP_ID:callkeep_core). pidof only
+# matches exact process names, so we use `ps -A | grep` on the device to
+# detect both. The grep is run on the device so that only one adb round-trip
+# is needed per poll iteration.
+#
+# After process death we also poll `dumpsys telecom` until the mCalls section
+# no longer references our package. Telecom drains DISCONNECTING connections
+# asynchronously after force-stop; if the next test starts before Telecom
+# finishes, callkeep.setUp() fails and all tests report "did not complete [E]".
+cleanup_device() {
+  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell am force-stop "$APP_ID" 2>/dev/null || true
+  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell telecom cleanup-stuck-calls 2>/dev/null || true
+  while adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
+      "ps -A 2>/dev/null | grep -q '$APP_ID'" 2>/dev/null; do
+    sleep 1
+  done
+  # Poll dumpsys telecom until our app has no active connections.
+  # The current call state lives in the "mCalls:" section of the dump.
+  # When it is empty (no active connections from any app), our app's package
+  # will not appear between "mCalls:" and the next section header.
+  # Timeout after 30 s.
+  local deadline=$((SECONDS + 30))
+  while [[ $SECONDS -lt $deadline ]]; do
+    local dump
+    dump=$(adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
+      "dumpsys telecom 2>/dev/null" 2>/dev/null || true)
+    # Extract the mCalls section and check if our package appears in it.
+    # When no calls are active, this section is empty and APP_ID won't match.
+    local mcalls_section
+    mcalls_section=$(echo "$dump" | awk '/mCalls:/,/mCallAudioManager:/')
+    if ! echo "$mcalls_section" | grep -q "${APP_ID}"; then
+      break
+    fi
+    sleep 1
+  done
+  # Fixed safety margin for UiAutomation to release its session.
+  sleep 5
+}
+
+run_test_file() {
+  local test_file="$1"
+  # Retry once on infrastructure failures (WebSocket drop during loading).
+  # These are not test-logic failures -- they occur when the Flutter test
+  # runner cannot attach to the app after a long previous test file.
+  if flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"; then
+    return 0
+  fi
+  echo "  [retry] $test_file failed, cleaning up and retrying once..."
+  cleanup_device
+  flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"
+}
 
 PASS=0
 FAIL=0
-FAILED_SCRIPTS=()
+FAILED_FILES=()
 
-for SCRIPT in "${TEST_SCRIPTS[@]}"; do
-  if "$SCRIPT_DIR/$SCRIPT" "${DEVICE_ARGS[@]+"${DEVICE_ARGS[@]}"}"; then
+# Initial cleanup so the suite starts from a known state regardless of what
+# was running on the device before.
+echo "  [init] Cleaning up any stale app state..."
+cleanup_device
+echo "  [init] Device ready."
+
+for TEST_FILE in "${TESTS[@]}"; do
+  echo ""
+  echo "=========================================="
+  echo "Running: $TEST_FILE"
+  echo "=========================================="
+
+  if run_test_file "$TEST_FILE"; then
     PASS=$((PASS + 1))
   else
     FAIL=$((FAIL + 1))
-    FAILED_SCRIPTS+=("$SCRIPT")
+    FAILED_FILES+=("$TEST_FILE")
   fi
+
+  cleanup_device
 done
 
 echo ""
 echo "=========================================="
 echo "Results: $PASS passed, $FAIL failed"
-if [[ ${#FAILED_SCRIPTS[@]} -gt 0 ]]; then
-  echo "Failed:"
-  for F in "${FAILED_SCRIPTS[@]}"; do
+if [[ ${#FAILED_FILES[@]} -gt 0 ]]; then
+  echo "Failed files:"
+  for F in "${FAILED_FILES[@]}"; do
     echo "  - $F"
   done
   exit 1

--- a/webtrit_callkeep/example/tools/_test_lib.sh
+++ b/webtrit_callkeep/example/tools/_test_lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Shared utilities sourced by individual test scripts and the orchestrator.
+#
+# Callers must set (or leave empty) before sourcing:
+#   DEVICE_FLAG      -- flutter -d flag, e.g. (-d abc123) or ()
+#   ADB_SERIAL_FLAG  -- adb -s flag,     e.g. (-s abc123) or ()
+#
+# parse_device_flags "$@" populates both from the -d <id> argument.
+
+APP_ID="com.example.example"
+
+# parse_device_flags: extract -d <device-id> from script arguments.
+# Sets DEVICE_FLAG and ADB_SERIAL_FLAG arrays.
+parse_device_flags() {
+  DEVICE_FLAG=()
+  ADB_SERIAL_FLAG=()
+  if [[ "${1:-}" == "-d" && -n "${2:-}" ]]; then
+    DEVICE_FLAG=(-d "$2")
+    ADB_SERIAL_FLAG=(-s "$2")
+  fi
+}
+
+# cleanup_device: force-stop the app and wait for both OS processes and
+# Telecom connections to drain before returning.
+#
+# Note: the app runs as two OS processes -- the main process ($APP_ID) and
+# the :callkeep_core service process ($APP_ID:callkeep_core). pidof only
+# matches exact process names, so we use `ps -A | grep` on the device to
+# detect both. The grep runs on the device so that only one adb round-trip
+# is needed per poll iteration.
+#
+# After process death we also poll `dumpsys telecom` until the mCalls section
+# no longer references our package. Telecom drains DISCONNECTING connections
+# asynchronously after force-stop; if the next test starts before Telecom
+# finishes, callkeep.setUp() fails and all tests report "did not complete [E]".
+cleanup_device() {
+  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell am force-stop "$APP_ID" 2>/dev/null || true
+  adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell telecom cleanup-stuck-calls 2>/dev/null || true
+  while adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
+      "ps -A 2>/dev/null | grep -q '$APP_ID'" 2>/dev/null; do
+    sleep 1
+  done
+  # Poll dumpsys telecom until our app has no active connections.
+  # The current call state lives in the "mCalls:" section of the dump.
+  # When it is empty (no active connections from any app), our app's package
+  # will not appear between "mCalls:" and the next section header.
+  # Timeout after 30 s.
+  local deadline=$((SECONDS + 30))
+  while [[ $SECONDS -lt $deadline ]]; do
+    local dump
+    dump=$(adb "${ADB_SERIAL_FLAG[@]+"${ADB_SERIAL_FLAG[@]}"}" shell \
+      "dumpsys telecom 2>/dev/null" 2>/dev/null || true)
+    local mcalls_section
+    mcalls_section=$(echo "$dump" | awk '/mCalls:/,/mCallAudioManager:/')
+    if ! echo "$mcalls_section" | grep -q "${APP_ID}"; then
+      break
+    fi
+    sleep 1
+  done
+  # Fixed safety margin for UiAutomation to release its session.
+  sleep 5
+}
+
+# run_test_file: run a single test file with one retry on infrastructure
+# failures (WebSocket drop during loading). These are not test-logic failures
+# -- they occur when the Flutter test runner cannot attach to the app after a
+# long previous test file.
+# Args: $1 = path to the test file (relative to the example directory).
+run_test_file() {
+  local test_file="$1"
+  if flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"; then
+    return 0
+  fi
+  echo "  [retry] $test_file failed, cleaning up and retrying once..."
+  cleanup_device
+  flutter test "$test_file" "${DEVICE_FLAG[@]+"${DEVICE_FLAG[@]}"}"
+}

--- a/webtrit_callkeep/example/tools/run_callkeep_background_services.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_background_services.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_background_services_test.dart in isolation.
+#
+# This test starts IncomingCallService which Android may restart after
+# force-stop. Run it last in the full suite to avoid the 5-second
+# ForegroundServiceDidNotStartInTimeException crash contaminating other files.
+#
+# Usage:
+#   ./tools/run_callkeep_background_services.sh
+#   ./tools/run_callkeep_background_services.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_background_services_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_call_scenarios.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_call_scenarios.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_call_scenarios_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_call_scenarios.sh
+#   ./tools/run_callkeep_call_scenarios.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_call_scenarios_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_client_scenarios.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_client_scenarios.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_client_scenarios_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_client_scenarios.sh
+#   ./tools/run_callkeep_client_scenarios.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_client_scenarios_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_connections.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_connections.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_connections_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_connections.sh
+#   ./tools/run_callkeep_connections.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_connections_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_delegate_edge_cases.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_delegate_edge_cases.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_delegate_edge_cases_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_delegate_edge_cases.sh
+#   ./tools/run_callkeep_delegate_edge_cases.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_delegate_edge_cases_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_foreground_service.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_foreground_service.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_foreground_service_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_foreground_service.sh
+#   ./tools/run_callkeep_foreground_service.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_foreground_service_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_lifecycle.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_lifecycle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_lifecycle_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_lifecycle.sh
+#   ./tools/run_callkeep_lifecycle.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_lifecycle_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_reportendcall_reasons.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_reportendcall_reasons.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_reportendcall_reasons_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_reportendcall_reasons.sh
+#   ./tools/run_callkeep_reportendcall_reasons.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_reportendcall_reasons_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_state_machine.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_state_machine.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_state_machine_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_state_machine.sh
+#   ./tools/run_callkeep_state_machine.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_state_machine_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS

--- a/webtrit_callkeep/example/tools/run_callkeep_stress.sh
+++ b/webtrit_callkeep/example/tools/run_callkeep_stress.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run integration_test/callkeep_stress_test.dart in isolation.
+#
+# Usage:
+#   ./tools/run_callkeep_stress.sh
+#   ./tools/run_callkeep_stress.sh -d <device-id>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=_test_lib.sh
+source "$SCRIPT_DIR/_test_lib.sh"
+
+parse_device_flags "$@"
+
+TEST_FILE="integration_test/callkeep_stress_test.dart"
+
+cd "$EXAMPLE_DIR"
+
+echo "  [init] Cleaning up before $TEST_FILE..."
+cleanup_device
+
+echo ""
+echo "=========================================="
+echo "Running: $TEST_FILE"
+echo "=========================================="
+
+run_test_file "$TEST_FILE"
+STATUS=$?
+
+cleanup_device
+
+exit $STATUS


### PR DESCRIPTION
## Summary

- Add `_test_lib.sh` with shared helpers (device selection, result reporting, colored output)
- Add `run_callkeep_*.sh` scripts for running each integration test suite in isolation
- Update `run_integration_tests.sh` to delegate to the per-suite scripts

## Test plan

- Run any `tools/run_callkeep_*.sh` script on a connected device
- Verify the suite-specific test runs and results are reported correctly