### PR TITLE
fix: release MediaPlayer after stopping ringback

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -109,7 +109,10 @@ class AudioManager(
      * Stop playing the ringback sound.
      */
     fun stopRingback() {
-        ringBack?.release()
-        ringBack = null
+        try {
+            ringBack?.release()
+        } finally {
+            ringBack = null
+        }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -109,7 +109,6 @@ class AudioManager(
      * Stop playing the ringback sound.
      */
     fun stopRingback() {
-        ringBack?.stop()
         ringBack?.release()
         ringBack = null
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -109,6 +109,8 @@ class AudioManager(
      * Stop playing the ringback sound.
      */
     fun stopRingback() {
-        ringBack?.pause()
+        ringBack?.stop()
+        ringBack?.release()
+        ringBack = null
     }
 }


### PR DESCRIPTION
## Summary

- `stopRingback()` was calling `pause()` instead of fully releasing the MediaPlayer
- A paused MediaPlayer holds audio resources and can resume unexpectedly on the next `startRingback()` call
- Replaced with `stop()` + `release()` + `null` so each ringback session starts from a clean state

## Root cause

Found while investigating a bug where ringback tone continued playing after a call was force-terminated due to network loss. Even when `stopRingback()` was eventually called, `pause()` did not fully release the audio stream.

## Test plan

- [ ] Make an outgoing call — ringback plays normally
- [ ] Call gets answered — ringback stops
- [ ] Make a second outgoing call — ringback starts fresh with no leftover state
- [ ] Drop network during outgoing call — verify ringback stops when call is terminated