### PR TITLE
fix: avoid Vulkan/Impeller init in callkeep background engine

### DIFF
--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger;
 
 import 'package:webtrit_callkeep_android/src/common/common.dart';
 import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
@@ -491,10 +492,17 @@ class _CallkeepBackgroundServiceDelegateRelay implements PDelegateBackgroundServ
 
 @pragma('vm:entry-point')
 void _isolatePluginCallbackDispatcher() {
-  // Initialize the Flutter framework necessary for method channels and Pigeon.
-  WidgetsFlutterBinding.ensureInitialized();
+  // Use BackgroundIsolateBinaryMessenger when the RootIsolateToken is available
+  // (background Flutter engine root isolate) to avoid initialising the full
+  // rendering stack (RendererBinding / Impeller / Vulkan). Falls back to
+  // WidgetsFlutterBinding when the token is unexpectedly absent.
+  final token = RootIsolateToken.instance;
+  if (token != null) {
+    BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
 
-  // WebtritCallkeepAndroid().wakeUpBackgroundHandler();
   // Set up the Pigeon API for the background service.
   PDelegateBackgroundRegisterFlutterApi.setUp(_BackgroundServiceDelegate());
 }

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger;
+import 'package:flutter/services.dart' show BackgroundIsolateBinaryMessenger, BinaryMessenger;
+import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 
 import 'package:webtrit_callkeep_android/src/common/common.dart';
 import 'package:webtrit_callkeep_platform_interface/webtrit_callkeep_platform_interface.dart';
@@ -492,19 +492,27 @@ class _CallkeepBackgroundServiceDelegateRelay implements PDelegateBackgroundServ
 
 @pragma('vm:entry-point')
 void _isolatePluginCallbackDispatcher() {
-  // Use BackgroundIsolateBinaryMessenger when the RootIsolateToken is available
-  // (background Flutter engine root isolate) to avoid initialising the full
-  // rendering stack (RendererBinding / Impeller / Vulkan). Falls back to
-  // WidgetsFlutterBinding when the token is unexpectedly absent.
+  final messenger = _ensureBinaryMessengerInitialized();
+  PDelegateBackgroundRegisterFlutterApi.setUp(_BackgroundServiceDelegate(), binaryMessenger: messenger);
+}
+
+/// Initialises a [BinaryMessenger] for platform channels in this background
+/// isolate without touching the full Flutter rendering stack.
+///
+/// Returns [BackgroundIsolateBinaryMessenger.instance] when
+/// [RootIsolateToken.instance] is available (background Flutter engine root
+/// isolate), avoiding RendererBinding / Impeller / Vulkan initialisation.
+/// Falls back to [WidgetsFlutterBinding] and returns `null` (Pigeon uses the
+/// binding's default messenger) when the token is unexpectedly absent.
+BinaryMessenger? _ensureBinaryMessengerInitialized() {
   final token = RootIsolateToken.instance;
   if (token != null) {
     BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+    return BackgroundIsolateBinaryMessenger.instance;
   } else {
     WidgetsFlutterBinding.ensureInitialized();
+    return null;
   }
-
-  // Set up the Pigeon API for the background service.
-  PDelegateBackgroundRegisterFlutterApi.setUp(_BackgroundServiceDelegate());
 }
 
 class _BackgroundServiceDelegate implements PDelegateBackgroundRegisterFlutterApi {


### PR DESCRIPTION
## Overview

The background isolate entry point `_isolatePluginCallbackDispatcher` used `WidgetsFlutterBinding.ensureInitialized()` to set up platform channels required by Pigeon. `WidgetsFlutterBinding` initialises the full rendering stack (`RendererBinding` → Impeller → Vulkan). A background Flutter engine has no rendering surface and does not need any of that — it only needs a `BinaryMessenger` to communicate over platform channels.

## Changes

**Replace binding initialisation:**
`WidgetsFlutterBinding.ensureInitialized()` → `BackgroundIsolateBinaryMessenger.ensureInitialized(token)`, which sets up only a `BinaryMessenger` without touching the rendering stack. `WidgetsFlutterBinding` is retained as a fallback when the token is unexpectedly absent.

**Extract helper and pass messenger explicitly:**
The initialisation is extracted into `_ensureBinaryMessengerInitialized()` which returns `BinaryMessenger?`. The result is passed explicitly to `PDelegateBackgroundRegisterFlutterApi.setUp(binaryMessenger: ...)`, removing the implicit dependency on `ServicesBinding.defaultBinaryMessenger`.

**Narrow import:**
`flutter/material.dart` replaced with `flutter/widgets.dart show WidgetsFlutterBinding` — only `WidgetsFlutterBinding` is needed in this file.

## Files changed

- `webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart`

## Test plan

- [ ] Build and install a debug APK
- [ ] Trigger an incoming call push while the app is in the background
- [ ] Confirm the call is received and handled correctly
- [ ] Confirm logcat shows no Impeller/Vulkan init from the background isolate thread