### PR TITLE
fix(android): start ringtone in StandaloneCallService (WT-1226)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -25,6 +25,7 @@ import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
 import com.webtrit.callkeep.services.core.CallkeepCore
 import java.util.concurrent.ConcurrentHashMap
+import com.webtrit.callkeep.managers.AudioManager as CallkeepAudioManager
 
 /**
  * Standalone call management service for devices that do not expose the
@@ -46,6 +47,7 @@ import java.util.concurrent.ConcurrentHashMap
 class StandaloneCallService : Service() {
     private val core get() = CallkeepCore.instance
     private val audioManager by lazy { getSystemService(AUDIO_SERVICE) as AudioManager }
+    private val ringtoneManager by lazy { CallkeepAudioManager(applicationContext) }
 
     // Tracks whether startForeground() has been called in this service instance.
     // startForeground() is deferred until an actual call is handled so that lifecycle-only
@@ -203,6 +205,7 @@ class StandaloneCallService : Service() {
         promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
         answeredCallIds.remove(metadata.callId)
+        ringtoneManager.startRingtone(metadata.ringtonePath)
         // Notify the main process that the call has been registered. ForegroundService listens
         // for this broadcast to resolve its pendingIncomingCallbacks entry and promote the call
         // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
@@ -229,6 +232,7 @@ class StandaloneCallService : Service() {
 
     private fun handleEstablishCall(metadata: CallMetadata) {
         Log.i(TAG, "handleEstablishCall: callId=${metadata.callId}")
+        ringtoneManager.stopRingtone()
         val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
         callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
         answeredCallIds.add(metadata.callId)
@@ -242,6 +246,7 @@ class StandaloneCallService : Service() {
 
     private fun handleAnswerCall(metadata: CallMetadata) {
         Log.i(TAG, "handleAnswerCall: callId=${metadata.callId}")
+        ringtoneManager.stopRingtone()
         val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
         callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
         answeredCallIds.add(metadata.callId)
@@ -255,12 +260,14 @@ class StandaloneCallService : Service() {
 
     private fun handleDeclineCall(metadata: CallMetadata) {
         Log.i(TAG, "handleDeclineCall: callId=${metadata.callId}")
+        ringtoneManager.stopRingtone()
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
     }
 
     private fun handleHungUpCall(metadata: CallMetadata) {
         Log.i(TAG, "handleHungUpCall: callId=${metadata.callId}")
+        ringtoneManager.stopRingtone()
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
     }
@@ -294,6 +301,7 @@ class StandaloneCallService : Service() {
 
     private fun handleTearDownConnections() {
         Log.i(TAG, "handleTearDownConnections: cleaning up ${callMetadataMap.size} calls")
+        ringtoneManager.stopRingtone()
         callMetadataMap.keys.toList().forEach { callId ->
             val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
             core.notifyConnectionEvent(CallLifecycleEvent.HungUp, meta.toBundle())

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -146,6 +146,7 @@ class StandaloneCallService : Service() {
 
     override fun onDestroy() {
         Log.i(TAG, "onDestroy")
+        ringtoneManager.stopRingtone()
         isRunning = false
         isForeground = false
         stopForeground(STOP_FOREGROUND_REMOVE)


### PR DESCRIPTION
## Summary

- `StandaloneCallService` is used on devices where `android.software.telecom` is unavailable (some OPPO/oplus, Android Go, certain tablets)
- Unlike the Telecom path (`PhoneConnection.onShowIncomingCallUi`), `handleIncomingCall` never called `AudioManager.startRingtone` → incoming calls were completely silent
- The notification-based ringtone (`FLAG_INSISTENT`) is also suppressed for signaling-registered calls, making this the only source of ringtone on affected devices

**Changes:**
- Import `com.webtrit.callkeep.managers.AudioManager as CallkeepAudioManager` to avoid collision with `android.media.AudioManager`
- Add `ringtoneManager: CallkeepAudioManager` field (lazy, uses `applicationContext`)
- `handleIncomingCall` → `ringtoneManager.startRingtone(metadata.ringtonePath)`
- `handleAnswerCall`, `handleEstablishCall`, `handleDeclineCall`, `handleHungUpCall`, `handleTearDownConnections` → `ringtoneManager.stopRingtone()`

## Reproduction

Device where `android.software.telecom` is not available (confirmed: OPPO/oplus Android 12, also Android 8). Log evidence: `[CK-ForegroundService] setUp: android.software.telecom not available on this device — skipping phone account registration, using standalone call mode`.

## Test plan

- [ ] Test incoming call on a device/emulator without `android.software.telecom` — ringtone plays
- [ ] Answer the call — ringtone stops
- [ ] Decline the call — ringtone stops
- [ ] Let the call time out — ringtone stops
- [ ] Test on normal device with Telecom support — no regression

Fixes [WT-1226](https://youtrack.portaone.com/issue/WT-1226)