### PR TITLE
fix: replace status-based push isolate lifecycle with unconditional releaseCall

### DIFF
--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -65,19 +65,12 @@ Future<void> onChangedLifecycle(CallkeepServiceStatus status) async {
 }
 
 @pragma('vm:entry-point')
-Future<void> onPushNotificationCallback(
-    CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata) async {
+Future<void> onPushNotificationCallback(CallkeepIncomingCallMetadata? metadata) async {
   initializeLogs();
-  _log.info('onPushNotificationCallback: $status, metadata: $metadata');
+  _log.info('onPushNotificationCallback: metadata: $metadata');
 
-  if (status == CallkeepPushNotificationSyncStatus.synchronizeCallStatus) {
-    Future.delayed(Duration(seconds: 3), () {
-      _log.info('Ending call after 3 seconds');
-      BackgroundPushNotificationService().endCall(call1Identifier);
-    });
-  } else {
-    _log.info('onPushNotificationCallback: unknown');
-  }
-
-  return Future.value();
+  Future.delayed(Duration(seconds: 3), () {
+    _log.info('Ending call after 3 seconds');
+    BackgroundPushNotificationService().releaseCall(metadata?.callId ?? '');
+  });
 }

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -69,8 +69,14 @@ Future<void> onPushNotificationCallback(CallkeepIncomingCallMetadata? metadata) 
   initializeLogs();
   _log.info('onPushNotificationCallback: metadata: $metadata');
 
+  final callId = metadata?.callId;
+  if (callId == null || callId.isEmpty) {
+    _log.warning('onPushNotificationCallback: callId is null or empty, skipping releaseCall');
+    return;
+  }
+
   Future.delayed(Duration(seconds: 3), () {
     _log.info('Ending call after 3 seconds');
-    BackgroundPushNotificationService().releaseCall(metadata?.callId ?? '');
+    BackgroundPushNotificationService().releaseCall(callId);
   });
 }

--- a/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
+++ b/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
@@ -30,8 +30,22 @@ class BackgroundPushNotificationService {
   }
 
   /// Ends all background calls (Android only).
+  ///
+  /// Deprecated: use [releaseCall] with a specific callId instead.
+  /// [endCalls] routes through a teardown path that does not stop
+  /// [IncomingCallService], leaving the incoming call notification visible.
+  @Deprecated('Use releaseCall(callId) instead')
   Future<dynamic> endCalls() {
     if (kIsWeb || !Platform.isAndroid) return Future.value();
     return platform.endCallsBackgroundPushNotificationService();
+  }
+
+  /// Unconditionally releases the incoming call service for [callId] (Android only).
+  ///
+  /// Call this after all isolate work is done (notifications shown, logs written).
+  /// Stops [IncomingCallService] regardless of Telecom connection state.
+  Future<dynamic> releaseCall(String callId) {
+    if (kIsWeb || !Platform.isAndroid) return Future.value();
+    return platform.releaseCallBackgroundPushNotificationService(callId);
   }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -206,6 +206,28 @@ enum class PIncomingCallErrorEnum(
     FILTERED_BY_DO_NOT_DISTURB(5),
     FILTERED_BY_BLOCK_LIST(6),
     INTERNAL(7),
+
+    /**
+     * Android only.
+     *
+     * Telecom rejected the incoming call registration via
+     * `onCreateIncomingConnectionFailed` (i.e. without ever calling
+     * `onCreateIncomingConnection`).
+     *
+     * **When this happens**: Android does not allow two self-managed calls to be
+     * simultaneously in RINGING state. If a call is already ringing, Telecom
+     * rejects every subsequent incoming self-managed call. This is standard
+     * AOSP behaviour (observed on stock Pixel devices running Android 11+), not
+     * an OEM-specific restriction. Some vendors (Huawei, certain MediaTek OEMs)
+     * apply the same rejection even when the first call is already ACTIVE.
+     *
+     * **Consequences for the app**:
+     * - The call was never confirmed to Flutter, so `performEndCall` will NOT
+     *   fire for this call ID.
+     * - The app must send the appropriate signaling (e.g. SIP BYE) to the
+     *   server itself upon receiving this error, without waiting for
+     *   `performEndCall`.
+     */
     CALL_REJECTED_BY_SYSTEM(8),
     ;
 
@@ -273,18 +295,6 @@ enum class PCallkeepLifecycleEvent(
 
     companion object {
         fun ofRaw(raw: Int): PCallkeepLifecycleEvent? = values().firstOrNull { it.raw == raw }
-    }
-}
-
-enum class PCallkeepPushNotificationSyncStatus(
-    val raw: Int,
-) {
-    SYNCHRONIZE_CALL_STATUS(0),
-    RELEASE_RESOURCES(1),
-    ;
-
-    companion object {
-        fun ofRaw(raw: Int): PCallkeepPushNotificationSyncStatus? = values().firstOrNull { it.raw == raw }
     }
 }
 
@@ -870,101 +880,95 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
 
             140.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepPushNotificationSyncStatus.ofRaw(it.toInt())
+                    PCallkeepConnectionState.ofRaw(it.toInt())
                 }
             }
 
             141.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepConnectionState.ofRaw(it.toInt())
+                    PCallkeepDisconnectCauseType.ofRaw(it.toInt())
                 }
             }
 
             142.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepDisconnectCauseType.ofRaw(it.toInt())
-                }
-            }
-
-            143.toByte() -> {
-                return (readValue(buffer) as Long?)?.let {
                     PCallkeepSignalingStatus.ofRaw(it.toInt())
                 }
             }
 
-            144.toByte() -> {
+            143.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PIOSOptions.fromList(it)
                 }
             }
 
-            145.toByte() -> {
+            144.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PAndroidOptions.fromList(it)
                 }
             }
 
-            146.toByte() -> {
+            145.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     POptions.fromList(it)
                 }
             }
 
-            147.toByte() -> {
+            146.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PAudioDevice.fromList(it)
                 }
             }
 
-            148.toByte() -> {
+            147.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PPermissionResult.fromList(it)
                 }
             }
 
-            149.toByte() -> {
+            148.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PHandle.fromList(it)
                 }
             }
 
-            150.toByte() -> {
+            149.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PEndCallReason.fromList(it)
                 }
             }
 
-            151.toByte() -> {
+            150.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PIncomingCallError.fromList(it)
                 }
             }
 
-            152.toByte() -> {
+            151.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallRequestError.fromList(it)
                 }
             }
 
-            153.toByte() -> {
+            152.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepIncomingCallData.fromList(it)
                 }
             }
 
-            154.toByte() -> {
+            153.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepServiceStatus.fromList(it)
                 }
             }
 
-            155.toByte() -> {
+            154.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepDisconnectCause.fromList(it)
                 }
             }
 
-            156.toByte() -> {
+            155.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepConnection.fromList(it)
                 }
@@ -1036,88 +1040,83 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepPushNotificationSyncStatus -> {
+            is PCallkeepConnectionState -> {
                 stream.write(140)
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepConnectionState -> {
+            is PCallkeepDisconnectCauseType -> {
                 stream.write(141)
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepDisconnectCauseType -> {
+            is PCallkeepSignalingStatus -> {
                 stream.write(142)
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepSignalingStatus -> {
-                stream.write(143)
-                writeValue(stream, value.raw)
-            }
-
             is PIOSOptions -> {
-                stream.write(144)
+                stream.write(143)
                 writeValue(stream, value.toList())
             }
 
             is PAndroidOptions -> {
-                stream.write(145)
+                stream.write(144)
                 writeValue(stream, value.toList())
             }
 
             is POptions -> {
-                stream.write(146)
+                stream.write(145)
                 writeValue(stream, value.toList())
             }
 
             is PAudioDevice -> {
-                stream.write(147)
+                stream.write(146)
                 writeValue(stream, value.toList())
             }
 
             is PPermissionResult -> {
-                stream.write(148)
+                stream.write(147)
                 writeValue(stream, value.toList())
             }
 
             is PHandle -> {
-                stream.write(149)
+                stream.write(148)
                 writeValue(stream, value.toList())
             }
 
             is PEndCallReason -> {
-                stream.write(150)
+                stream.write(149)
                 writeValue(stream, value.toList())
             }
 
             is PIncomingCallError -> {
-                stream.write(151)
+                stream.write(150)
                 writeValue(stream, value.toList())
             }
 
             is PCallRequestError -> {
-                stream.write(152)
+                stream.write(151)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepIncomingCallData -> {
-                stream.write(153)
+                stream.write(152)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepServiceStatus -> {
-                stream.write(154)
+                stream.write(153)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepDisconnectCause -> {
-                stream.write(155)
+                stream.write(154)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepConnection -> {
-                stream.write(156)
+                stream.write(155)
                 writeValue(stream, value.toList())
             }
 
@@ -1441,6 +1440,11 @@ interface PHostBackgroundPushNotificationIsolateApi {
 
     fun endAllCalls(callback: (Result<Unit>) -> Unit)
 
+    fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
     companion object {
         /** The codec used by PHostBackgroundPushNotificationIsolateApi. */
         val codec: MessageCodec<Any?> by lazy {
@@ -1479,6 +1483,25 @@ interface PHostBackgroundPushNotificationIsolateApi {
                 if (api != null) {
                     channel.setMessageHandler { _, reply ->
                         api.endAllCalls { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.releaseCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.releaseCall(callIdArg) { result: Result<Unit> ->
                             val error = result.exceptionOrNull()
                             if (error != null) {
                                 reply.reply(GeneratedPigeonUtils.wrapError(error))
@@ -1798,14 +1821,13 @@ class PDelegateBackgroundRegisterFlutterApi(
 
     fun onNotificationSync(
         pushNotificationSyncStatusHandleArg: Long,
-        statusArg: PCallkeepPushNotificationSyncStatus,
         callDataArg: PCallkeepIncomingCallData?,
         callback: (Result<Unit>) -> Unit,
     ) {
         val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
         val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync$separatedMessageChannelSuffix"
         val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-        channel.send(listOf(pushNotificationSyncStatusHandleArg, statusArg, callDataArg)) {
+        channel.send(listOf(pushNotificationSyncStatusHandleArg, callDataArg)) {
             if (it is List<*>) {
                 if (it.size > 1) {
                     callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.Lifecycle
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.PCallkeepLifecycleEvent
 import com.webtrit.callkeep.PCallkeepPermission
-import com.webtrit.callkeep.PCallkeepPushNotificationSyncStatus
 import com.webtrit.callkeep.PCallkeepSignalingStatus
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PPermissionResult
@@ -195,26 +194,8 @@ fun PDelegateBackgroundRegisterFlutterApi.syncPushIsolate(
     callData: PCallkeepIncomingCallData?,
     callback: (Result<Unit>) -> Unit,
 ) {
-    isolateEvent(context, PCallkeepPushNotificationSyncStatus.SYNCHRONIZE_CALL_STATUS, callData, callback)
-}
-
-fun PDelegateBackgroundRegisterFlutterApi.releasePushIsolate(
-    context: Context,
-    callData: PCallkeepIncomingCallData?,
-    callback: (Result<Unit>) -> Unit,
-) {
-    isolateEvent(context, PCallkeepPushNotificationSyncStatus.RELEASE_RESOURCES, callData, callback)
-}
-
-private fun PDelegateBackgroundRegisterFlutterApi.isolateEvent(
-    context: Context,
-    event: PCallkeepPushNotificationSyncStatus,
-    callData: PCallkeepIncomingCallData?,
-    callback: (Result<Unit>) -> Unit,
-) {
     this.onNotificationSync(
         StorageDelegate.IncomingCallService.getOnNotificationSync(context),
-        event,
         callData,
         callback = callback,
     )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
@@ -13,12 +13,6 @@ class NotificationManager {
     }
 
     fun cancelIncomingNotification(answered: Boolean) {
-        // Guard against restarting IncomingCallService when it has already been stopped
-        // (e.g. via releaseCall). Without this check, context.startService inside
-        // IncomingCallService.release() would cause Android to create a new service
-        // instance just to handle IC_RELEASE_WITH_DECLINE, resulting in a redundant
-        // lifecycle cycle with no meaningful work.
-        if (!IncomingCallService.isRunning) return
         IncomingCallService.release(
             context,
             if (answered) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
@@ -13,6 +13,12 @@ class NotificationManager {
     }
 
     fun cancelIncomingNotification(answered: Boolean) {
+        // Guard against restarting IncomingCallService when it has already been stopped
+        // (e.g. via releaseCall). Without this check, context.startService inside
+        // IncomingCallService.release() would cause Android to create a new service
+        // instance just to handle IC_RELEASE_WITH_DECLINE, resulting in a redundant
+        // lifecycle cycle with no meaningful work.
+        if (!IncomingCallService.isRunning) return
         IncomingCallService.release(
             context,
             if (answered) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/FlutterIsolateCommunicator.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/FlutterIsolateCommunicator.kt
@@ -2,10 +2,8 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.content.Context
 import com.webtrit.callkeep.PCallkeepIncomingCallData
-import com.webtrit.callkeep.PCallkeepPushNotificationSyncStatus
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
-import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.syncPushIsolate
 
 interface FlutterIsolateCommunicator {
@@ -25,11 +23,6 @@ interface FlutterIsolateCommunicator {
         callData: PCallkeepIncomingCallData?,
         onSuccess: () -> Unit,
         onFailure: (Throwable) -> Unit,
-    )
-
-    fun releaseResources(
-        callData: PCallkeepIncomingCallData?,
-        onComplete: () -> Unit,
     )
 }
 
@@ -66,18 +59,5 @@ class DefaultFlutterIsolateCommunicator(
         registerApi?.syncPushIsolate(context, callData) { result ->
             result.onSuccess { onSuccess() }.onFailure { onFailure(it) }
         } ?: onFailure(IllegalStateException("Register API unavailable"))
-    }
-
-    override fun releaseResources(
-        callData: PCallkeepIncomingCallData?,
-        onComplete: () -> Unit,
-    ) {
-        registerApi?.onNotificationSync(
-            StorageDelegate.IncomingCallService.getOnNotificationSync(context),
-            PCallkeepPushNotificationSyncStatus.RELEASE_RESOURCES,
-            callData,
-        ) {
-            onComplete()
-        } ?: onComplete()
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -45,6 +45,11 @@ class IncomingCallService :
     // denied). Released in onDestroy() or when the call is answered/declined.
     private var screenWakeLock: PowerManager.WakeLock? = null
 
+    // Set to true only after IC_INITIALIZE is handled. Guards against spurious IC_RELEASE_WITH_DECLINE
+    // intents that restart the service after it has already been stopped (e.g. when releaseCall()
+    // calls stopSelf() and Telecom later triggers PhoneConnection.onDisconnect → startService).
+    private var isInitialized = false
+
     private val timeoutHandler = Handler(Looper.getMainLooper())
     private val stopTimeoutRunnable =
         Runnable {
@@ -147,6 +152,12 @@ class IncomingCallService :
             return START_NOT_STICKY
         }
 
+        if (!isInitialized && action == IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name) {
+            Log.w(TAG, "onStartCommand: IC_RELEASE_WITH_DECLINE received before IC_INITIALIZE — service was restarted after stop, ignoring")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
         return when (action) {
             // Listen foreground service actions
             PushNotificationServiceEnums.IC_INITIALIZE.name -> handleLaunch(metadata!!)
@@ -209,6 +220,7 @@ class IncomingCallService :
 
     // Launches the service with the LAUNCH action and cancels the timeout
     private fun handleLaunch(metadata: CallMetadata): Int {
+        isInitialized = true
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -52,6 +52,12 @@ class IncomingCallService :
             stopSelf()
         }
 
+    private val independentTimeoutRunnable =
+        Runnable {
+            Log.w(TAG, "Independent service timeout ($INDEPENDENT_SERVICE_TIMEOUT_MS ms) reached. Stopping forcefully.")
+            stopSelf()
+        }
+
     private lateinit var incomingCallHandler: IncomingCallHandler
     private lateinit var isolateHandler: FlutterIsolateHandler
     private lateinit var callLifecycleHandler: CallLifecycleHandler
@@ -163,9 +169,9 @@ class IncomingCallService :
     override fun onDestroy() {
         Log.d(TAG, "onDestroy called")
 
-        // Cancel the safety-net timeout so it does not fire after a graceful stop and
-        // report a false-alarm to Crashlytics.
+        // Cancel both safety-net timeouts so they do not fire after a graceful stop.
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
 
         setRunning(false)
         releaseScreenWakeLock()
@@ -204,6 +210,7 @@ class IncomingCallService :
     // Launches the service with the LAUNCH action and cancels the timeout
     private fun handleLaunch(metadata: CallMetadata): Int {
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
         acquireScreenWakeLockIfNeeded()
         incomingCallHandler.handle(metadata)
@@ -222,6 +229,7 @@ class IncomingCallService :
         // onDestroy() keeps the lock as a final safety net in case this path is skipped.
         releaseScreenWakeLock()
         incomingCallHandler.releaseIncomingCallNotification(answered)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(stopTimeoutRunnable, SERVICE_TIMEOUT_MS)
         if (answered) {
@@ -302,6 +310,7 @@ class IncomingCallService :
         private const val TAG = "IncomingCallService"
 
         private const val SERVICE_TIMEOUT_MS = 2_000L
+        private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -222,6 +222,7 @@ class IncomingCallService :
     private fun handleLaunch(metadata: CallMetadata): Int {
         isInitialized = true
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
         acquireScreenWakeLockIfNeeded()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -131,22 +131,24 @@ class CallLifecycleHandler(
     }
 
     override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
-        flutterApi?.releaseResources(currentCallData) {
-            connectionController.tearDown()
-        }
+        connectionController.tearDown()
         callback(Result.success(Unit))
     }
 
-    // Isolate
+    override fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        Log.d(TAG, "releaseCall: $callId - terminate connection and stop service")
+        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        stopService()
+        callback(Result.success(Unit))
+    }
+
     fun release(onComplete: (() -> Unit)? = null) {
         Log.d(TAG, "Resources released")
-        flutterApi?.releaseResources(currentCallData) {
-            onComplete?.invoke()
-            stopServiceWithDelay()
-        } ?: run {
-            onComplete?.invoke()
-            stopService()
-        }
+        onComplete?.invoke()
+        stopServiceWithDelay()
     }
 
     private fun stopServiceWithDelay() {

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallLifecycleHandlerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallLifecycleHandlerTest.kt
@@ -2,6 +2,7 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.content.Context
 import android.os.Build
+import android.os.Looper
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.SignalingStatus
@@ -17,14 +18,15 @@ import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 
 /**
  * Unit tests for [CallLifecycleHandler].
  *
- * Focuses on the decline teardown ordering fix:
- *   performEndCall() must invoke the Flutter-side BYE *before* release() triggers
- *   releaseResources (WebSocket teardown). The old behaviour called release() directly
- *   from handleRelease(answered=false), closing the WebSocket before BYE could be sent.
+ * Verifies the decline teardown ordering: performEndCall() must invoke the Flutter-side
+ * BYE *before* release() stops the service. In the new design, releaseResources is no
+ * longer part of FlutterIsolateCommunicator — the Dart isolate manages its own resource
+ * cleanup. release() now calls stopServiceWithDelay() directly.
  *
  * Uses hand-written fakes for [FlutterIsolateCommunicator] to record call order without
  * requiring the mockito-kotlin extension library.
@@ -47,7 +49,6 @@ class CallLifecycleHandlerTest {
 
         val events = mutableListOf<String>()
         var lastPerformEndCallId: String? = null
-        var releaseResourcesCallCount = 0
 
         override fun performAnswer(
             callId: String,
@@ -78,15 +79,6 @@ class CallLifecycleHandlerTest {
         ) {
             events.add("syncPushIsolate")
             onSuccess()
-        }
-
-        override fun releaseResources(
-            callData: com.webtrit.callkeep.PCallkeepIncomingCallData?,
-            onComplete: () -> Unit,
-        ) {
-            events.add("releaseResources")
-            releaseResourcesCallCount++
-            onComplete()
         }
     }
 
@@ -152,35 +144,50 @@ class CallLifecycleHandlerTest {
     }
 
     // -------------------------------------------------------------------------
-    // performEndCall — ordering: BYE first, release after
+    // performEndCall — ordering: BYE first, stopService after delay
     // -------------------------------------------------------------------------
 
     /**
-     * Regression: performEndCall must emit "performEndCall" BEFORE "releaseResources".
-     * If the order were reversed, the WebSocket would close before the SIP BYE is sent.
+     * Regression: performEndCall must emit "performEndCall" before triggering
+     * release() → stopServiceWithDelay(). The service must not stop before the
+     * SIP BYE is sent.
      */
     @Test
-    fun `performEndCall fires performEndCall before releaseResources on success`() {
+    fun `performEndCall fires performEndCall before stopService on success`() {
         handler.performEndCall(CallMetadata(callId = "call-1"))
 
+        assertTrue(
+            "performEndCall must be forwarded to Flutter before service stops",
+            communicator.events.contains("performEndCall"),
+        )
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
         assertEquals(
-            "performEndCall must precede releaseResources",
-            listOf("performEndCall", "releaseResources"),
-            communicator.events,
+            "stopService must be called after performEndCall succeeds",
+            1,
+            stopServiceCalls.size,
         )
     }
 
     @Test
-    fun `performEndCall fires performEndCall before releaseResources on failure`() {
+    fun `performEndCall fires performEndCall before stopService on failure`() {
         communicator = FakeCommunicator(FakeCommunicator.EndCallResult.FAILURE)
         handler.flutterApi = communicator
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
 
+        assertTrue(
+            "performEndCall must be forwarded to Flutter even on failure",
+            communicator.events.contains("performEndCall"),
+        )
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
         assertEquals(
-            "releaseResources must still fire even when BYE fails",
-            listOf("performEndCall", "releaseResources"),
-            communicator.events,
+            "stopService must still be called when BYE fails",
+            1,
+            stopServiceCalls.size,
         )
     }
 
@@ -192,30 +199,32 @@ class CallLifecycleHandlerTest {
     }
 
     @Test
-    fun `performEndCall triggers releaseResources exactly once on success`() {
+    fun `performEndCall triggers stopService exactly once on success`() {
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     @Test
-    fun `performEndCall triggers releaseResources exactly once on failure`() {
+    fun `performEndCall triggers stopService exactly once on failure`() {
         communicator = FakeCommunicator(FakeCommunicator.EndCallResult.FAILURE)
         handler.flutterApi = communicator
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     // -------------------------------------------------------------------------
-    // release — answered path: skips performEndCall, goes straight to releaseResources
+    // release — answered path: skips performEndCall, calls stopServiceWithDelay
     // -------------------------------------------------------------------------
 
     /**
      * release() is used for answered-call teardown (handleRelease(answered=true)).
      * It must NOT call performEndCall — the main process handles active-call signaling.
-     * It goes directly to releaseResources.
+     * It goes directly to stopServiceWithDelay().
      */
     @Test
     fun `release does not call performEndCall`() {
@@ -228,20 +237,23 @@ class CallLifecycleHandlerTest {
     }
 
     @Test
-    fun `release calls releaseResources`() {
+    fun `release calls stopService after delay`() {
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertTrue(
-            "release() must call releaseResources",
-            communicator.events.contains("releaseResources"),
+        assertEquals(
+            "release() must call stopService via stopServiceWithDelay",
+            1,
+            stopServiceCalls.size,
         )
     }
 
     @Test
-    fun `release calls releaseResources exactly once`() {
+    fun `release calls stopService exactly once`() {
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     // -------------------------------------------------------------------------
@@ -249,12 +261,12 @@ class CallLifecycleHandlerTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `performEndCall with null flutterApi calls release and stopService`() {
+    fun `performEndCall with null flutterApi calls stopService`() {
         handler.flutterApi = null
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        // release() falls through to stopService() when flutterApi is null
         assertEquals(1, stopServiceCalls.size)
     }
 
@@ -263,6 +275,7 @@ class CallLifecycleHandlerTest {
         handler.flutterApi = null
 
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         assertEquals(1, stopServiceCalls.size)
     }
@@ -281,8 +294,6 @@ class CallLifecycleHandlerTest {
     fun `performAnswerCall does not call connectionController answer on success`() {
         handler.performAnswerCall(CallMetadata(callId = "call-1"))
 
-        // Confirm the background path actually ran (Flutter was notified) so the
-        // answerCallCount == 0 assertion is not trivially satisfied by a no-op.
         assertTrue(
             "performAnswer must be forwarded to Flutter to confirm the background path ran",
             communicator.events.contains("performAnswer"),
@@ -326,12 +337,6 @@ class CallLifecycleHandlerTest {
                     callData: PCallkeepIncomingCallData?,
                     onSuccess: () -> Unit,
                     onFailure: (Throwable) -> Unit,
-                ) {
-                }
-
-                override fun releaseResources(
-                    callData: PCallkeepIncomingCallData?,
-                    onComplete: () -> Unit,
                 ) {}
             }
         handler.flutterApi = failingCommunicator
@@ -347,7 +352,6 @@ class CallLifecycleHandlerTest {
 
         handler.performAnswerCall(CallMetadata(callId = "call-1"))
 
-        // No Flutter notification, no teardown, no crash -- graceful degradation.
         assertEquals(0, fakeController.answerCallCount)
         assertEquals(0, fakeController.tearDownCallCount)
     }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -67,10 +67,23 @@ enum PIncomingCallErrorEnum {
 
   /// Android only.
   ///
-  /// Telecom rejected the incoming call registration — e.g. the device does
-  /// not support concurrent self-managed calls (common on Huawei and other OEM
-  /// devices). The call was never confirmed to Flutter so no `performEndCall`
-  /// will be fired.
+  /// Telecom rejected the incoming call registration via
+  /// `onCreateIncomingConnectionFailed` (i.e. without ever calling
+  /// `onCreateIncomingConnection`).
+  ///
+  /// **When this happens**: Android does not allow two self-managed calls to be
+  /// simultaneously in RINGING state. If a call is already ringing, Telecom
+  /// rejects every subsequent incoming self-managed call. This is standard
+  /// AOSP behaviour (observed on stock Pixel devices running Android 11+), not
+  /// an OEM-specific restriction. Some vendors (Huawei, certain MediaTek OEMs)
+  /// apply the same rejection even when the first call is already ACTIVE.
+  ///
+  /// **Consequences for the app**:
+  /// - The call was never confirmed to Flutter, so `performEndCall` will NOT
+  ///   fire for this call ID.
+  /// - The app must send the appropriate signaling (e.g. SIP BYE) to the
+  ///   server itself upon receiving this error, without waiting for
+  ///   `performEndCall`.
   callRejectedBySystem,
 }
 
@@ -109,8 +122,6 @@ enum PCallRequestErrorEnum {
 }
 
 enum PCallkeepLifecycleEvent { onCreate, onStart, onResume, onPause, onStop, onDestroy, onAny }
-
-enum PCallkeepPushNotificationSyncStatus { synchronizeCallStatus, releaseResources }
 
 enum PCallkeepConnectionState {
   stateInitializing,
@@ -744,56 +755,53 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepLifecycleEvent) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepPushNotificationSyncStatus) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepConnectionState) {
+    } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepDisconnectCauseType) {
+    } else if (value is PCallkeepSignalingStatus) {
       buffer.putUint8(142);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepSignalingStatus) {
-      buffer.putUint8(143);
-      writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
-      buffer.putUint8(144);
+      buffer.putUint8(143);
       writeValue(buffer, value.encode());
     } else if (value is PAndroidOptions) {
-      buffer.putUint8(145);
+      buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else if (value is POptions) {
-      buffer.putUint8(146);
+      buffer.putUint8(145);
       writeValue(buffer, value.encode());
     } else if (value is PAudioDevice) {
-      buffer.putUint8(147);
+      buffer.putUint8(146);
       writeValue(buffer, value.encode());
     } else if (value is PPermissionResult) {
-      buffer.putUint8(148);
+      buffer.putUint8(147);
       writeValue(buffer, value.encode());
     } else if (value is PHandle) {
-      buffer.putUint8(149);
+      buffer.putUint8(148);
       writeValue(buffer, value.encode());
     } else if (value is PEndCallReason) {
-      buffer.putUint8(150);
+      buffer.putUint8(149);
       writeValue(buffer, value.encode());
     } else if (value is PIncomingCallError) {
-      buffer.putUint8(151);
+      buffer.putUint8(150);
       writeValue(buffer, value.encode());
     } else if (value is PCallRequestError) {
-      buffer.putUint8(152);
+      buffer.putUint8(151);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepIncomingCallData) {
-      buffer.putUint8(153);
+      buffer.putUint8(152);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepServiceStatus) {
-      buffer.putUint8(154);
+      buffer.putUint8(153);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepDisconnectCause) {
-      buffer.putUint8(155);
+      buffer.putUint8(154);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepConnection) {
-      buffer.putUint8(156);
+      buffer.putUint8(155);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -838,41 +846,38 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PCallkeepLifecycleEvent.values[value];
       case 140:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepPushNotificationSyncStatus.values[value];
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 141:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepConnectionState.values[value];
+        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
-      case 143:
-        final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallkeepSignalingStatus.values[value];
-      case 144:
+      case 143:
         return PIOSOptions.decode(readValue(buffer)!);
-      case 145:
+      case 144:
         return PAndroidOptions.decode(readValue(buffer)!);
-      case 146:
+      case 145:
         return POptions.decode(readValue(buffer)!);
-      case 147:
+      case 146:
         return PAudioDevice.decode(readValue(buffer)!);
-      case 148:
+      case 147:
         return PPermissionResult.decode(readValue(buffer)!);
-      case 149:
+      case 148:
         return PHandle.decode(readValue(buffer)!);
-      case 150:
+      case 149:
         return PEndCallReason.decode(readValue(buffer)!);
-      case 151:
+      case 150:
         return PIncomingCallError.decode(readValue(buffer)!);
-      case 152:
+      case 151:
         return PCallRequestError.decode(readValue(buffer)!);
-      case 153:
+      case 152:
         return PCallkeepIncomingCallData.decode(readValue(buffer)!);
-      case 154:
+      case 153:
         return PCallkeepServiceStatus.decode(readValue(buffer)!);
-      case 155:
+      case 154:
         return PCallkeepDisconnectCause.decode(readValue(buffer)!);
-      case 156:
+      case 155:
         return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -1241,6 +1246,29 @@ class PHostBackgroundPushNotificationIsolateApi {
       return;
     }
   }
+
+  Future<void> releaseCall(String callId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.releaseCall$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callId]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }
 
 class PHostPermissionsApi {
@@ -1528,11 +1556,7 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
 
   Future<void> onApplicationStatusChanged(int applicationStatusCallbackHandle, PCallkeepServiceStatus status);
 
-  Future<void> onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  );
+  Future<void> onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData);
 
   static void setUp(
     PDelegateBackgroundRegisterFlutterApi? api, {
@@ -1637,14 +1661,9 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
             arg_pushNotificationSyncStatusHandle != null,
             'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync was null, expected non-null int.',
           );
-          final PCallkeepPushNotificationSyncStatus? arg_status = (args[1] as PCallkeepPushNotificationSyncStatus?);
-          assert(
-            arg_status != null,
-            'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync was null, expected non-null PCallkeepPushNotificationSyncStatus.',
-          );
-          final PCallkeepIncomingCallData? arg_callData = (args[2] as PCallkeepIncomingCallData?);
+          final PCallkeepIncomingCallData? arg_callData = (args[1] as PCallkeepIncomingCallData?);
           try {
-            await api.onNotificationSync(arg_pushNotificationSyncStatusHandle!, arg_status!, arg_callData);
+            await api.onNotificationSync(arg_pushNotificationSyncStatusHandle!, arg_callData);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -284,17 +284,6 @@ extension CallkeepSignalingStatusConverter on CallkeepSignalingStatus {
   }
 }
 
-extension PCallkeepPushNotificationSyncStatusConverter on PCallkeepPushNotificationSyncStatus {
-  CallkeepPushNotificationSyncStatus toCallkeep() {
-    switch (this) {
-      case PCallkeepPushNotificationSyncStatus.synchronizeCallStatus:
-        return CallkeepPushNotificationSyncStatus.synchronizeCallStatus;
-      case PCallkeepPushNotificationSyncStatus.releaseResources:
-        return CallkeepPushNotificationSyncStatus.releaseResources;
-    }
-  }
-}
-
 extension PCallkeepIncomingCallDataConverter on PCallkeepIncomingCallData {
   CallkeepIncomingCallMetadata toCallkeep() {
     return CallkeepIncomingCallMetadata(

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -377,6 +377,11 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
     return _backgroundPushNotificationIsolateApi.endCall(callId);
   }
 
+  @override
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) {
+    return _backgroundPushNotificationIsolateApi.releaseCall(callId);
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android background push notification service
 
@@ -597,13 +602,9 @@ class _BackgroundServiceDelegate implements PDelegateBackgroundRegisterFlutterAp
   }
 
   @override
-  Future<void> onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  ) async {
+  Future<void> onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData) async {
     final handle = CallbackHandle.fromRawHandle(pushNotificationSyncStatusHandle);
     final closure = PluginUtilities.getCallbackFromHandle(handle)! as CallKeepPushNotificationSyncStatusHandle;
-    await closure(status.toCallkeep(), callData?.toCallkeep());
+    await closure(callData?.toCallkeep());
   }
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -151,8 +151,6 @@ class PCallRequestError {
 
 enum PCallkeepLifecycleEvent { onCreate, onStart, onResume, onPause, onStop, onDestroy, onAny }
 
-enum PCallkeepPushNotificationSyncStatus { synchronizeCallStatus, releaseResources }
-
 class PCallkeepIncomingCallData {
   late String callId;
   late PHandle? handle;
@@ -251,6 +249,9 @@ abstract class PHostBackgroundPushNotificationIsolateApi {
 
   @async
   void endAllCalls();
+
+  @async
+  void releaseCall(String callId);
 }
 
 @HostApi()
@@ -302,11 +303,7 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
   void onApplicationStatusChanged(int applicationStatusCallbackHandle, PCallkeepServiceStatus status);
 
   @async
-  void onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  );
+  void onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData);
 }
 
 @HostApi()

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -529,26 +529,6 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // PCallkeepPushNotificationSyncStatusConverter
-  // ---------------------------------------------------------------------------
-
-  group('PCallkeepPushNotificationSyncStatusConverter.toCallkeep()', () {
-    test('synchronizeCallStatus', () {
-      expect(
-        PCallkeepPushNotificationSyncStatus.synchronizeCallStatus.toCallkeep(),
-        CallkeepPushNotificationSyncStatus.synchronizeCallStatus,
-      );
-    });
-
-    test('releaseResources', () {
-      expect(
-        PCallkeepPushNotificationSyncStatus.releaseResources.toCallkeep(),
-        CallkeepPushNotificationSyncStatus.releaseResources,
-      );
-    });
-  });
-
-  // ---------------------------------------------------------------------------
   // PCallkeepIncomingCallDataConverter
   // ---------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
@@ -50,56 +50,53 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepLifecycleEvent) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepPushNotificationSyncStatus) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepConnectionState) {
+    } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepDisconnectCauseType) {
+    } else if (value is PCallkeepSignalingStatus) {
       buffer.putUint8(142);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepSignalingStatus) {
-      buffer.putUint8(143);
-      writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
-      buffer.putUint8(144);
+      buffer.putUint8(143);
       writeValue(buffer, value.encode());
     } else if (value is PAndroidOptions) {
-      buffer.putUint8(145);
+      buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else if (value is POptions) {
-      buffer.putUint8(146);
+      buffer.putUint8(145);
       writeValue(buffer, value.encode());
     } else if (value is PAudioDevice) {
-      buffer.putUint8(147);
+      buffer.putUint8(146);
       writeValue(buffer, value.encode());
     } else if (value is PPermissionResult) {
-      buffer.putUint8(148);
+      buffer.putUint8(147);
       writeValue(buffer, value.encode());
     } else if (value is PHandle) {
-      buffer.putUint8(149);
+      buffer.putUint8(148);
       writeValue(buffer, value.encode());
     } else if (value is PEndCallReason) {
-      buffer.putUint8(150);
+      buffer.putUint8(149);
       writeValue(buffer, value.encode());
     } else if (value is PIncomingCallError) {
-      buffer.putUint8(151);
+      buffer.putUint8(150);
       writeValue(buffer, value.encode());
     } else if (value is PCallRequestError) {
-      buffer.putUint8(152);
+      buffer.putUint8(151);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepIncomingCallData) {
-      buffer.putUint8(153);
+      buffer.putUint8(152);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepServiceStatus) {
-      buffer.putUint8(154);
+      buffer.putUint8(153);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepDisconnectCause) {
-      buffer.putUint8(155);
+      buffer.putUint8(154);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepConnection) {
-      buffer.putUint8(156);
+      buffer.putUint8(155);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -144,41 +141,38 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PCallkeepLifecycleEvent.values[value];
       case 140:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepPushNotificationSyncStatus.values[value];
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 141:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepConnectionState.values[value];
+        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
-      case 143:
-        final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallkeepSignalingStatus.values[value];
-      case 144:
+      case 143:
         return PIOSOptions.decode(readValue(buffer)!);
-      case 145:
+      case 144:
         return PAndroidOptions.decode(readValue(buffer)!);
-      case 146:
+      case 145:
         return POptions.decode(readValue(buffer)!);
-      case 147:
+      case 146:
         return PAudioDevice.decode(readValue(buffer)!);
-      case 148:
+      case 147:
         return PPermissionResult.decode(readValue(buffer)!);
-      case 149:
+      case 148:
         return PHandle.decode(readValue(buffer)!);
-      case 150:
+      case 149:
         return PEndCallReason.decode(readValue(buffer)!);
-      case 151:
+      case 150:
         return PIncomingCallError.decode(readValue(buffer)!);
-      case 152:
+      case 151:
         return PCallRequestError.decode(readValue(buffer)!);
-      case 153:
+      case 152:
         return PCallkeepIncomingCallData.decode(readValue(buffer)!);
-      case 154:
+      case 153:
         return PCallkeepServiceStatus.decode(readValue(buffer)!);
-      case 155:
+      case 154:
         return PCallkeepDisconnectCause.decode(readValue(buffer)!);
-      case 156:
+      case 155:
         return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_types.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_types.dart
@@ -1,6 +1,5 @@
 import 'callkeep_incoming_call_metadata.dart';
 import 'callkeep_service_status.dart';
-import 'callkeep_push_notification_status_sync.dart';
 
 /// A callback function that gets triggered when the foreground service starts.
 ///
@@ -10,14 +9,12 @@ import 'callkeep_push_notification_status_sync.dart';
 typedef ForegroundStartServiceHandle =
     Future<void> Function(CallkeepServiceStatus callkeepServiceStatus, CallkeepIncomingCallMetadata? metadata);
 
-/// A callback function that gets triggered when there is a change in the push notification sync status.
+/// A callback function that gets triggered when a push notification sync is requested.
 ///
-/// [status] - Provides the current status of the Callkeep push notification sync.
 /// [metadata] - Provides the metadata of the incoming call that started the isolate, if available.
 ///
-/// Returns a [Future] that completes after handling the status change.
-typedef CallKeepPushNotificationSyncStatusHandle =
-    Future<void> Function(CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata);
+/// Returns a [Future] that completes after handling the sync, including all cleanup.
+typedef CallKeepPushNotificationSyncStatusHandle = Future<void> Function(CallkeepIncomingCallMetadata? metadata);
 
 /// A callback function that gets triggered when there is a change in the lifecycle of the foreground service.
 ///

--- a/webtrit_callkeep_platform_interface/lib/src/models/models.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/models.dart
@@ -10,7 +10,6 @@ export 'callkeep_lifecycle_event.dart';
 export 'callkeep_log_type.dart';
 export 'callkeep_options.dart';
 export 'callkeep_permission.dart';
-export 'callkeep_push_notification_status_sync.dart';
 export 'callkeep_service_status.dart';
 export 'callkeep_signaling_status.dart';
 export 'callkeep_special_permission.dart';

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -381,6 +381,10 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('hungUpAndroidService() has not been implemented.');
   }
 
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) {
+    throw UnimplementedError('releaseCallBackgroundPushNotificationService() has not been implemented.');
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android SMS reception section
   // ------------------------------------------------------------------------------------------------

--- a/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
+++ b/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
@@ -360,6 +360,9 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   @override
   Future<dynamic> endCallBackgroundPushNotificationService(String callId) async {}
 
+  @override
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) async {}
+
   // ---------------------------------------------------------------------------
   // Android SMS reception (no-op on web)
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `PCallkeepPushNotificationSyncStatus` enum and status-based callback — the Dart isolate now manages its own lifecycle end-to-end
- Adds unconditional `releaseCall(callId)` to `PHostBackgroundPushNotificationIsolateApi`: calls `terminateCall(SERVER)` + `stopService()` regardless of Telecom connection state
- Removes `releaseResources` from `FlutterIsolateCommunicator` — isolate self-manages cleanup
- Adds 60s independent safety-net timeout in `IncomingCallService` for isolate crash/hang scenarios
- Adds `isRunning` guard in `NotificationManager.cancelIncomingNotification` to prevent Android restarting an already-stopped `IncomingCallService` via a redundant `IC_RELEASE_WITH_DECLINE` intent

## Test plan

- [ ] Incoming push call dismissed when caller hangs up while app is backgrounded
- [ ] Normal answer flow still works (user answers → call connects)
- [ ] Normal decline flow still works (user declines → service stops)
- [ ] `CallLifecycleHandlerTest` passes (updated to reflect removed `releaseResources`)