### PR TITLE
fix(android): add TelephonyManager fallback to isTelecomSupported

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -102,13 +102,35 @@ class TelephonyUtils(
         private val logger = Log(TAG)
 
         /**
-         * Returns true if the device supports the Android Telecom framework
-         * (`android.software.telecom` system feature).
+         * Returns true if the device supports the Android Telecom framework.
          *
-         * Devices without this feature (e.g. some tablets, Android Go builds, certain OEM
-         * configurations) cannot use [TelecomManager] for call management. Callers should
-         * check this before registering a phone account or invoking any Telecom API.
+         * Checks the `android.software.telecom` system feature first. If that flag is absent,
+         * falls back to inspecting [TelephonyManager.getPhoneType]: any device with a GSM,
+         * CDMA, or SIP radio has the Telecom infrastructure available, regardless of whether
+         * the OEM advertises the feature flag.
+         *
+         * This fallback handles known OEM omissions (e.g. ASUS AI2202) where the device is a
+         * fully functional phone with Telecom support but does not declare the feature flag in
+         * its system build.
+         *
+         * Devices that return [TelephonyManager.PHONE_TYPE_NONE] (e.g. Wi-Fi-only tablets,
+         * Android Go builds) do not have Telecom infrastructure and should use the standalone
+         * call path instead.
          */
-        fun isTelecomSupported(context: Context): Boolean = context.packageManager.hasSystemFeature("android.software.telecom")
+        fun isTelecomSupported(context: Context): Boolean {
+            if (context.packageManager.hasSystemFeature("android.software.telecom")) return true
+
+            // Fallback for OEMs that have Telecom infrastructure but omit the feature flag.
+            return try {
+                val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+                val phoneType = tm?.phoneType ?: TelephonyManager.PHONE_TYPE_NONE
+                val supported = phoneType != TelephonyManager.PHONE_TYPE_NONE
+                logger.i("isTelecomSupported: feature flag absent, phoneType=$phoneType — treating Telecom as supported=$supported")
+                supported
+            } catch (e: Exception) {
+                logger.w("isTelecomSupported: fallback check failed (${e.message}), assuming no Telecom support")
+                false
+            }
+        }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -109,9 +109,8 @@ class TelephonyUtils(
          * CDMA, or SIP radio has the Telecom infrastructure available, regardless of whether
          * the OEM advertises the feature flag.
          *
-         * This fallback handles known OEM omissions (e.g. ASUS AI2202) where the device is a
-         * fully functional phone with Telecom support but does not declare the feature flag in
-         * its system build.
+         * Some OEM devices have full Telecom support but do not declare the feature flag in
+         * their system build. The fallback covers this case.
          *
          * Devices that return [TelephonyManager.PHONE_TYPE_NONE] (e.g. Wi-Fi-only tablets,
          * Android Go builds) do not have Telecom infrastructure and should use the standalone

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -99,15 +99,21 @@ class TelephonyUtils(
     companion object {
         private const val TAG = "TelephonyUtils"
 
+        // Equivalent to PackageManager.FEATURE_TELECOM (added in API 34).
+        // Defined as a local constant to avoid a lint InlinedApi warning on minSdk 26.
+        private const val FEATURE_TELECOM = "android.software.telecom"
+
         private val logger = Log(TAG)
 
         /**
          * Returns true if the device supports the Android Telecom framework.
          *
          * Checks the `android.software.telecom` system feature first. If that flag is absent,
-         * falls back to inspecting [TelephonyManager.getPhoneType]: any device with a GSM,
-         * CDMA, or SIP radio has the Telecom infrastructure available, regardless of whether
-         * the OEM advertises the feature flag.
+         * falls back to inspecting [TelephonyManager.getPhoneType]: any device whose phone
+         * type is not [TelephonyManager.PHONE_TYPE_NONE] is treated as having Telecom
+         * infrastructure available, regardless of whether the OEM advertises the feature flag.
+         * This includes common telephony types such as GSM, CDMA, and SIP, and also preserves
+         * support for any other non-NONE phone types reported by the platform.
          *
          * Some OEM devices have full Telecom support but do not declare the feature flag in
          * their system build. The fallback covers this case.
@@ -117,7 +123,7 @@ class TelephonyUtils(
          * call path instead.
          */
         fun isTelecomSupported(context: Context): Boolean {
-            if (context.packageManager.hasSystemFeature("android.software.telecom")) return true
+            if (context.packageManager.hasSystemFeature(FEATURE_TELECOM)) return true
 
             // Fallback for OEMs that have Telecom infrastructure but omit the feature flag.
             return try {
@@ -127,7 +133,7 @@ class TelephonyUtils(
                 logger.i("isTelecomSupported: feature flag absent, phoneType=$phoneType — treating Telecom as supported=$supported")
                 supported
             } catch (e: Exception) {
-                logger.w("isTelecomSupported: fallback check failed (${e.message}), assuming no Telecom support")
+                logger.w("isTelecomSupported: fallback check failed, assuming no Telecom support", e)
                 false
             }
         }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/TelephonyUtilsIsTelecomSupportedTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/TelephonyUtilsIsTelecomSupportedTest.kt
@@ -1,0 +1,57 @@
+package com.webtrit.callkeep.common
+
+import android.content.Context
+import android.os.Build
+import android.telephony.TelephonyManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class TelephonyUtilsIsTelecomSupportedTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+    }
+
+    private fun setFeatureFlag(enabled: Boolean) {
+        Shadows
+            .shadowOf(context.packageManager)
+            .setSystemFeature("android.software.telecom", enabled)
+    }
+
+    private fun setPhoneType(phoneType: Int) {
+        Shadows
+            .shadowOf(context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+            .setPhoneType(phoneType)
+    }
+
+    @Test
+    fun `returns true when feature flag is present`() {
+        setFeatureFlag(true)
+        assertTrue(TelephonyUtils.isTelecomSupported(context))
+    }
+
+    @Test
+    fun `returns true when feature flag is absent but phoneType is non-NONE`() {
+        setFeatureFlag(false)
+        setPhoneType(TelephonyManager.PHONE_TYPE_GSM)
+        assertTrue(TelephonyUtils.isTelecomSupported(context))
+    }
+
+    @Test
+    fun `returns false when feature flag is absent and phoneType is NONE`() {
+        setFeatureFlag(false)
+        setPhoneType(TelephonyManager.PHONE_TYPE_NONE)
+        assertFalse(TelephonyUtils.isTelecomSupported(context))
+    }
+}


### PR DESCRIPTION
## Problem

On some OEM devices `PackageManager.hasSystemFeature("android.software.telecom")` returns `false` despite the device being a fully functional phone with Telecom support. This caused `CallServiceRouter` to route all calls to `StandaloneCallService` instead of `PhoneConnectionService`.

`StandaloneCallService` then crashed with `SecurityException` when trying to start a foreground service with `FOREGROUND_SERVICE_TYPE_MICROPHONE` from a background push handler — the runtime `RECORD_AUDIO` permission check and foreground-eligibility check both fail in that context.

## Fix

Added a fallback check in `TelephonyUtils.isTelecomSupported()` via `TelephonyManager.phoneType`:

- If `android.software.telecom` feature flag is present — returns `true` (no behavior change)
- If the flag is absent — checks `phoneType`: any device whose phone type is not `PHONE_TYPE_NONE` is treated as having Telecom infrastructure available
- `PHONE_TYPE_NONE` — Wi-Fi-only tablets, Android Go builds — returns `false`, standalone path remains correct

Also addressed review feedback:
- Replaced raw feature string with a local `FEATURE_TELECOM` constant to avoid lint warnings on minSdk 26
- KDoc updated to accurately reflect the `!= PHONE_TYPE_NONE` condition
- Exception passed to `logger.w` for full stack trace on fallback failure
- Added Robolectric tests for all three routing cases

## Affected files

- `webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt`
- `webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/TelephonyUtilsIsTelecomSupportedTest.kt`