### PR TITLE
fix(android): always acquire screen wake lock on incoming call

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/NotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/NotificationBuilder.kt
@@ -16,15 +16,7 @@ abstract class NotificationBuilder {
         val hostAppActivity =
             Platform.getLaunchActivity(context)?.apply {
                 data = uri
-                // FLAG_TURN_SCREEN_ON and FLAG_SHOW_WHEN_LOCKED allow the Activity to
-                // wake the screen and display over the keyguard when launched via a
-                // full-screen intent. Without these flags the Activity may be started
-                // silently behind the lock screen on Android 14+ and HyperOS devices.
-                flags =
-                    Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                    Intent.FLAG_TURN_SCREEN_ON or
-                    Intent.FLAG_SHOW_WHEN_LOCKED
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
             }
 
         return PendingIntent.getActivity(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/NotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/NotificationBuilder.kt
@@ -16,7 +16,15 @@ abstract class NotificationBuilder {
         val hostAppActivity =
             Platform.getLaunchActivity(context)?.apply {
                 data = uri
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                // FLAG_TURN_SCREEN_ON and FLAG_SHOW_WHEN_LOCKED allow the Activity to
+                // wake the screen and display over the keyguard when launched via a
+                // full-screen intent. Without these flags the Activity may be started
+                // silently behind the lock screen on Android 14+ and HyperOS devices.
+                flags =
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                    Intent.FLAG_TURN_SCREEN_ON or
+                    Intent.FLAG_SHOW_WHEN_LOCKED
             }
 
         return PendingIntent.getActivity(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -294,10 +294,16 @@ class IncomingCallService :
     /**
      * Acquires a wake lock that turns on the screen when an incoming call arrives.
      *
-     * This is a fallback for devices (MIUI/HyperOS) where USE_FULL_SCREEN_INTENT is
-     * denied by default and the full-screen intent cannot wake the display. When
-     * full-screen intent is available and enabled, the system handles screen wake via
-     * the full-screen intent itself, so no wake lock is needed.
+     * SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP is required to physically turn the
+     * screen on via PowerManager. This is complementary to the full-screen intent — the
+     * intent launches the incoming call UI; the wake lock turns the screen on so the UI
+     * is visible. They must both be used together.
+     *
+     * The two mechanisms are NOT mutually exclusive. When the app is in the foreground
+     * with the screen locked (Activity state ON_STOP), Android may suppress the
+     * full-screen intent Activity launch because the app is already "visible". In that
+     * case only the wake lock can turn the screen on. Skipping it when full-screen intent
+     * is available causes the ringtone to play on a dark screen with no call UI shown.
      *
      * The lock expires automatically after WAKELOCK_TIMEOUT_MS to prevent battery
      * drain if the release path is skipped.
@@ -305,12 +311,6 @@ class IncomingCallService :
     @Suppress("DEPRECATION") // SCREEN_BRIGHT_WAKE_LOCK is deprecated but is the correct flag
     // for waking the screen; the modern alternative (FLAG_TURN_SCREEN_ON) requires an Activity.
     private fun acquireScreenWakeLockIfNeeded() {
-        val fullScreenEnabled = StorageDelegate.IncomingCall.isFullScreen(this)
-        val canUseFullScreenIntent = PermissionsHelper(this).canUseFullScreenIntent()
-        if (fullScreenEnabled && canUseFullScreenIntent) {
-            Log.d(TAG, "Screen wake lock skipped: full-screen intent is available")
-            return
-        }
         if (screenWakeLock?.isHeld == true) return
         val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
         screenWakeLock =


### PR DESCRIPTION
## Problem

On Xiaomi (HyperOS, Android 15) when the screen is locked but the app is **active in the foreground** (user had the app open before locking), an incoming call plays the ringtone but the screen stays dark — no call UI is shown.

Reproduced on: Xiaomi 25028RN03Y, Android 15 (HyperOS).

## Root Cause

`IncomingCallService.acquireScreenWakeLockIfNeeded()` skipped the `SCREEN_BRIGHT_WAKE_LOCK` when `canUseFullScreenIntent() == true`, assuming the full-screen intent would wake the screen by launching the IncomingCallActivity.

This assumption breaks in the **foreground-locked** scenario:

1. Activity lifecycle state is `ON_STOP` (screen locked, app was in foreground)
2. Android / HyperOS suppresses the full-screen intent Activity launch because the app is already considered "visible"
3. `setTurnScreenOn(true)` on a paused Activity does not physically turn the screen on — it only acts when the Activity is being brought to the foreground

From logcat (`Xiaomi-25028RN03Y-Android-15_2026-04-13_161729.logcat`):
```
16:17:06.833  maybeInitBackgroundHandling: app is active (state=ON_STOP)
16:17:06.923  Screen wake lock skipped: full-screen intent is available  ← no wake lock acquired
16:17:07.014  wakeScreenOnShow(enable: true)                             ← flag on paused Activity, no effect
```

No `SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP` was acquired anywhere for the incoming call.

## Fix

### `IncomingCallService.kt`

Remove the early-return guard. The `SCREEN_BRIGHT_WAKE_LOCK` and the full-screen intent are **complementary**:
- the intent launches the call UI
- the wake lock physically turns the screen on

They must both be used together. Previously this was treated as either/or.

### `NotificationBuilder.kt`

Add `FLAG_TURN_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED` to the pending intent flags so that when the Activity *is* launched via the full-screen intent it can display over the keyguard on Android 14+ / HyperOS.

## Test plan

- [ ] Xiaomi (HyperOS): screen locked, app was in foreground → incoming call wakes screen and shows call UI
- [ ] Xiaomi (HyperOS): screen locked, app in background → incoming call wakes screen and shows call UI  
- [ ] Non-Xiaomi device (Pixel, Samsung): incoming call still wakes screen and shows call UI
- [ ] `USE_FULL_SCREEN_INTENT` denied → ringtone plays and screen still wakes (wake lock fallback)