### PR TITLE
fix: transfer back fail

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -25,7 +25,9 @@ import java.util.concurrent.ConcurrentHashMap
  * Call state is mirrored via a combination of main-process updates (pending registration and
  * local guards) and IPC broadcasts from `:callkeep_core` for lifecycle transitions.
  */
-class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
+class MainProcessConnectionTracker internal constructor(
+    private val clock: () -> Long = System::currentTimeMillis,
+) : ConnectionTracker {
     // callId -> metadata for all known, non-terminated calls
     private val connections = ConcurrentHashMap<String, CallMetadata>()
 
@@ -36,7 +38,8 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     private val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // callIds for which the call has fully terminated (guards duplicate endCall)
-    private val terminatedCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    // Stores termination timestamp; entries are evicted lazily after TERMINATED_TTL_MS.
+    private val terminatedCallIds: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
 
     // callIds for which answerCall was requested before the PhoneConnection was created
     private val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()
@@ -145,7 +148,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
      * so that [isTerminated] returns true for duplicate endCall guards.
      */
     override fun markTerminated(callId: String) {
-        terminatedCallIds.add(callId)
+        terminatedCallIds[callId] = clock()
         connections.remove(callId)
         answeredCallIds.remove(callId)
         pendingCallIds.remove(callId)
@@ -166,8 +169,15 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     /** Returns a non-destructive snapshot of all currently pending call IDs. */
     override fun getPendingCallIds(): Set<String> = pendingCallIds.toSet()
 
-    /** Returns true if [callId] has been marked terminated. */
-    override fun isTerminated(callId: String): Boolean = terminatedCallIds.contains(callId)
+    /** Returns true if [callId] has been marked terminated within the last [TERMINATED_TTL_MS] ms. */
+    override fun isTerminated(callId: String): Boolean {
+        val ts = terminatedCallIds[callId] ?: return false
+        if (clock() - ts >= TERMINATED_TTL_MS) {
+            terminatedCallIds.remove(callId)
+            return false
+        }
+        return true
+    }
 
     /** Returns true if [callId] has been answered. */
     override fun isAnswered(callId: String): Boolean = answeredCallIds.contains(callId)
@@ -279,6 +289,10 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     override fun consumeSignalingRegistered(callId: String): Boolean = signalingRegisteredCallIds.remove(callId)
 
     companion object {
+        // Big enough to cover race conditions in the same session, but small enough to prevent 
+        // stale state from blocking new calls with same id in a future session. e.g transfer back and forth between two apps.
+        private const val TERMINATED_TTL_MS = 10_000L
+
         /**
          * Process-wide singleton. All main-process components ([ForegroundService],
          * [com.webtrit.callkeep.ConnectionsApi], etc.) share this single instance so that

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -24,12 +24,14 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 class MainProcessConnectionTrackerTest {
     private lateinit var tracker: MainProcessConnectionTracker
+    private var fakeNow = 0L
 
     private fun metadata(callId: String = "call-1") = CallMetadata(callId = callId)
 
     @Before
     fun setUp() {
-        tracker = MainProcessConnectionTracker()
+        fakeNow = 0L
+        tracker = MainProcessConnectionTracker(clock = { fakeNow })
     }
 
     // -------------------------------------------------------------------------
@@ -589,5 +591,62 @@ class MainProcessConnectionTrackerTest {
 
         val drained = tracker.drainUnconnectedPendingCallIds()
         assertFalse(drained.contains("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // terminatedCallIds TTL (10 s auto-cleanup)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isTerminated — returns true immediately after markTerminated`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        assertTrue(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `isTerminated — returns true just before TTL expires`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        fakeNow = 9_999L
+        assertTrue(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `isTerminated — returns false exactly at TTL boundary`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        fakeNow = 10_000L
+        assertFalse(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `isTerminated — returns false after TTL has passed`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.markTerminated("call-1")
+        fakeNow = 15_000L
+        assertFalse(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `isTerminated — evicts entry on expiry so repeated calls return false`() {
+        tracker.markTerminated("call-1")
+        fakeNow = 10_000L
+        assertFalse(tracker.isTerminated("call-1"))
+        // Second call must also return false (entry was removed on first expiry read)
+        assertFalse(tracker.isTerminated("call-1"))
+    }
+
+    @Test
+    fun `isTerminated — independent TTLs per call`() {
+        tracker.markTerminated("call-1")
+        fakeNow = 5_000L
+        tracker.markTerminated("call-2")
+
+        fakeNow = 10_000L
+        // call-1 terminated at t=0, now t=10_000 -> expired
+        assertFalse(tracker.isTerminated("call-1"))
+        // call-2 terminated at t=5_000, now t=10_000 -> 5 s elapsed -> still valid
+        assertTrue(tracker.isTerminated("call-2"))
     }
 }


### PR DESCRIPTION

## Description

Replaced the MutableSet<String> with a ConcurrentHashMap<String, Long> that stores the termination timestamp per call ID. isTerminated() now evicts an entry lazily on read once 10 s have elapsed, returning false.
Needed to prevent incoming calls from fail if its transfer back.

  - `markTerminated` stores `clock()` instead of set-add
  - `isTerminated` checks age and removes expired entries on read
  - Clock injected via constructor (`System::currentTimeMillis` by default)
    for deterministic unit testing
  - 6 new TTL tests cover: immediate guard, boundary, expiry, idempotency,
    independent TTLs per call ID

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
