### PR TITLE
feat(android): configurable incoming/outgoing call timeout via CallkeepAndroidOptions

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -406,13 +406,25 @@ data class PAndroidOptions(
     val ringtoneSound: String? = null,
     val ringbackSound: String? = null,
     val incomingCallFullScreen: Boolean? = null,
+    /**
+     * Timeout in milliseconds before an unanswered incoming call (STATE_RINGING) is
+     * automatically disconnected. When null the native default is used.
+     */
+    val incomingCallTimeoutMs: Long? = null,
+    /**
+     * Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING) is
+     * automatically disconnected. When null the native default is used.
+     */
+    val outgoingCallTimeoutMs: Long? = null,
 ) {
     companion object {
         fun fromList(pigeonVar_list: List<Any?>): PAndroidOptions {
             val ringtoneSound = pigeonVar_list[0] as String?
             val ringbackSound = pigeonVar_list[1] as String?
             val incomingCallFullScreen = pigeonVar_list[2] as Boolean?
-            return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen)
+            val incomingCallTimeoutMs = pigeonVar_list[3] as Long?
+            val outgoingCallTimeoutMs = pigeonVar_list[4] as Long?
+            return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen, incomingCallTimeoutMs, outgoingCallTimeoutMs)
         }
     }
 
@@ -421,6 +433,8 @@ data class PAndroidOptions(
             ringtoneSound,
             ringbackSound,
             incomingCallFullScreen,
+            incomingCallTimeoutMs,
+            outgoingCallTimeoutMs,
         )
 
     override fun equals(other: Any?): Boolean {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -82,6 +82,30 @@ object StorageDelegate {
         fun getCallbackDispatcher(context: Context): Long = sharedPreferences(context).getLong(INCOMING_CALL_HANDLER, -1)
     }
 
+    object Timeout {
+        private const val INCOMING_CALL_TIMEOUT_MS = "INCOMING_CALL_TIMEOUT_MS"
+        private const val OUTGOING_CALL_TIMEOUT_MS = "OUTGOING_CALL_TIMEOUT_MS"
+        private const val DEFAULT_TIMEOUT_MS = 35_000L
+
+        fun setIncomingCallTimeoutMs(
+            context: Context,
+            ms: Long,
+        ) {
+            sharedPreferences(context).edit().putLong(INCOMING_CALL_TIMEOUT_MS, ms).apply()
+        }
+
+        fun getIncomingCallTimeoutMs(context: Context): Long = sharedPreferences(context).getLong(INCOMING_CALL_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
+
+        fun setOutgoingCallTimeoutMs(
+            context: Context,
+            ms: Long,
+        ) {
+            sharedPreferences(context).edit().putLong(OUTGOING_CALL_TIMEOUT_MS, ms).apply()
+        }
+
+        fun getOutgoingCallTimeoutMs(context: Context): Long = sharedPreferences(context).getLong(OUTGOING_CALL_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
+    }
+
     object IncomingCallSmsConfig {
         private const val SMS_PREFIX = "SMS_PREFIX"
         private const val SMS_REGEX_PATTERN = "SMS_REGEX_PATTERN"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -85,7 +85,7 @@ object StorageDelegate {
     object Timeout {
         private const val INCOMING_CALL_TIMEOUT_MS = "INCOMING_CALL_TIMEOUT_MS"
         private const val OUTGOING_CALL_TIMEOUT_MS = "OUTGOING_CALL_TIMEOUT_MS"
-        private const val DEFAULT_TIMEOUT_MS = 35_000L
+        private const val DEFAULT_TIMEOUT_MS = 60_000L
 
         fun setIncomingCallTimeoutMs(
             context: Context,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -18,6 +18,7 @@ import androidx.core.net.toUri
 import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.Platform
+import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.managers.AudioManager
 import com.webtrit.callkeep.managers.NotificationManager
 import com.webtrit.callkeep.models.AudioDevice
@@ -761,7 +762,7 @@ class PhoneConnection internal constructor(
             dispatcher = dispatcher,
             metadata = metadata,
             onDisconnectCallback = onDisconnect,
-            timeout = ConnectionTimeout.createIncomingConnectionTimeout(),
+            timeout = ConnectionTimeout.createIncomingConnectionTimeout(context),
         ).apply {
             setInitialized()
             setRinging()
@@ -780,7 +781,7 @@ class PhoneConnection internal constructor(
             dispatcher = dispatcher,
             metadata = metadata,
             onDisconnectCallback = onDisconnect,
-            timeout = ConnectionTimeout.createOutgoingConnectionTimeout(),
+            timeout = ConnectionTimeout.createOutgoingConnectionTimeout(context),
         ).apply {
             setDialing()
             setCallerDisplayName(metadata.name, TelecomManager.PRESENTATION_ALLOWED)
@@ -820,11 +821,6 @@ class ConnectionTimeout(
 
     companion object {
         /**
-         * Duration in milliseconds before a call in a transient state is automatically disconnected.
-         */
-        private const val TIMEOUT_DURATION_MS = 35000L
-
-        /**
          * Telecom states that trigger the timeout for incoming calls.
          */
         private val DEFAULT_INCOMING_STATES = listOf(Connection.STATE_NEW, Connection.STATE_RINGING)
@@ -836,12 +832,14 @@ class ConnectionTimeout(
 
         /**
          * Creates a timeout configuration for outgoing dialing.
+         * The duration is read from [StorageDelegate.Timeout] so it can be configured via [CallkeepAndroidOptions].
          */
-        fun createOutgoingConnectionTimeout() = ConnectionTimeout(TIMEOUT_DURATION_MS, DEFAULT_OUTGOING_STATES)
+        fun createOutgoingConnectionTimeout(context: Context) = ConnectionTimeout(StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context), DEFAULT_OUTGOING_STATES)
 
         /**
          * Creates a timeout configuration for incoming ringing.
+         * The duration is read from [StorageDelegate.Timeout] so it can be configured via [CallkeepAndroidOptions].
          */
-        fun createIncomingConnectionTimeout() = ConnectionTimeout(TIMEOUT_DURATION_MS, DEFAULT_INCOMING_STATES)
+        fun createIncomingConnectionTimeout(context: Context) = ConnectionTimeout(StorageDelegate.Timeout.getIncomingCallTimeoutMs(context), DEFAULT_INCOMING_STATES)
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -242,6 +242,8 @@ class ForegroundService :
             options.android.ringtoneSound?.let { StorageDelegate.Sound.initRingtonePath(baseContext, it) }
             options.android.ringbackSound?.let { StorageDelegate.Sound.initRingbackPath(baseContext, it) }
             options.android.incomingCallFullScreen?.let { StorageDelegate.IncomingCall.setFullScreen(baseContext, it) }
+            options.android.incomingCallTimeoutMs?.let { StorageDelegate.Timeout.setIncomingCallTimeoutMs(baseContext, it) }
+            options.android.outgoingCallTimeoutMs?.let { StorageDelegate.Timeout.setOutgoingCallTimeoutMs(baseContext, it) }
         }.onFailure { Log.w("CallKeep", "Android options init failed: ${it.message}", it) }
     }
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateTimeoutTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/StorageDelegateTimeoutTest.kt
@@ -1,0 +1,83 @@
+package com.webtrit.callkeep.common
+
+import android.content.Context
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class StorageDelegateTimeoutTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+    }
+
+    // -------------------------------------------------------------------------
+    // Incoming timeout — default / set / get
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getIncomingCallTimeoutMs returns 60000 by default when key is absent`() {
+        assertEquals(60_000L, StorageDelegate.Timeout.getIncomingCallTimeoutMs(context))
+    }
+
+    @Test
+    fun `setIncomingCallTimeoutMs is returned by getIncomingCallTimeoutMs`() {
+        StorageDelegate.Timeout.setIncomingCallTimeoutMs(context, 120_000L)
+        assertEquals(120_000L, StorageDelegate.Timeout.getIncomingCallTimeoutMs(context))
+    }
+
+    @Test
+    fun `setIncomingCallTimeoutMs can be updated to a new value`() {
+        StorageDelegate.Timeout.setIncomingCallTimeoutMs(context, 90_000L)
+        assertEquals(90_000L, StorageDelegate.Timeout.getIncomingCallTimeoutMs(context))
+
+        StorageDelegate.Timeout.setIncomingCallTimeoutMs(context, 30_000L)
+        assertEquals(30_000L, StorageDelegate.Timeout.getIncomingCallTimeoutMs(context))
+    }
+
+    // -------------------------------------------------------------------------
+    // Outgoing timeout — default / set / get
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getOutgoingCallTimeoutMs returns 60000 by default when key is absent`() {
+        assertEquals(60_000L, StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context))
+    }
+
+    @Test
+    fun `setOutgoingCallTimeoutMs is returned by getOutgoingCallTimeoutMs`() {
+        StorageDelegate.Timeout.setOutgoingCallTimeoutMs(context, 120_000L)
+        assertEquals(120_000L, StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context))
+    }
+
+    @Test
+    fun `setOutgoingCallTimeoutMs can be updated to a new value`() {
+        StorageDelegate.Timeout.setOutgoingCallTimeoutMs(context, 90_000L)
+        assertEquals(90_000L, StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context))
+
+        StorageDelegate.Timeout.setOutgoingCallTimeoutMs(context, 30_000L)
+        assertEquals(30_000L, StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context))
+    }
+
+    // -------------------------------------------------------------------------
+    // Incoming and outgoing are independent
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `incoming and outgoing timeouts are stored independently`() {
+        StorageDelegate.Timeout.setIncomingCallTimeoutMs(context, 120_000L)
+        StorageDelegate.Timeout.setOutgoingCallTimeoutMs(context, 45_000L)
+
+        assertEquals(120_000L, StorageDelegate.Timeout.getIncomingCallTimeoutMs(context))
+        assertEquals(45_000L, StorageDelegate.Timeout.getOutgoingCallTimeoutMs(context))
+    }
+}

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -247,7 +247,13 @@ class PIOSOptions {
 }
 
 class PAndroidOptions {
-  PAndroidOptions({this.ringtoneSound, this.ringbackSound, this.incomingCallFullScreen});
+  PAndroidOptions({
+    this.ringtoneSound,
+    this.ringbackSound,
+    this.incomingCallFullScreen,
+    this.incomingCallTimeoutMs,
+    this.outgoingCallTimeoutMs,
+  });
 
   String? ringtoneSound;
 
@@ -255,8 +261,22 @@ class PAndroidOptions {
 
   bool? incomingCallFullScreen;
 
+  /// Timeout in milliseconds before an unanswered incoming call (STATE_RINGING) is
+  /// automatically disconnected. When null the native default is used.
+  int? incomingCallTimeoutMs;
+
+  /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING) is
+  /// automatically disconnected. When null the native default is used.
+  int? outgoingCallTimeoutMs;
+
   List<Object?> _toList() {
-    return <Object?>[ringtoneSound, ringbackSound, incomingCallFullScreen];
+    return <Object?>[
+      ringtoneSound,
+      ringbackSound,
+      incomingCallFullScreen,
+      incomingCallTimeoutMs,
+      outgoingCallTimeoutMs,
+    ];
   }
 
   Object encode() {
@@ -269,6 +289,8 @@ class PAndroidOptions {
       ringtoneSound: result[0] as String?,
       ringbackSound: result[1] as String?,
       incomingCallFullScreen: result[2] as bool?,
+      incomingCallTimeoutMs: result[3] as int?,
+      outgoingCallTimeoutMs: result[4] as int?,
     );
   }
 

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -175,6 +175,8 @@ extension CallkeepAndroidOptionsConverter on CallkeepAndroidOptions {
       ringtoneSound: ringtoneSound,
       ringbackSound: ringbackSound,
       incomingCallFullScreen: incomingCallFullScreen,
+      incomingCallTimeoutMs: incomingCallTimeoutMs,
+      outgoingCallTimeoutMs: outgoingCallTimeoutMs,
     );
   }
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -29,6 +29,14 @@ class PAndroidOptions {
   late String? ringtoneSound;
   late String? ringbackSound;
   late bool? incomingCallFullScreen;
+
+  /// Timeout in milliseconds before an unanswered incoming call (STATE_RINGING) is
+  /// automatically disconnected. When null the native default is used.
+  late int? incomingCallTimeoutMs;
+
+  /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING) is
+  /// automatically disconnected. When null the native default is used.
+  late int? outgoingCallTimeoutMs;
 }
 
 class POptions {

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -56,8 +56,8 @@ class CallkeepAndroidOptions extends Equatable {
     this.ringtoneSound,
     this.ringbackSound,
     this.incomingCallFullScreen,
-    this.incomingCallTimeoutMs,
-    this.outgoingCallTimeoutMs,
+    this.incomingCallTimeoutMs = 60000,
+    this.outgoingCallTimeoutMs = 60000,
   });
 
   final String? ringtoneSound;

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -69,12 +69,12 @@ class CallkeepAndroidOptions extends Equatable {
   final bool? incomingCallFullScreen;
 
   /// Timeout in milliseconds before an unanswered incoming call (STATE_RINGING)
-  /// is automatically disconnected. When null the native default (60 000 ms) is used.
-  final int? incomingCallTimeoutMs;
+  /// is automatically disconnected. Defaults to `60000` ms.
+  final int incomingCallTimeoutMs;
 
   /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING)
-  /// is automatically disconnected. When null the native default (60 000 ms) is used.
-  final int? outgoingCallTimeoutMs;
+  /// is automatically disconnected. Defaults to `60000` ms.
+  final int outgoingCallTimeoutMs;
 
   @override
   List<Object?> get props => [

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -52,7 +52,13 @@ class CallkeepIOSOptions extends Equatable {
 }
 
 class CallkeepAndroidOptions extends Equatable {
-  const CallkeepAndroidOptions({this.ringtoneSound, this.ringbackSound, this.incomingCallFullScreen});
+  const CallkeepAndroidOptions({
+    this.ringtoneSound,
+    this.ringbackSound,
+    this.incomingCallFullScreen,
+    this.incomingCallTimeoutMs,
+    this.outgoingCallTimeoutMs,
+  });
 
   final String? ringtoneSound;
   final String? ringbackSound;
@@ -62,6 +68,20 @@ class CallkeepAndroidOptions extends Equatable {
   /// when not specified. Pass `false` to show a heads-up notification instead.
   final bool? incomingCallFullScreen;
 
+  /// Timeout in milliseconds before an unanswered incoming call (STATE_RINGING)
+  /// is automatically disconnected. When null the native default (35 000 ms) is used.
+  final int? incomingCallTimeoutMs;
+
+  /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING)
+  /// is automatically disconnected. When null the native default (35 000 ms) is used.
+  final int? outgoingCallTimeoutMs;
+
   @override
-  List<Object?> get props => [ringtoneSound, ringbackSound, incomingCallFullScreen];
+  List<Object?> get props => [
+    ringtoneSound,
+    ringbackSound,
+    incomingCallFullScreen,
+    incomingCallTimeoutMs,
+    outgoingCallTimeoutMs,
+  ];
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -69,11 +69,11 @@ class CallkeepAndroidOptions extends Equatable {
   final bool? incomingCallFullScreen;
 
   /// Timeout in milliseconds before an unanswered incoming call (STATE_RINGING)
-  /// is automatically disconnected. When null the native default (35 000 ms) is used.
+  /// is automatically disconnected. When null the native default (60 000 ms) is used.
   final int? incomingCallTimeoutMs;
 
   /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING)
-  /// is automatically disconnected. When null the native default (35 000 ms) is used.
+  /// is automatically disconnected. When null the native default (60 000 ms) is used.
   final int? outgoingCallTimeoutMs;
 
   @override


### PR DESCRIPTION
## Summary

- Adds `incomingCallTimeoutMs` and `outgoingCallTimeoutMs` to `CallkeepAndroidOptions` so callers can configure how long the app waits before auto-disconnecting an unanswered call
- Default is **60 000 ms** (both Dart constructor and native fallback), up from the previous hardcoded 35 000 ms
- Values are persisted via `StorageDelegate.Timeout` and read by `ConnectionTimeout` factory methods at connection creation time — no change needed to call sites beyond passing `context`
- Generated Pigeon files (`callkeep.pigeon.dart`, `Generated.kt`) regenerated via `flutter pub run pigeon`

## Motivation

PortaSIP terminates unanswered calls after 120 s. The previous 35 s hardcoded timeout caused CallKeep to disconnect calls on the Android side well before PortaSIP acted, resulting in unexpected early hang-ups (see WT-1273).

## Usage

```dart
android: CallkeepAndroidOptions(
  ringtoneSound: Assets.ringtones.incomingCall1,
  ringbackSound: Assets.ringtones.outgoingCall1,
  incomingCallTimeoutMs: 120000,  // align with PortaSIP
  outgoingCallTimeoutMs: 120000,
),
```

## Test plan

- [ ] Incoming call — do not answer — verify call stays active for at least 60 s before auto-disconnect
- [ ] Outgoing call — remote does not answer — verify caller stays in DIALING for at least 60 s
- [ ] Pass explicit `incomingCallTimeoutMs: 120000` — verify timeout fires after 120 s
- [ ] Omit the fields — verify default 60 s behaviour

Fixes WT-1273