### PR TITLE
fix: replace status-based push isolate lifecycle with unconditional releaseCall

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Inside the isolate, use `CallkeepBackgroundServiceDelegate` to receive answer/en
 Earlier versions also included a persistent signaling isolate — a long-lived foreground service
 that kept a Flutter isolate running with an open WebSocket connection to the signaling server. It
 was removed because Android increasingly restricts persistent background services (battery
-optimisation, Doze mode, vendor-specific kill policies), making reliable long-running isolates
+optimization, Doze mode, vendor-specific kill policies), making reliable long-running isolates
 impractical. Signaling is also application-level responsibility: the plugin is concerned with
 presenting calls to the OS, not maintaining a connection. FCM high-priority push is the
 recommended and sufficient mechanism to wake the device for an incoming call.

--- a/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_background_services_test.dart
@@ -19,7 +19,7 @@ import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 // The tests exercise the *callkeep layer* side of those services:
 //   - Call registration / deduplication between isolate and main process.
 //   - performEndCall / performAnswerCall delegate routing.
-//   - endCall / endCalls clean-up triggered by signaling events
+//   - releaseCall clean-up triggered by signaling events
 //     (_onHangupCall, _onSignalingError, _onNoActiveLines, _onUnregistered).
 //   - Lifecycle management: startService / stopService without crash.
 // ---------------------------------------------------------------------------
@@ -284,17 +284,16 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // endCalls — all-calls cleanup
+    // Multi-call cleanup
     //
     // Scenario: signaling error / unregistered event while multiple calls are
-    // active. IsolateManager._onSignalingError / _onUnregistered calls
-    // endCallsOnService() which must trigger performEndCall for every active
-    // call.
-    // Matches: IsolateManager._onSignalingError → endCallsOnService()
-    //          IsolateManager._onUnregistered   → endCallsOnService()
+    // active. IsolateManager calls releaseCall(callId) for each terminal path
+    // which must trigger performEndCall for every active call.
+    // Matches: IsolateManager._onSignalingError → releaseCall(callId)
+    //          IsolateManager._onUnregistered   → releaseCall(callId)
     // -----------------------------------------------------------------------
 
-    // Note: BackgroundPushNotificationService.endCalls() requires
+    // Note: releaseCall(callId) targets a specific call and requires
     // IncomingCallService (push isolate), which is only started by FCM.
     // We use callkeep.endCall() per call instead to end Telecom connections
     // and verify performEndCall fires for each one.

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -1,7 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:webtrit_callkeep/webtrit_callkeep.dart';
 
-import 'app/constants.dart';
 import 'bootstrap.dart';
 
 final _log = Logger('Isolates');

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -7,19 +7,12 @@ import 'bootstrap.dart';
 final _log = Logger('Isolates');
 
 @pragma('vm:entry-point')
-Future<void> onPushNotificationCallback(
-    CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata) async {
+Future<void> onPushNotificationCallback(CallkeepIncomingCallMetadata? metadata) async {
   initializeLogs();
-  _log.info('onPushNotificationCallback: $status, metadata: $metadata');
+  _log.info('onPushNotificationCallback: metadata: $metadata');
 
-  if (status == CallkeepPushNotificationSyncStatus.synchronizeCallStatus) {
-    Future.delayed(Duration(seconds: 3), () {
-      _log.info('Ending call after 3 seconds');
-      BackgroundPushNotificationService().endCall(call1Identifier);
-    });
-  } else {
-    _log.info('onPushNotificationCallback: unknown');
-  }
-
-  return Future.value();
+  Future.delayed(Duration(seconds: 3), () {
+    _log.info('Ending call after 3 seconds');
+    BackgroundPushNotificationService().releaseCall(metadata?.callId ?? '');
+  });
 }

--- a/webtrit_callkeep/example/lib/isolates.dart
+++ b/webtrit_callkeep/example/lib/isolates.dart
@@ -11,8 +11,14 @@ Future<void> onPushNotificationCallback(CallkeepIncomingCallMetadata? metadata) 
   initializeLogs();
   _log.info('onPushNotificationCallback: metadata: $metadata');
 
+  final callId = metadata?.callId;
+  if (callId == null || callId.isEmpty) {
+    _log.warning('onPushNotificationCallback: callId is null or empty, skipping releaseCall');
+    return;
+  }
+
   Future.delayed(Duration(seconds: 3), () {
     _log.info('Ending call after 3 seconds');
-    BackgroundPushNotificationService().releaseCall(metadata?.callId ?? '');
+    BackgroundPushNotificationService().releaseCall(callId);
   });
 }

--- a/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
+++ b/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
@@ -30,8 +30,22 @@ class BackgroundPushNotificationService {
   }
 
   /// Ends all background calls (Android only).
+  ///
+  /// Deprecated: use [releaseCall] with a specific callId instead.
+  /// [endCalls] routes through a teardown path that does not stop
+  /// [IncomingCallService], leaving the incoming call notification visible.
+  @Deprecated('Use releaseCall(callId) instead')
   Future<dynamic> endCalls() {
     if (kIsWeb || !Platform.isAndroid) return Future.value();
     return platform.endCallsBackgroundPushNotificationService();
+  }
+
+  /// Unconditionally releases the incoming call service for [callId] (Android only).
+  ///
+  /// Call this after all isolate work is done (notifications shown, logs written).
+  /// Stops [IncomingCallService] regardless of Telecom connection state.
+  Future<dynamic> releaseCall(String callId) {
+    if (kIsWeb || !Platform.isAndroid) return Future.value();
+    return platform.releaseCallBackgroundPushNotificationService(callId);
   }
 }

--- a/webtrit_callkeep_android/analysis_options.yaml
+++ b/webtrit_callkeep_android/analysis_options.yaml
@@ -11,3 +11,6 @@ analyzer:
 
 formatter:
   page_width: 120
+  exclude:
+    - "**/*.pigeon.dart"
+    - "**/*.g.dart"

--- a/webtrit_callkeep_android/analysis_options.yaml
+++ b/webtrit_callkeep_android/analysis_options.yaml
@@ -11,6 +11,3 @@ analyzer:
 
 formatter:
   page_width: 120
-  exclude:
-    - "**/*.pigeon.dart"
-    - "**/*.g.dart"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -298,18 +298,6 @@ enum class PCallkeepLifecycleEvent(
     }
 }
 
-enum class PCallkeepPushNotificationSyncStatus(
-    val raw: Int,
-) {
-    SYNCHRONIZE_CALL_STATUS(0),
-    RELEASE_RESOURCES(1),
-    ;
-
-    companion object {
-        fun ofRaw(raw: Int): PCallkeepPushNotificationSyncStatus? = values().firstOrNull { it.raw == raw }
-    }
-}
-
 enum class PCallkeepConnectionState(
     val raw: Int,
 ) {
@@ -874,19 +862,19 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
 
             140.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepPushNotificationSyncStatus.ofRaw(it.toInt())
+                    PCallkeepConnectionState.ofRaw(it.toInt())
                 }
             }
 
             141.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepConnectionState.ofRaw(it.toInt())
+                    PCallkeepDisconnectCauseType.ofRaw(it.toInt())
                 }
             }
 
             142.toByte() -> {
                 return (readValue(buffer) as Long?)?.let {
-                    PCallkeepDisconnectCauseType.ofRaw(it.toInt())
+                    PCallkeepSignalingStatus.ofRaw(it.toInt())
                 }
             }
 
@@ -1034,17 +1022,17 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepPushNotificationSyncStatus -> {
+            is PCallkeepConnectionState -> {
                 stream.write(140)
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepConnectionState -> {
+            is PCallkeepDisconnectCauseType -> {
                 stream.write(141)
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepDisconnectCauseType -> {
+            is PCallkeepSignalingStatus -> {
                 stream.write(142)
                 writeValue(stream, value.raw)
             }
@@ -1231,6 +1219,11 @@ interface PHostBackgroundPushNotificationIsolateApi {
 
     fun endAllCalls(callback: (Result<Unit>) -> Unit)
 
+    fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
     companion object {
         /** The codec used by PHostBackgroundPushNotificationIsolateApi. */
         val codec: MessageCodec<Any?> by lazy {
@@ -1269,6 +1262,25 @@ interface PHostBackgroundPushNotificationIsolateApi {
                 if (api != null) {
                     channel.setMessageHandler { _, reply ->
                         api.endAllCalls { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.releaseCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.releaseCall(callIdArg) { result: Result<Unit> ->
                             val error = result.exceptionOrNull()
                             if (error != null) {
                                 reply.reply(GeneratedPigeonUtils.wrapError(error))
@@ -1567,14 +1579,13 @@ class PDelegateBackgroundRegisterFlutterApi(
 
     fun onNotificationSync(
         pushNotificationSyncStatusHandleArg: Long,
-        statusArg: PCallkeepPushNotificationSyncStatus,
         callDataArg: PCallkeepIncomingCallData?,
         callback: (Result<Unit>) -> Unit,
     ) {
         val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
         val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync$separatedMessageChannelSuffix"
         val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-        channel.send(listOf(pushNotificationSyncStatusHandleArg, statusArg, callDataArg)) {
+        channel.send(listOf(pushNotificationSyncStatusHandleArg, callDataArg)) {
             if (it is List<*>) {
                 if (it.size > 1) {
                     callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -873,84 +873,78 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
             }
 
             142.toByte() -> {
-                return (readValue(buffer) as Long?)?.let {
-                    PCallkeepSignalingStatus.ofRaw(it.toInt())
-                }
-            }
-
-            143.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PIOSOptions.fromList(it)
                 }
             }
 
-            144.toByte() -> {
+            143.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PAndroidOptions.fromList(it)
                 }
             }
 
-            145.toByte() -> {
+            144.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     POptions.fromList(it)
                 }
             }
 
-            146.toByte() -> {
+            145.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PAudioDevice.fromList(it)
                 }
             }
 
-            147.toByte() -> {
+            146.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PPermissionResult.fromList(it)
                 }
             }
 
-            148.toByte() -> {
+            147.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PHandle.fromList(it)
                 }
             }
 
-            149.toByte() -> {
+            148.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PEndCallReason.fromList(it)
                 }
             }
 
-            150.toByte() -> {
+            149.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PIncomingCallError.fromList(it)
                 }
             }
 
-            151.toByte() -> {
+            150.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallRequestError.fromList(it)
                 }
             }
 
-            152.toByte() -> {
+            151.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepIncomingCallData.fromList(it)
                 }
             }
 
-            153.toByte() -> {
+            152.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepServiceStatus.fromList(it)
                 }
             }
 
-            154.toByte() -> {
+            153.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepDisconnectCause.fromList(it)
                 }
             }
 
-            155.toByte() -> {
+            154.toByte() -> {
                 return (readValue(buffer) as? List<Any?>)?.let {
                     PCallkeepConnection.fromList(it)
                 }
@@ -1032,73 +1026,68 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
                 writeValue(stream, value.raw)
             }
 
-            is PCallkeepSignalingStatus -> {
-                stream.write(142)
-                writeValue(stream, value.raw)
-            }
-
             is PIOSOptions -> {
-                stream.write(143)
+                stream.write(142)
                 writeValue(stream, value.toList())
             }
 
             is PAndroidOptions -> {
-                stream.write(144)
+                stream.write(143)
                 writeValue(stream, value.toList())
             }
 
             is POptions -> {
-                stream.write(145)
+                stream.write(144)
                 writeValue(stream, value.toList())
             }
 
             is PAudioDevice -> {
-                stream.write(146)
+                stream.write(145)
                 writeValue(stream, value.toList())
             }
 
             is PPermissionResult -> {
-                stream.write(147)
+                stream.write(146)
                 writeValue(stream, value.toList())
             }
 
             is PHandle -> {
-                stream.write(148)
+                stream.write(147)
                 writeValue(stream, value.toList())
             }
 
             is PEndCallReason -> {
-                stream.write(149)
+                stream.write(148)
                 writeValue(stream, value.toList())
             }
 
             is PIncomingCallError -> {
-                stream.write(150)
+                stream.write(149)
                 writeValue(stream, value.toList())
             }
 
             is PCallRequestError -> {
-                stream.write(151)
+                stream.write(150)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepIncomingCallData -> {
-                stream.write(152)
+                stream.write(151)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepServiceStatus -> {
-                stream.write(153)
+                stream.write(152)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepDisconnectCause -> {
-                stream.write(154)
+                stream.write(153)
                 writeValue(stream, value.toList())
             }
 
             is PCallkeepConnection -> {
-                stream.write(155)
+                stream.write(154)
                 writeValue(stream, value.toList())
             }
 
@@ -1565,6 +1554,27 @@ class PDelegateBackgroundRegisterFlutterApi(
         val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onWakeUpBackgroundHandler$separatedMessageChannelSuffix"
         val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
         channel.send(listOf(userCallbackHandleArg, statusArg, callDataArg)) {
+            if (it is List<*>) {
+                if (it.size > 1) {
+                    callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(Result.failure(GeneratedPigeonUtils.createConnectionError(channelName)))
+            }
+        }
+    }
+
+    fun onApplicationStatusChanged(
+        applicationStatusCallbackHandleArg: Long,
+        statusArg: PCallkeepServiceStatus,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+        val channelName = "dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged$separatedMessageChannelSuffix"
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+        channel.send(listOf(applicationStatusCallbackHandleArg, statusArg)) {
             if (it is List<*>) {
                 if (it.size > 1) {
                     callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.Lifecycle
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.PCallkeepLifecycleEvent
 import com.webtrit.callkeep.PCallkeepPermission
-import com.webtrit.callkeep.PCallkeepSignalingStatus
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PPermissionResult
 import com.webtrit.callkeep.PSpecialPermissionStatusTypeEnum

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.Lifecycle
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.PCallkeepLifecycleEvent
 import com.webtrit.callkeep.PCallkeepPermission
-import com.webtrit.callkeep.PCallkeepPushNotificationSyncStatus
+import com.webtrit.callkeep.PCallkeepSignalingStatus
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PPermissionResult
 import com.webtrit.callkeep.PSpecialPermissionStatusTypeEnum
@@ -175,26 +175,8 @@ fun PDelegateBackgroundRegisterFlutterApi.syncPushIsolate(
     callData: PCallkeepIncomingCallData?,
     callback: (Result<Unit>) -> Unit,
 ) {
-    isolateEvent(context, PCallkeepPushNotificationSyncStatus.SYNCHRONIZE_CALL_STATUS, callData, callback)
-}
-
-fun PDelegateBackgroundRegisterFlutterApi.releasePushIsolate(
-    context: Context,
-    callData: PCallkeepIncomingCallData?,
-    callback: (Result<Unit>) -> Unit,
-) {
-    isolateEvent(context, PCallkeepPushNotificationSyncStatus.RELEASE_RESOURCES, callData, callback)
-}
-
-private fun PDelegateBackgroundRegisterFlutterApi.isolateEvent(
-    context: Context,
-    event: PCallkeepPushNotificationSyncStatus,
-    callData: PCallkeepIncomingCallData?,
-    callback: (Result<Unit>) -> Unit,
-) {
     this.onNotificationSync(
         StorageDelegate.IncomingCallService.getOnNotificationSync(context),
-        event,
         callData,
         callback = callback,
     )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
@@ -13,12 +13,6 @@ class NotificationManager {
     }
 
     fun cancelIncomingNotification(answered: Boolean) {
-        // Guard against restarting IncomingCallService when it has already been stopped
-        // (e.g. via releaseCall). Without this check, context.startService inside
-        // IncomingCallService.release() would cause Android to create a new service
-        // instance just to handle IC_RELEASE_WITH_DECLINE, resulting in a redundant
-        // lifecycle cycle with no meaningful work.
-        if (!IncomingCallService.isRunning) return
         IncomingCallService.release(
             context,
             if (answered) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
@@ -13,6 +13,12 @@ class NotificationManager {
     }
 
     fun cancelIncomingNotification(answered: Boolean) {
+        // Guard against restarting IncomingCallService when it has already been stopped
+        // (e.g. via releaseCall). Without this check, context.startService inside
+        // IncomingCallService.release() would cause Android to create a new service
+        // instance just to handle IC_RELEASE_WITH_DECLINE, resulting in a redundant
+        // lifecycle cycle with no meaningful work.
+        if (!IncomingCallService.isRunning) return
         IncomingCallService.release(
             context,
             if (answered) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/FlutterIsolateCommunicator.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/FlutterIsolateCommunicator.kt
@@ -2,10 +2,8 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.content.Context
 import com.webtrit.callkeep.PCallkeepIncomingCallData
-import com.webtrit.callkeep.PCallkeepPushNotificationSyncStatus
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
-import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.syncPushIsolate
 
 interface FlutterIsolateCommunicator {
@@ -25,11 +23,6 @@ interface FlutterIsolateCommunicator {
         callData: PCallkeepIncomingCallData?,
         onSuccess: () -> Unit,
         onFailure: (Throwable) -> Unit,
-    )
-
-    fun releaseResources(
-        callData: PCallkeepIncomingCallData?,
-        onComplete: () -> Unit,
     )
 }
 
@@ -66,18 +59,5 @@ class DefaultFlutterIsolateCommunicator(
         registerApi?.syncPushIsolate(context, callData) { result ->
             result.onSuccess { onSuccess() }.onFailure { onFailure(it) }
         } ?: onFailure(IllegalStateException("Register API unavailable"))
-    }
-
-    override fun releaseResources(
-        callData: PCallkeepIncomingCallData?,
-        onComplete: () -> Unit,
-    ) {
-        registerApi?.onNotificationSync(
-            StorageDelegate.IncomingCallService.getOnNotificationSync(context),
-            PCallkeepPushNotificationSyncStatus.RELEASE_RESOURCES,
-            callData,
-        ) {
-            onComplete()
-        } ?: onComplete()
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -45,6 +45,11 @@ class IncomingCallService :
     // denied). Released in onDestroy() or when the call is answered/declined.
     private var screenWakeLock: PowerManager.WakeLock? = null
 
+    // Set to true only after IC_INITIALIZE is handled. Guards against spurious IC_RELEASE_WITH_DECLINE
+    // intents that restart the service after it has already been stopped (e.g. when releaseCall()
+    // calls stopSelf() and Telecom later triggers PhoneConnection.onDisconnect → startService).
+    private var isInitialized = false
+
     private val timeoutHandler = Handler(Looper.getMainLooper())
     private val stopTimeoutRunnable =
         Runnable {
@@ -152,6 +157,12 @@ class IncomingCallService :
             return START_NOT_STICKY
         }
 
+        if (!isInitialized && action == IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name) {
+            Log.w(TAG, "onStartCommand: IC_RELEASE_WITH_DECLINE received before IC_INITIALIZE — service was restarted after stop, ignoring")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
         return when (action) {
             // Listen foreground service actions
             PushNotificationServiceEnums.IC_INITIALIZE.name -> handleLaunch(metadata!!)
@@ -214,6 +225,7 @@ class IncomingCallService :
 
     // Launches the service with the LAUNCH action and cancels the timeout
     private fun handleLaunch(metadata: CallMetadata): Int {
+        isInitialized = true
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -52,6 +52,12 @@ class IncomingCallService :
             stopSelf()
         }
 
+    private val independentTimeoutRunnable =
+        Runnable {
+            Log.w(TAG, "Independent service timeout ($INDEPENDENT_SERVICE_TIMEOUT_MS ms) reached. Stopping forcefully.")
+            stopSelf()
+        }
+
     private lateinit var incomingCallHandler: IncomingCallHandler
     private lateinit var isolateHandler: FlutterIsolateHandler
     private lateinit var callLifecycleHandler: CallLifecycleHandler
@@ -168,9 +174,9 @@ class IncomingCallService :
     override fun onDestroy() {
         Log.d(TAG, "onDestroy called")
 
-        // Cancel the safety-net timeout so it does not fire after a graceful stop and
-        // report a false-alarm to Crashlytics.
+        // Cancel both safety-net timeouts so they do not fire after a graceful stop.
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
 
         setRunning(false)
         releaseScreenWakeLock()
@@ -209,6 +215,7 @@ class IncomingCallService :
     // Launches the service with the LAUNCH action and cancels the timeout
     private fun handleLaunch(metadata: CallMetadata): Int {
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
         acquireScreenWakeLockIfNeeded()
         incomingCallHandler.handle(metadata)
@@ -227,6 +234,7 @@ class IncomingCallService :
         // onDestroy() keeps the lock as a final safety net in case this path is skipped.
         releaseScreenWakeLock()
         incomingCallHandler.releaseIncomingCallNotification(answered)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(stopTimeoutRunnable, SERVICE_TIMEOUT_MS)
         if (answered) {
@@ -307,6 +315,7 @@ class IncomingCallService :
         private const val TAG = "IncomingCallService"
 
         private const val SERVICE_TIMEOUT_MS = 2_000L
+        private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -227,6 +227,7 @@ class IncomingCallService :
     private fun handleLaunch(metadata: CallMetadata): Int {
         isInitialized = true
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
+        timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
         acquireScreenWakeLockIfNeeded()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -131,22 +131,24 @@ class CallLifecycleHandler(
     }
 
     override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
-        flutterApi?.releaseResources(currentCallData) {
-            connectionController.tearDown()
-        }
+        connectionController.tearDown()
         callback(Result.success(Unit))
     }
 
-    // Isolate
+    override fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        Log.d(TAG, "releaseCall: $callId - terminate connection and stop service")
+        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        stopService()
+        callback(Result.success(Unit))
+    }
+
     fun release(onComplete: (() -> Unit)? = null) {
         Log.d(TAG, "Resources released")
-        flutterApi?.releaseResources(currentCallData) {
-            onComplete?.invoke()
-            stopServiceWithDelay()
-        } ?: run {
-            onComplete?.invoke()
-            stopService()
-        }
+        onComplete?.invoke()
+        stopServiceWithDelay()
     }
 
     private fun stopServiceWithDelay() {

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallLifecycleHandlerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/incoming_call/CallLifecycleHandlerTest.kt
@@ -2,6 +2,7 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.content.Context
 import android.os.Build
+import android.os.Looper
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.services.incoming_call.handlers.CallLifecycleHandler
@@ -15,14 +16,15 @@ import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 
 /**
  * Unit tests for [CallLifecycleHandler].
  *
- * Focuses on the decline teardown ordering fix:
- *   performEndCall() must invoke the Flutter-side BYE *before* release() triggers
- *   releaseResources (WebSocket teardown). The old behaviour called release() directly
- *   from handleRelease(answered=false), closing the WebSocket before BYE could be sent.
+ * Verifies the decline teardown ordering: performEndCall() must invoke the Flutter-side
+ * BYE *before* release() stops the service. In the new design, releaseResources is no
+ * longer part of FlutterIsolateCommunicator — the Dart isolate manages its own resource
+ * cleanup. release() now calls stopServiceWithDelay() directly.
  *
  * Uses hand-written fakes for [FlutterIsolateCommunicator] to record call order without
  * requiring the mockito-kotlin extension library.
@@ -45,7 +47,6 @@ class CallLifecycleHandlerTest {
 
         val events = mutableListOf<String>()
         var lastPerformEndCallId: String? = null
-        var releaseResourcesCallCount = 0
 
         override fun performAnswer(
             callId: String,
@@ -76,15 +77,6 @@ class CallLifecycleHandlerTest {
         ) {
             events.add("syncPushIsolate")
             onSuccess()
-        }
-
-        override fun releaseResources(
-            callData: com.webtrit.callkeep.PCallkeepIncomingCallData?,
-            onComplete: () -> Unit,
-        ) {
-            events.add("releaseResources")
-            releaseResourcesCallCount++
-            onComplete()
         }
     }
 
@@ -145,35 +137,50 @@ class CallLifecycleHandlerTest {
     }
 
     // -------------------------------------------------------------------------
-    // performEndCall — ordering: BYE first, release after
+    // performEndCall — ordering: BYE first, stopService after delay
     // -------------------------------------------------------------------------
 
     /**
-     * Regression: performEndCall must emit "performEndCall" BEFORE "releaseResources".
-     * If the order were reversed, the WebSocket would close before the SIP BYE is sent.
+     * Regression: performEndCall must emit "performEndCall" before triggering
+     * release() → stopServiceWithDelay(). The service must not stop before the
+     * SIP BYE is sent.
      */
     @Test
-    fun `performEndCall fires performEndCall before releaseResources on success`() {
+    fun `performEndCall fires performEndCall before stopService on success`() {
         handler.performEndCall(CallMetadata(callId = "call-1"))
 
+        assertTrue(
+            "performEndCall must be forwarded to Flutter before service stops",
+            communicator.events.contains("performEndCall"),
+        )
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
         assertEquals(
-            "performEndCall must precede releaseResources",
-            listOf("performEndCall", "releaseResources"),
-            communicator.events,
+            "stopService must be called after performEndCall succeeds",
+            1,
+            stopServiceCalls.size,
         )
     }
 
     @Test
-    fun `performEndCall fires performEndCall before releaseResources on failure`() {
+    fun `performEndCall fires performEndCall before stopService on failure`() {
         communicator = FakeCommunicator(FakeCommunicator.EndCallResult.FAILURE)
         handler.flutterApi = communicator
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
 
+        assertTrue(
+            "performEndCall must be forwarded to Flutter even on failure",
+            communicator.events.contains("performEndCall"),
+        )
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
         assertEquals(
-            "releaseResources must still fire even when BYE fails",
-            listOf("performEndCall", "releaseResources"),
-            communicator.events,
+            "stopService must still be called when BYE fails",
+            1,
+            stopServiceCalls.size,
         )
     }
 
@@ -185,30 +192,32 @@ class CallLifecycleHandlerTest {
     }
 
     @Test
-    fun `performEndCall triggers releaseResources exactly once on success`() {
+    fun `performEndCall triggers stopService exactly once on success`() {
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     @Test
-    fun `performEndCall triggers releaseResources exactly once on failure`() {
+    fun `performEndCall triggers stopService exactly once on failure`() {
         communicator = FakeCommunicator(FakeCommunicator.EndCallResult.FAILURE)
         handler.flutterApi = communicator
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     // -------------------------------------------------------------------------
-    // release — answered path: skips performEndCall, goes straight to releaseResources
+    // release — answered path: skips performEndCall, calls stopServiceWithDelay
     // -------------------------------------------------------------------------
 
     /**
      * release() is used for answered-call teardown (handleRelease(answered=true)).
      * It must NOT call performEndCall — the main process handles active-call signaling.
-     * It goes directly to releaseResources.
+     * It goes directly to stopServiceWithDelay().
      */
     @Test
     fun `release does not call performEndCall`() {
@@ -221,20 +230,23 @@ class CallLifecycleHandlerTest {
     }
 
     @Test
-    fun `release calls releaseResources`() {
+    fun `release calls stopService after delay`() {
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertTrue(
-            "release() must call releaseResources",
-            communicator.events.contains("releaseResources"),
+        assertEquals(
+            "release() must call stopService via stopServiceWithDelay",
+            1,
+            stopServiceCalls.size,
         )
     }
 
     @Test
-    fun `release calls releaseResources exactly once`() {
+    fun `release calls stopService exactly once`() {
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals(1, communicator.releaseResourcesCallCount)
+        assertEquals(1, stopServiceCalls.size)
     }
 
     // -------------------------------------------------------------------------
@@ -242,12 +254,12 @@ class CallLifecycleHandlerTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `performEndCall with null flutterApi calls release and stopService`() {
+    fun `performEndCall with null flutterApi calls stopService`() {
         handler.flutterApi = null
 
         handler.performEndCall(CallMetadata(callId = "call-1"))
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        // release() falls through to stopService() when flutterApi is null
         assertEquals(1, stopServiceCalls.size)
     }
 
@@ -256,6 +268,7 @@ class CallLifecycleHandlerTest {
         handler.flutterApi = null
 
         handler.release()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         assertEquals(1, stopServiceCalls.size)
     }
@@ -274,8 +287,6 @@ class CallLifecycleHandlerTest {
     fun `performAnswerCall does not call connectionController answer on success`() {
         handler.performAnswerCall(CallMetadata(callId = "call-1"))
 
-        // Confirm the background path actually ran (Flutter was notified) so the
-        // answerCallCount == 0 assertion is not trivially satisfied by a no-op.
         assertTrue(
             "performAnswer must be forwarded to Flutter to confirm the background path ran",
             communicator.events.contains("performAnswer"),
@@ -319,12 +330,6 @@ class CallLifecycleHandlerTest {
                     callData: PCallkeepIncomingCallData?,
                     onSuccess: () -> Unit,
                     onFailure: (Throwable) -> Unit,
-                ) {
-                }
-
-                override fun releaseResources(
-                    callData: PCallkeepIncomingCallData?,
-                    onComplete: () -> Unit,
                 ) {}
             }
         handler.flutterApi = failingCommunicator
@@ -340,7 +345,6 @@ class CallLifecycleHandlerTest {
 
         handler.performAnswerCall(CallMetadata(callId = "call-1"))
 
-        // No Flutter notification, no teardown, no crash -- graceful degradation.
         assertEquals(0, fakeController.answerCallCount)
         assertEquals(0, fakeController.tearDownCallCount)
     }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -123,8 +123,6 @@ enum PCallRequestErrorEnum {
 
 enum PCallkeepLifecycleEvent { onCreate, onStart, onResume, onPause, onStop, onDestroy, onAny }
 
-enum PCallkeepPushNotificationSyncStatus { synchronizeCallStatus, releaseResources }
-
 enum PCallkeepConnectionState {
   stateInitializing,
   stateNew,
@@ -750,13 +748,13 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepLifecycleEvent) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepPushNotificationSyncStatus) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepConnectionState) {
+    } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepDisconnectCauseType) {
+    } else if (value is PCallkeepSignalingStatus) {
       buffer.putUint8(142);
       writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
@@ -841,13 +839,13 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PCallkeepLifecycleEvent.values[value];
       case 140:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepPushNotificationSyncStatus.values[value];
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 141:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepConnectionState.values[value];
+        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
+        return value == null ? null : PCallkeepSignalingStatus.values[value];
       case 143:
         return PIOSOptions.decode(readValue(buffer)!);
       case 144:
@@ -1028,6 +1026,29 @@ class PHostBackgroundPushNotificationIsolateApi {
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> releaseCall(String callId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.releaseCall$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callId]);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -1326,11 +1347,9 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
     PCallkeepIncomingCallData? callData,
   );
 
-  Future<void> onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  );
+  Future<void> onApplicationStatusChanged(int applicationStatusCallbackHandle, PCallkeepServiceStatus status);
+
+  Future<void> onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData);
 
   static void setUp(
     PDelegateBackgroundRegisterFlutterApi? api, {
@@ -1397,14 +1416,9 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
             arg_pushNotificationSyncStatusHandle != null,
             'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync was null, expected non-null int.',
           );
-          final PCallkeepPushNotificationSyncStatus? arg_status = (args[1] as PCallkeepPushNotificationSyncStatus?);
-          assert(
-            arg_status != null,
-            'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onNotificationSync was null, expected non-null PCallkeepPushNotificationSyncStatus.',
-          );
-          final PCallkeepIncomingCallData? arg_callData = (args[2] as PCallkeepIncomingCallData?);
+          final PCallkeepIncomingCallData? arg_callData = (args[1] as PCallkeepIncomingCallData?);
           try {
-            await api.onNotificationSync(arg_pushNotificationSyncStatusHandle!, arg_status!, arg_callData);
+            await api.onNotificationSync(arg_pushNotificationSyncStatusHandle!, arg_callData);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -754,47 +754,44 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepSignalingStatus) {
-      buffer.putUint8(142);
-      writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
-      buffer.putUint8(143);
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else if (value is PAndroidOptions) {
-      buffer.putUint8(144);
+      buffer.putUint8(143);
       writeValue(buffer, value.encode());
     } else if (value is POptions) {
-      buffer.putUint8(145);
+      buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else if (value is PAudioDevice) {
-      buffer.putUint8(146);
+      buffer.putUint8(145);
       writeValue(buffer, value.encode());
     } else if (value is PPermissionResult) {
-      buffer.putUint8(147);
+      buffer.putUint8(146);
       writeValue(buffer, value.encode());
     } else if (value is PHandle) {
-      buffer.putUint8(148);
+      buffer.putUint8(147);
       writeValue(buffer, value.encode());
     } else if (value is PEndCallReason) {
-      buffer.putUint8(149);
+      buffer.putUint8(148);
       writeValue(buffer, value.encode());
     } else if (value is PIncomingCallError) {
-      buffer.putUint8(150);
+      buffer.putUint8(149);
       writeValue(buffer, value.encode());
     } else if (value is PCallRequestError) {
-      buffer.putUint8(151);
+      buffer.putUint8(150);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepIncomingCallData) {
-      buffer.putUint8(152);
+      buffer.putUint8(151);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepServiceStatus) {
-      buffer.putUint8(153);
+      buffer.putUint8(152);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepDisconnectCause) {
-      buffer.putUint8(154);
+      buffer.putUint8(153);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepConnection) {
-      buffer.putUint8(155);
+      buffer.putUint8(154);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -844,33 +841,30 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
-        final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepSignalingStatus.values[value];
-      case 143:
         return PIOSOptions.decode(readValue(buffer)!);
-      case 144:
+      case 143:
         return PAndroidOptions.decode(readValue(buffer)!);
-      case 145:
+      case 144:
         return POptions.decode(readValue(buffer)!);
-      case 146:
+      case 145:
         return PAudioDevice.decode(readValue(buffer)!);
-      case 147:
+      case 146:
         return PPermissionResult.decode(readValue(buffer)!);
-      case 148:
+      case 147:
         return PHandle.decode(readValue(buffer)!);
-      case 149:
+      case 148:
         return PEndCallReason.decode(readValue(buffer)!);
-      case 150:
+      case 149:
         return PIncomingCallError.decode(readValue(buffer)!);
-      case 151:
+      case 150:
         return PCallRequestError.decode(readValue(buffer)!);
-      case 152:
+      case 151:
         return PCallkeepIncomingCallData.decode(readValue(buffer)!);
-      case 153:
+      case 152:
         return PCallkeepServiceStatus.decode(readValue(buffer)!);
-      case 154:
+      case 153:
         return PCallkeepDisconnectCause.decode(readValue(buffer)!);
-      case 155:
+      case 154:
         return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -1385,6 +1379,44 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
           final PCallkeepIncomingCallData? arg_callData = (args[2] as PCallkeepIncomingCallData?);
           try {
             await api.onWakeUpBackgroundHandler(arg_userCallbackHandle!, arg_status!, arg_callData);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_applicationStatusCallbackHandle = (args[0] as int?);
+          assert(
+            arg_applicationStatusCallbackHandle != null,
+            'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged was null, expected non-null int.',
+          );
+          final PCallkeepServiceStatus? arg_status = (args[1] as PCallkeepServiceStatus?);
+          assert(
+            arg_status != null,
+            'Argument for dev.flutter.pigeon.webtrit_callkeep_android.PDelegateBackgroundRegisterFlutterApi.onApplicationStatusChanged was null, expected non-null PCallkeepServiceStatus.',
+          );
+          try {
+            await api.onApplicationStatusChanged(arg_applicationStatusCallbackHandle!, arg_status!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -250,13 +250,36 @@ extension CallkeepLifecycleTypeConverter on CallkeepLifecycleEvent {
   }
 }
 
-extension PCallkeepPushNotificationSyncStatusConverter on PCallkeepPushNotificationSyncStatus {
-  CallkeepPushNotificationSyncStatus toCallkeep() {
+extension PCallkeepSignalingStatusConverter on PCallkeepSignalingStatus {
+  CallkeepSignalingStatus toCallkeep() {
     switch (this) {
-      case PCallkeepPushNotificationSyncStatus.synchronizeCallStatus:
-        return CallkeepPushNotificationSyncStatus.synchronizeCallStatus;
-      case PCallkeepPushNotificationSyncStatus.releaseResources:
-        return CallkeepPushNotificationSyncStatus.releaseResources;
+      case PCallkeepSignalingStatus.disconnecting:
+        return CallkeepSignalingStatus.disconnecting;
+      case PCallkeepSignalingStatus.disconnect:
+        return CallkeepSignalingStatus.disconnect;
+      case PCallkeepSignalingStatus.connecting:
+        return CallkeepSignalingStatus.connecting;
+      case PCallkeepSignalingStatus.connect:
+        return CallkeepSignalingStatus.connect;
+      case PCallkeepSignalingStatus.failure:
+        return CallkeepSignalingStatus.failure;
+    }
+  }
+}
+
+extension CallkeepSignalingStatusConverter on CallkeepSignalingStatus {
+  PCallkeepSignalingStatus toPigeon() {
+    switch (this) {
+      case CallkeepSignalingStatus.disconnecting:
+        return PCallkeepSignalingStatus.disconnecting;
+      case CallkeepSignalingStatus.disconnect:
+        return PCallkeepSignalingStatus.disconnect;
+      case CallkeepSignalingStatus.connecting:
+        return PCallkeepSignalingStatus.connecting;
+      case CallkeepSignalingStatus.connect:
+        return PCallkeepSignalingStatus.connect;
+      case CallkeepSignalingStatus.failure:
+        return PCallkeepSignalingStatus.failure;
     }
   }
 }

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -250,40 +250,6 @@ extension CallkeepLifecycleTypeConverter on CallkeepLifecycleEvent {
   }
 }
 
-extension PCallkeepSignalingStatusConverter on PCallkeepSignalingStatus {
-  CallkeepSignalingStatus toCallkeep() {
-    switch (this) {
-      case PCallkeepSignalingStatus.disconnecting:
-        return CallkeepSignalingStatus.disconnecting;
-      case PCallkeepSignalingStatus.disconnect:
-        return CallkeepSignalingStatus.disconnect;
-      case PCallkeepSignalingStatus.connecting:
-        return CallkeepSignalingStatus.connecting;
-      case PCallkeepSignalingStatus.connect:
-        return CallkeepSignalingStatus.connect;
-      case PCallkeepSignalingStatus.failure:
-        return CallkeepSignalingStatus.failure;
-    }
-  }
-}
-
-extension CallkeepSignalingStatusConverter on CallkeepSignalingStatus {
-  PCallkeepSignalingStatus toPigeon() {
-    switch (this) {
-      case CallkeepSignalingStatus.disconnecting:
-        return PCallkeepSignalingStatus.disconnecting;
-      case CallkeepSignalingStatus.disconnect:
-        return PCallkeepSignalingStatus.disconnect;
-      case CallkeepSignalingStatus.connecting:
-        return PCallkeepSignalingStatus.connecting;
-      case CallkeepSignalingStatus.connect:
-        return PCallkeepSignalingStatus.connect;
-      case CallkeepSignalingStatus.failure:
-        return PCallkeepSignalingStatus.failure;
-    }
-  }
-}
-
 extension PCallkeepIncomingCallDataConverter on PCallkeepIncomingCallData {
   CallkeepIncomingCallMetadata toCallkeep() {
     return CallkeepIncomingCallMetadata(

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -303,6 +303,11 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
     return _backgroundPushNotificationIsolateApi.endCall(callId);
   }
 
+  @override
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) {
+    return _backgroundPushNotificationIsolateApi.releaseCall(callId);
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android background push notification service
 
@@ -515,13 +520,17 @@ class _BackgroundServiceDelegate implements PDelegateBackgroundRegisterFlutterAp
   }
 
   @override
-  Future<void> onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  ) async {
+  Future<void> onApplicationStatusChanged(int applicationStatusCallbackHandle, PCallkeepServiceStatus status) async {
+    final handle = CallbackHandle.fromRawHandle(applicationStatusCallbackHandle);
+    final closure = PluginUtilities.getCallbackFromHandle(handle)! as ForegroundChangeLifecycleHandle;
+
+    await closure(status.toCallkeep());
+  }
+
+  @override
+  Future<void> onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData) async {
     final handle = CallbackHandle.fromRawHandle(pushNotificationSyncStatusHandle);
     final closure = PluginUtilities.getCallbackFromHandle(handle)! as CallKeepPushNotificationSyncStatusHandle;
-    await closure(status.toCallkeep(), callData?.toCallkeep());
+    await closure(callData?.toCallkeep());
   }
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -151,8 +151,6 @@ class PCallRequestError {
 
 enum PCallkeepLifecycleEvent { onCreate, onStart, onResume, onPause, onStop, onDestroy, onAny }
 
-enum PCallkeepPushNotificationSyncStatus { synchronizeCallStatus, releaseResources }
-
 class PCallkeepIncomingCallData {
   late String callId;
   late PHandle? handle;
@@ -221,6 +219,9 @@ abstract class PHostBackgroundPushNotificationIsolateApi {
 
   @async
   void endAllCalls();
+
+  @async
+  void releaseCall(String callId);
 }
 
 @HostApi()
@@ -269,11 +270,10 @@ abstract class PDelegateBackgroundRegisterFlutterApi {
   );
 
   @async
-  void onNotificationSync(
-    int pushNotificationSyncStatusHandle,
-    PCallkeepPushNotificationSyncStatus status,
-    PCallkeepIncomingCallData? callData,
-  );
+  void onApplicationStatusChanged(int applicationStatusCallbackHandle, PCallkeepServiceStatus status);
+
+  @async
+  void onNotificationSync(int pushNotificationSyncStatusHandle, PCallkeepIncomingCallData? callData);
 }
 
 @HostApi()

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -471,22 +471,60 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // PCallkeepPushNotificationSyncStatusConverter
+  // PCallkeepSignalingStatusConverter
   // ---------------------------------------------------------------------------
 
-  group('PCallkeepPushNotificationSyncStatusConverter.toCallkeep()', () {
-    test('synchronizeCallStatus', () {
-      expect(
-        PCallkeepPushNotificationSyncStatus.synchronizeCallStatus.toCallkeep(),
-        CallkeepPushNotificationSyncStatus.synchronizeCallStatus,
-      );
+  group('PCallkeepSignalingStatusConverter.toCallkeep()', () {
+    test('disconnecting', () {
+      expect(PCallkeepSignalingStatus.disconnecting.toCallkeep(), CallkeepSignalingStatus.disconnecting);
     });
 
-    test('releaseResources', () {
-      expect(
-        PCallkeepPushNotificationSyncStatus.releaseResources.toCallkeep(),
-        CallkeepPushNotificationSyncStatus.releaseResources,
-      );
+    test('disconnect', () {
+      expect(PCallkeepSignalingStatus.disconnect.toCallkeep(), CallkeepSignalingStatus.disconnect);
+    });
+
+    test('connecting', () {
+      expect(PCallkeepSignalingStatus.connecting.toCallkeep(), CallkeepSignalingStatus.connecting);
+    });
+
+    test('connect', () {
+      expect(PCallkeepSignalingStatus.connect.toCallkeep(), CallkeepSignalingStatus.connect);
+    });
+
+    test('failure', () {
+      expect(PCallkeepSignalingStatus.failure.toCallkeep(), CallkeepSignalingStatus.failure);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CallkeepSignalingStatusConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepSignalingStatusConverter.toPigeon()', () {
+    test('disconnecting', () {
+      expect(CallkeepSignalingStatus.disconnecting.toPigeon(), PCallkeepSignalingStatus.disconnecting);
+    });
+
+    test('disconnect', () {
+      expect(CallkeepSignalingStatus.disconnect.toPigeon(), PCallkeepSignalingStatus.disconnect);
+    });
+
+    test('connecting', () {
+      expect(CallkeepSignalingStatus.connecting.toPigeon(), PCallkeepSignalingStatus.connecting);
+    });
+
+    test('connect', () {
+      expect(CallkeepSignalingStatus.connect.toPigeon(), PCallkeepSignalingStatus.connect);
+    });
+
+    test('failure', () {
+      expect(CallkeepSignalingStatus.failure.toPigeon(), PCallkeepSignalingStatus.failure);
+    });
+
+    test('round-trip for all values', () {
+      for (final status in CallkeepSignalingStatus.values) {
+        expect(status.toPigeon().toCallkeep(), status);
+      }
     });
   });
 

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -471,64 +471,6 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // PCallkeepSignalingStatusConverter
-  // ---------------------------------------------------------------------------
-
-  group('PCallkeepSignalingStatusConverter.toCallkeep()', () {
-    test('disconnecting', () {
-      expect(PCallkeepSignalingStatus.disconnecting.toCallkeep(), CallkeepSignalingStatus.disconnecting);
-    });
-
-    test('disconnect', () {
-      expect(PCallkeepSignalingStatus.disconnect.toCallkeep(), CallkeepSignalingStatus.disconnect);
-    });
-
-    test('connecting', () {
-      expect(PCallkeepSignalingStatus.connecting.toCallkeep(), CallkeepSignalingStatus.connecting);
-    });
-
-    test('connect', () {
-      expect(PCallkeepSignalingStatus.connect.toCallkeep(), CallkeepSignalingStatus.connect);
-    });
-
-    test('failure', () {
-      expect(PCallkeepSignalingStatus.failure.toCallkeep(), CallkeepSignalingStatus.failure);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // CallkeepSignalingStatusConverter
-  // ---------------------------------------------------------------------------
-
-  group('CallkeepSignalingStatusConverter.toPigeon()', () {
-    test('disconnecting', () {
-      expect(CallkeepSignalingStatus.disconnecting.toPigeon(), PCallkeepSignalingStatus.disconnecting);
-    });
-
-    test('disconnect', () {
-      expect(CallkeepSignalingStatus.disconnect.toPigeon(), PCallkeepSignalingStatus.disconnect);
-    });
-
-    test('connecting', () {
-      expect(CallkeepSignalingStatus.connecting.toPigeon(), PCallkeepSignalingStatus.connecting);
-    });
-
-    test('connect', () {
-      expect(CallkeepSignalingStatus.connect.toPigeon(), PCallkeepSignalingStatus.connect);
-    });
-
-    test('failure', () {
-      expect(CallkeepSignalingStatus.failure.toPigeon(), PCallkeepSignalingStatus.failure);
-    });
-
-    test('round-trip for all values', () {
-      for (final status in CallkeepSignalingStatus.values) {
-        expect(status.toPigeon().toCallkeep(), status);
-      }
-    });
-  });
-
-  // ---------------------------------------------------------------------------
   // PCallkeepIncomingCallDataConverter
   // ---------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
@@ -56,47 +56,44 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepSignalingStatus) {
-      buffer.putUint8(142);
-      writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
-      buffer.putUint8(143);
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else if (value is PAndroidOptions) {
-      buffer.putUint8(144);
+      buffer.putUint8(143);
       writeValue(buffer, value.encode());
     } else if (value is POptions) {
-      buffer.putUint8(145);
+      buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else if (value is PAudioDevice) {
-      buffer.putUint8(146);
+      buffer.putUint8(145);
       writeValue(buffer, value.encode());
     } else if (value is PPermissionResult) {
-      buffer.putUint8(147);
+      buffer.putUint8(146);
       writeValue(buffer, value.encode());
     } else if (value is PHandle) {
-      buffer.putUint8(148);
+      buffer.putUint8(147);
       writeValue(buffer, value.encode());
     } else if (value is PEndCallReason) {
-      buffer.putUint8(149);
+      buffer.putUint8(148);
       writeValue(buffer, value.encode());
     } else if (value is PIncomingCallError) {
-      buffer.putUint8(150);
+      buffer.putUint8(149);
       writeValue(buffer, value.encode());
     } else if (value is PCallRequestError) {
-      buffer.putUint8(151);
+      buffer.putUint8(150);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepIncomingCallData) {
-      buffer.putUint8(152);
+      buffer.putUint8(151);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepServiceStatus) {
-      buffer.putUint8(153);
+      buffer.putUint8(152);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepDisconnectCause) {
-      buffer.putUint8(154);
+      buffer.putUint8(153);
       writeValue(buffer, value.encode());
     } else if (value is PCallkeepConnection) {
-      buffer.putUint8(155);
+      buffer.putUint8(154);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -146,33 +143,30 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
-        final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepSignalingStatus.values[value];
-      case 143:
         return PIOSOptions.decode(readValue(buffer)!);
-      case 144:
+      case 143:
         return PAndroidOptions.decode(readValue(buffer)!);
-      case 145:
+      case 144:
         return POptions.decode(readValue(buffer)!);
-      case 146:
+      case 145:
         return PAudioDevice.decode(readValue(buffer)!);
-      case 147:
+      case 146:
         return PPermissionResult.decode(readValue(buffer)!);
-      case 148:
+      case 147:
         return PHandle.decode(readValue(buffer)!);
-      case 149:
+      case 148:
         return PEndCallReason.decode(readValue(buffer)!);
-      case 150:
+      case 149:
         return PIncomingCallError.decode(readValue(buffer)!);
-      case 151:
+      case 150:
         return PCallRequestError.decode(readValue(buffer)!);
-      case 152:
+      case 151:
         return PCallkeepIncomingCallData.decode(readValue(buffer)!);
-      case 153:
+      case 152:
         return PCallkeepServiceStatus.decode(readValue(buffer)!);
-      case 154:
+      case 153:
         return PCallkeepDisconnectCause.decode(readValue(buffer)!);
-      case 155:
+      case 154:
         return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/test/src/common/test_callkeep.pigeon.dart
@@ -50,13 +50,13 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepLifecycleEvent) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepPushNotificationSyncStatus) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepConnectionState) {
+    } else if (value is PCallkeepDisconnectCauseType) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is PCallkeepDisconnectCauseType) {
+    } else if (value is PCallkeepSignalingStatus) {
       buffer.putUint8(142);
       writeValue(buffer, value.index);
     } else if (value is PIOSOptions) {
@@ -141,13 +141,13 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : PCallkeepLifecycleEvent.values[value];
       case 140:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepPushNotificationSyncStatus.values[value];
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 141:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepConnectionState.values[value];
+        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
       case 142:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : PCallkeepDisconnectCauseType.values[value];
+        return value == null ? null : PCallkeepSignalingStatus.values[value];
       case 143:
         return PIOSOptions.decode(readValue(buffer)!);
       case 144:

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_types.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_types.dart
@@ -1,6 +1,5 @@
 import 'callkeep_incoming_call_metadata.dart';
 import 'callkeep_service_status.dart';
-import 'callkeep_push_notification_status_sync.dart';
 
 /// A callback function that gets triggered when the foreground service starts.
 ///
@@ -10,11 +9,16 @@ import 'callkeep_push_notification_status_sync.dart';
 typedef ForegroundStartServiceHandle =
     Future<void> Function(CallkeepServiceStatus callkeepServiceStatus, CallkeepIncomingCallMetadata? metadata);
 
-/// A callback function that gets triggered when there is a change in the push notification sync status.
+/// A callback function that gets triggered when a push notification sync is requested.
 ///
-/// [status] - Provides the current status of the Callkeep push notification sync.
 /// [metadata] - Provides the metadata of the incoming call that started the isolate, if available.
 ///
-/// Returns a [Future] that completes after handling the status change.
-typedef CallKeepPushNotificationSyncStatusHandle =
-    Future<void> Function(CallkeepPushNotificationSyncStatus status, CallkeepIncomingCallMetadata? metadata);
+/// Returns a [Future] that completes after handling the sync, including all cleanup.
+typedef CallKeepPushNotificationSyncStatusHandle = Future<void> Function(CallkeepIncomingCallMetadata? metadata);
+
+/// A callback function that gets triggered when there is a change in the lifecycle of the foreground service.
+///
+/// [callkeepServiceStatus] - Provides the current status of the Callkeep service when the lifecycle changes.
+///
+/// Returns a [Future] that completes after handling the lifecycle change.
+typedef ForegroundChangeLifecycleHandle = Future<void> Function(CallkeepServiceStatus callkeepServiceStatus);

--- a/webtrit_callkeep_platform_interface/lib/src/models/models.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/models.dart
@@ -10,7 +10,6 @@ export 'callkeep_lifecycle_event.dart';
 export 'callkeep_log_type.dart';
 export 'callkeep_options.dart';
 export 'callkeep_permission.dart';
-export 'callkeep_push_notification_status_sync.dart';
 export 'callkeep_service_status.dart';
 export 'callkeep_special_permission.dart';
 export 'callkeep_special_permission_status.dart';

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -307,6 +307,10 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('hungUpAndroidService() has not been implemented.');
   }
 
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) {
+    throw UnimplementedError('releaseCallBackgroundPushNotificationService() has not been implemented.');
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android SMS reception section
   // ------------------------------------------------------------------------------------------------

--- a/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
+++ b/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
@@ -320,6 +320,9 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   @override
   Future<dynamic> endCallBackgroundPushNotificationService(String callId) async {}
 
+  @override
+  Future<dynamic> releaseCallBackgroundPushNotificationService(String callId) async {}
+
   // ---------------------------------------------------------------------------
   // Android SMS reception (no-op on web)
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `PCallkeepPushNotificationSyncStatus` enum and status-based callback — the Dart isolate now manages its own lifecycle end-to-end
- Adds unconditional `releaseCall(callId)` to `PHostBackgroundPushNotificationIsolateApi`: calls `terminateCall(SERVER)` + `stopService()` regardless of Telecom connection state
- Removes `releaseResources` from `FlutterIsolateCommunicator` — isolate self-manages cleanup
- Adds 60s independent safety-net timeout in `IncomingCallService` for isolate crash/hang scenarios
- Moves `IC_RELEASE_WITH_DECLINE` guard into `IncomingCallService.onStartCommand` (main process) instead of `NotificationManager` (`:callkeep_core` process) — fixes cross-process static field issue

## Test plan

- [ ] Incoming push call dismissed when caller hangs up while app is backgrounded
- [ ] Normal answer flow still works (user answers → call connects)
- [ ] Normal decline flow still works (user declines → service stops)
- [ ] `CallLifecycleHandlerTest` passes (updated to reflect removed `releaseResources`)