### PR TITLE
fix(android): show proper incoming call notification in standalone mode (WT-1227)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
@@ -1,0 +1,125 @@
+package com.webtrit.callkeep.notifications
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Person
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.ContextHolder.context
+import com.webtrit.callkeep.common.PermissionsHelper
+import com.webtrit.callkeep.common.Platform
+import com.webtrit.callkeep.common.StorageDelegate
+import com.webtrit.callkeep.managers.NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+import com.webtrit.callkeep.services.services.connection.StandaloneServiceAction
+
+/**
+ * Builds an incoming call notification for the standalone call path — used on devices that do
+ * not expose the [android.software.telecom] system feature.
+ *
+ * Mirrors the logic of [IncomingCallNotificationBuilder] but routes Answer/Decline
+ * [PendingIntent]s directly to [StandaloneCallService] via [StandaloneServiceAction], so the
+ * user can answer or decline from the notification without the Telecom-backed
+ * [com.webtrit.callkeep.services.services.incoming_call.IncomingCallService] being involved.
+ */
+internal class StandaloneIncomingCallNotificationBuilder {
+    private fun createActionIntent(
+        metadata: CallMetadata,
+        action: StandaloneServiceAction,
+    ): PendingIntent {
+        val intent =
+            Intent(context, StandaloneCallService::class.java).apply {
+                this.action = action.action
+                putExtras(metadata.toBundle())
+            }
+        return PendingIntent.getService(
+            context,
+            // Use ordinal as unique request code so Answer and Decline get distinct PendingIntents.
+            action.ordinal,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun baseBuilder(
+        title: String,
+        text: String,
+    ): Notification.Builder =
+        Notification.Builder(context, INCOMING_CALL_NOTIFICATION_CHANNEL_ID).apply {
+            setSmallIcon(R.drawable.ic_notification)
+            setCategory(NotificationCompat.CATEGORY_CALL)
+            setContentTitle(title)
+            setContentText(text)
+            setOngoing(true)
+            setAutoCancel(false)
+            // Explicit PUBLIC visibility so the full notification content is shown on the lock
+            // screen — channel-level VISIBILITY_PUBLIC is not always inherited on MIUI/HyperOS.
+            setVisibility(Notification.VISIBILITY_PUBLIC)
+        }
+
+    fun build(metadata: CallMetadata): Notification {
+        val answerIntent = createActionIntent(metadata, StandaloneServiceAction.AnswerCall)
+        val declineIntent = createActionIntent(metadata, StandaloneServiceAction.DeclineCall)
+
+        val title = context.getString(R.string.incoming_call_title)
+        val text = context.getString(R.string.incoming_call_description, metadata.name)
+
+        val builder =
+            baseBuilder(title, text).apply {
+                val canUseFullScreen =
+                    StorageDelegate.IncomingCall.isFullScreen(context) &&
+                        PermissionsHelper(context).canUseFullScreenIntent()
+                if (canUseFullScreen) {
+                    setFullScreenIntent(buildOpenAppIntent(), true)
+                }
+            }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val person =
+                Person
+                    .Builder()
+                    .setName(metadata.name)
+                    .setImportant(true)
+                    .build()
+            builder
+                .setStyle(Notification.CallStyle.forIncomingCall(person, declineIntent, answerIntent))
+                .build()
+                .apply { flags = flags or NotificationCompat.FLAG_INSISTENT }
+        } else {
+            builder
+                .addAction(
+                    Notification.Action
+                        .Builder(
+                            Icon.createWithResource(context, R.drawable.ic_call_hungup),
+                            context.getString(R.string.decline_button_text),
+                            declineIntent,
+                        ).build(),
+                ).addAction(
+                    Notification.Action
+                        .Builder(
+                            Icon.createWithResource(context, R.drawable.ic_call_answer),
+                            context.getString(R.string.answer_call_button_text),
+                            answerIntent,
+                        ).build(),
+                ).build()
+                .apply { flags = flags or NotificationCompat.FLAG_INSISTENT }
+        }
+    }
+
+    private fun buildOpenAppIntent(): PendingIntent {
+        val intent =
+            Platform.getLaunchActivity(context)?.apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        return PendingIntent.getActivity(
+            context,
+            R.integer.notification_incoming_call_id,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
@@ -21,12 +21,19 @@ import com.webtrit.callkeep.services.services.connection.StandaloneServiceAction
  * Builds an incoming call notification for the standalone call path — used on devices that do
  * not expose the [android.software.telecom] system feature.
  *
- * Mirrors the logic of [IncomingCallNotificationBuilder] but routes Answer/Decline
- * [PendingIntent]s directly to [StandaloneCallService] via [StandaloneServiceAction], so the
- * user can answer or decline from the notification without the Telecom-backed
+ * Extends [NotificationBuilder] to reuse [buildOpenAppIntent] and keep behaviour consistent with
+ * [IncomingCallNotificationBuilder]. Answer/Decline [PendingIntent]s are routed directly to
+ * [StandaloneCallService] via [StandaloneServiceAction] so the user can interact with the
+ * notification without the Telecom-backed
  * [com.webtrit.callkeep.services.services.incoming_call.IncomingCallService] being involved.
  */
-internal class StandaloneIncomingCallNotificationBuilder {
+internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder() {
+    private var callMetaData: CallMetadata? = null
+
+    fun setCallMetaData(callMetaData: CallMetadata) {
+        this.callMetaData = callMetaData
+    }
+
     private fun createActionIntent(
         metadata: CallMetadata,
         action: StandaloneServiceAction,
@@ -61,20 +68,28 @@ internal class StandaloneIncomingCallNotificationBuilder {
             setVisibility(Notification.VISIBILITY_PUBLIC)
         }
 
-    fun build(metadata: CallMetadata): Notification {
-        val answerIntent = createActionIntent(metadata, StandaloneServiceAction.AnswerCall)
-        val declineIntent = createActionIntent(metadata, StandaloneServiceAction.DeclineCall)
+    override fun build(): Notification {
+        val meta =
+            requireNotNull(callMetaData) { "Call metadata must be set before building the notification." }
+
+        val answerIntent = createActionIntent(meta, StandaloneServiceAction.AnswerCall)
+        val declineIntent = createActionIntent(meta, StandaloneServiceAction.DeclineCall)
 
         val title = context.getString(R.string.incoming_call_title)
-        val text = context.getString(R.string.incoming_call_description, metadata.name)
+        val text = context.getString(R.string.incoming_call_description, meta.name)
 
         val builder =
             baseBuilder(title, text).apply {
+                // Guard against a null launch intent before calling buildOpenAppIntent: if no
+                // launchable activity exists, PendingIntent.getActivity() would receive a null
+                // Intent and behave unpredictably on some API levels.
+                val launchIntent = Platform.getLaunchActivity(context)
                 val canUseFullScreen =
-                    StorageDelegate.IncomingCall.isFullScreen(context) &&
+                    launchIntent != null &&
+                        StorageDelegate.IncomingCall.isFullScreen(context) &&
                         PermissionsHelper(context).canUseFullScreenIntent()
                 if (canUseFullScreen) {
-                    setFullScreenIntent(buildOpenAppIntent(), true)
+                    setFullScreenIntent(buildOpenAppIntent(context), true)
                 }
             }
 
@@ -82,7 +97,7 @@ internal class StandaloneIncomingCallNotificationBuilder {
             val person =
                 Person
                     .Builder()
-                    .setName(metadata.name)
+                    .setName(meta.name)
                     .setImportant(true)
                     .build()
             builder
@@ -108,18 +123,5 @@ internal class StandaloneIncomingCallNotificationBuilder {
                 ).build()
                 .apply { flags = flags or NotificationCompat.FLAG_INSISTENT }
         }
-    }
-
-    private fun buildOpenAppIntent(): PendingIntent {
-        val intent =
-            Platform.getLaunchActivity(context)?.apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            }
-        return PendingIntent.getActivity(
-            context,
-            R.integer.notification_incoming_call_id,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE,
-        )
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -54,6 +54,19 @@ class StandaloneCallService : Service() {
     // notification when there is no call in progress.
     private var isForeground = false
 
+    // FOREGROUND_SERVICE_TYPE_MICROPHONE was introduced in API 31 (Android 12).
+    // On API 29-30 the type is unknown to the framework and startForeground() throws
+    // IllegalArgumentException when the requested type does not match the manifest.
+    // Passing null selects the 2-arg startForeground() fallback in startForegroundServiceCompat(),
+    // which skips type validation on older builds.
+    private val foregroundServiceType: Int?
+        get() =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                null
+            }
+
     override fun onCreate() {
         super.onCreate()
         ContextHolder.init(applicationContext)
@@ -184,18 +197,7 @@ class StandaloneCallService : Service() {
                 .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setOngoing(true)
                 .build()
-        // FOREGROUND_SERVICE_TYPE_MICROPHONE was introduced in API 31 (Android 12).
-        // On API 29-30 the type is unknown to the framework and startForeground() throws
-        // IllegalArgumentException when the requested type does not match the manifest.
-        // Passing null here selects the 2-arg startForeground() fallback in
-        // startForegroundServiceCompat(), which skips type validation on older builds.
-        val foregroundType =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-            } else {
-                null
-            }
-        startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, foregroundType)
+        startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, foregroundServiceType)
         isForeground = true
     }
 
@@ -227,14 +229,11 @@ class StandaloneCallService : Service() {
     }
 
     private fun showIncomingCallNotification(metadata: CallMetadata) {
-        val notification = StandaloneIncomingCallNotificationBuilder().build(metadata)
-        val foregroundType =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-            } else {
-                null
-            }
-        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundType)
+        val notification =
+            StandaloneIncomingCallNotificationBuilder()
+                .apply { setCallMetaData(metadata) }
+                .build()
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
     }
 
     private fun handleOutgoingCall(metadata: CallMetadata) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -20,6 +20,7 @@ import com.webtrit.callkeep.managers.NotificationChannelManager
 import com.webtrit.callkeep.models.AudioDevice
 import com.webtrit.callkeep.models.AudioDeviceType
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.notifications.StandaloneIncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
@@ -203,6 +204,15 @@ class StandaloneCallService : Service() {
         promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
         answeredCallIds.remove(metadata.callId)
+
+        // Replace the placeholder foreground notification (posted by promoteToForeground) with
+        // a full incoming call notification — including Answer/Decline buttons and CallStyle on
+        // API 31+.  The placeholder uses FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID (low importance)
+        // only to satisfy the 5-second startForeground() ANR window; this call switches to
+        // INCOMING_CALL_NOTIFICATION_CHANNEL_ID (high importance) so the system treats it as a
+        // ringing call rather than a silent ongoing service notification.
+        showIncomingCallNotification(metadata)
+
         // Notify the main process that the call has been registered. ForegroundService listens
         // for this broadcast to resolve its pendingIncomingCallbacks entry and promote the call
         // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
@@ -214,6 +224,17 @@ class StandaloneCallService : Service() {
         if (pendingAnswers.remove(metadata.callId)) {
             handleAnswerCall(metadata)
         }
+    }
+
+    private fun showIncomingCallNotification(metadata: CallMetadata) {
+        val notification = StandaloneIncomingCallNotificationBuilder().build(metadata)
+        val foregroundType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                null
+            }
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundType)
     }
 
     private fun handleOutgoingCall(metadata: CallMetadata) {


### PR DESCRIPTION
## Summary

- Devices without `android.software.telecom` (OPPO, Android Go, some tablets) fall back to `StandaloneCallService` instead of the Telecom API path
- Previously, `promoteToForeground()` posted a low-importance placeholder notification (no buttons, no `CallStyle`) and `handleIncomingCall()` never replaced it — users had no way to answer or decline from the notification panel
- Added `StandaloneIncomingCallNotificationBuilder` that mirrors `IncomingCallNotificationBuilder` but routes `Answer`/`Decline` `PendingIntent`s to `StandaloneCallService` via `StandaloneServiceAction`
- `showIncomingCallNotification()` is called immediately after `promoteToForeground()` in `handleIncomingCall()`, replacing the placeholder with a high-importance notification including `Notification.CallStyle.forIncomingCall()` on API 31+, and explicit action buttons on API 29–30

## Root cause

```
[CK-ForegroundService] setUp: android.software.telecom not available — using standalone call mode
[CK-Extensions] startForegroundServiceCompat: SDK_INT: 31, foregroundServiceType: 128 (MICROPHONE)
[CK-StandaloneCallService] handleIncomingCall: callId=…
// ← notification never updated past the placeholder
[CK-ForegroundService] reportNewIncomingCall: rejecting duplicate CALL_ID_ALREADY_EXISTS
// ← IncomingCallService (which has the proper notification) never started
```

Reported in WT-1227, reproduced on OPPO CPH2089 (Android 12) and Android 8.

## Test plan

- [ ] Trigger incoming call on a device without `android.software.telecom` (OPPO, Android Go emulator) — verify notification shows caller name + Answer/Decline buttons
- [ ] Answer from notification — verify call connects, audio works
- [ ] Decline from notification — verify call ends
- [ ] Verify full-screen intent fires on devices where `USE_FULL_SCREEN_INTENT` is granted
- [ ] Verify Pixel / standard Android with Telecom is unaffected (existing path untouched)