### PR TITLE
fix(ci): allow semver dots in release branch names

### DIFF
--- a/tool/scripts/branch-name-check.sh
+++ b/tool/scripts/branch-name-check.sh
@@ -12,7 +12,7 @@ if [[ "$BRANCH" == "main" || "$BRANCH" == "develop" || "$BRANCH" == "HEAD" ]]; t
   exit 0
 fi
 
-PATTERN='^(feat|feature|fix|refactor|chore|build|style|docs|release|test|ci)/[a-z0-9]+(-[a-z0-9]+)*$'
+PATTERN='^(feat|feature|fix|refactor|chore|build|style|docs|test|ci)/[a-z0-9]+(-[a-z0-9]+)*$|^release/[0-9]+\.[0-9]+\.[0-9]+$'
 if ! echo "$BRANCH" | grep -qE "$PATTERN"; then
   echo "ERROR: Branch name '$BRANCH' does not follow the naming convention." >&2
   echo "  Expected: type/description  (e.g. feat/android-background-service)" >&2


### PR DESCRIPTION
## Summary

- Branch name check script rejected `release/X.Y.Z` branches because the pattern did not allow dots
- All existing release branches (`release/0.4.1`, `release/0.4.0`, etc.) use semantic versioning with dots — the hook was added after those branches existed
- Updated pattern: non-release branches keep the original kebab-case rule; `release/` branches now match `release/X.Y.Z` (semver only)

## Test plan

- [ ] `release/0.5.0` passes the branch name check
- [ ] `release/1.0.0` passes the branch name check
- [ ] `feat/some-feature` still passes
- [ ] `release/invalid` still fails
- [ ] `release/0.5` still fails (requires full semver X.Y.Z)