### PR TITLE
fix(android): silence ringtone on volume key press during incoming call (WT-1300)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -133,7 +133,7 @@ class PhoneConnection internal constructor(
      * For self-managed calls, Telecom does not control the ringtone directly — it delegates
      * silence requests to the app via this callback. Without this override the ringtone keeps
      * playing regardless of volume key presses (confirmed on Xiaomi/MIUI and Samsung/One UI,
-     * Android 11, WT-1300).
+     * Android 11).
      */
     override fun onSilence() {
         logger.i("Silencing ringtone for callId: $callId")

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -38,6 +38,7 @@ class PhoneConnection internal constructor(
     private var metadata: CallMetadata,
     var onDisconnectCallback: (connection: PhoneConnection) -> Unit,
     var timeout: ConnectionTimeout? = null,
+    private val audioManager: AudioManager = AudioManager(context),
 ) : Connection() {
     private var isMute = false
     private var isHasSpeaker = false
@@ -61,7 +62,6 @@ class PhoneConnection internal constructor(
     private var pendingEndpointRequest: CallEndpoint? = null
     private var availableCallEndpoints: List<CallEndpoint> = emptyList()
     private val notificationManager = NotificationManager()
-    private val audioManager = AudioManager(context)
 
     val callId: String
         get() = metadata.callId

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -133,10 +133,10 @@ class PhoneConnection internal constructor(
      * For self-managed calls, Telecom does not control the ringtone directly — it delegates
      * silence requests to the app via this callback. Without this override the ringtone keeps
      * playing regardless of volume key presses (confirmed on Xiaomi/MIUI and Samsung/One UI,
-     * Android 11).
+     * Android 11, WT-1300).
      */
     override fun onSilence() {
-        logger.i("Silencing ringtone for callId: $callId")
+        logger.d("Silencing ringtone for callId: $callId")
         audioManager.stopRingtone()
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -128,6 +128,19 @@ class PhoneConnection internal constructor(
     }
 
     /**
+     * Invoked by Telecom when the user presses a volume key during an incoming call.
+     *
+     * For self-managed calls, Telecom does not control the ringtone directly — it delegates
+     * silence requests to the app via this callback. Without this override the ringtone keeps
+     * playing regardless of volume key presses (confirmed on Xiaomi/MIUI and Samsung/One UI,
+     * Android 11, WT-1300).
+     */
+    override fun onSilence() {
+        logger.i("Silencing ringtone for callId: $callId")
+        audioManager.stopRingtone()
+    }
+
+    /**
      * Handles the transition when a user accepts an incoming call.
      */
     override fun onAnswer() {
@@ -198,15 +211,16 @@ class PhoneConnection internal constructor(
      * Orchestrates logical transitions based on the underlying Telecom state.
      */
     override fun onStateChanged(state: Int) {
-        val stateText = when (state) {
-            STATE_NEW -> "NEW"
-            STATE_DIALING -> "DIALING"
-            STATE_RINGING -> "RINGING"
-            STATE_HOLDING -> "HOLDING"
-            STATE_ACTIVE -> "ACTIVE"
-            STATE_DISCONNECTED -> "DISCONNECTED"
-            else -> "UNKNOWN($state)"
-        }
+        val stateText =
+            when (state) {
+                STATE_NEW -> "NEW"
+                STATE_DIALING -> "DIALING"
+                STATE_RINGING -> "RINGING"
+                STATE_HOLDING -> "HOLDING"
+                STATE_ACTIVE -> "ACTIVE"
+                STATE_DISCONNECTED -> "DISCONNECTED"
+                else -> "UNKNOWN($state)"
+            }
         logger.v("Connection state is now: $stateText for callId: $callId")
         super.onStateChanged(state)
         handleConnectionTimeout(state)
@@ -283,19 +297,21 @@ class PhoneConnection internal constructor(
      */
     private fun dispatchFallbackAudioState() {
         logger.w("dispatchFallbackAudioState: callAudioState not set by system — building device list from AudioManager")
-        val supportedDevices = buildList {
-            add(AudioDevice(AudioDeviceType.EARPIECE))
-            add(AudioDevice(AudioDeviceType.SPEAKER))
-            if (audioManager.isWiredHeadsetConnected()) add(AudioDevice(AudioDeviceType.WIRED_HEADSET))
-            if (audioManager.isBluetoothConnected()) add(AudioDevice(AudioDeviceType.BLUETOOTH))
-        }
+        val supportedDevices =
+            buildList {
+                add(AudioDevice(AudioDeviceType.EARPIECE))
+                add(AudioDevice(AudioDeviceType.SPEAKER))
+                if (audioManager.isWiredHeadsetConnected()) add(AudioDevice(AudioDeviceType.WIRED_HEADSET))
+                if (audioManager.isBluetoothConnected()) add(AudioDevice(AudioDeviceType.BLUETOOTH))
+            }
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = supportedDevices))
 
-        val currentDevice = when {
-            audioManager.isBluetoothConnected() -> AudioDevice(AudioDeviceType.BLUETOOTH)
-            audioManager.isWiredHeadsetConnected() -> AudioDevice(AudioDeviceType.WIRED_HEADSET)
-            else -> AudioDevice(AudioDeviceType.EARPIECE)
-        }
+        val currentDevice =
+            when {
+                audioManager.isBluetoothConnected() -> AudioDevice(AudioDeviceType.BLUETOOTH)
+                audioManager.isWiredHeadsetConnected() -> AudioDevice(AudioDeviceType.WIRED_HEADSET)
+                else -> AudioDevice(AudioDeviceType.EARPIECE)
+            }
         dispatcher(CallMediaEvent.AudioDeviceSet, metadata.copy(audioDevice = currentDevice))
     }
 
@@ -395,9 +411,10 @@ class PhoneConnection internal constructor(
                 return
             }
 
-            val endpoint = availableCallEndpoints.firstOrNull {
-                it.identifier == ParcelUuid.fromString(deviceId)
-            }
+            val endpoint =
+                availableCallEndpoints.firstOrNull {
+                    it.identifier == ParcelUuid.fromString(deviceId)
+                }
 
             if (endpoint != null) {
                 performEndpointChange(endpoint)
@@ -657,32 +674,36 @@ class PhoneConnection internal constructor(
      * Converts a [CallEndpoint] into a domain [AudioDevice] model.
      */
     @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    private fun mapEndpointToAudioDevice(endpoint: CallEndpoint) = AudioDevice(
-        type = when (endpoint.endpointType) {
-            CallEndpoint.TYPE_EARPIECE -> AudioDeviceType.EARPIECE
-            CallEndpoint.TYPE_SPEAKER -> AudioDeviceType.SPEAKER
-            CallEndpoint.TYPE_BLUETOOTH -> AudioDeviceType.BLUETOOTH
-            CallEndpoint.TYPE_WIRED_HEADSET -> AudioDeviceType.WIRED_HEADSET
-            CallEndpoint.TYPE_STREAMING -> AudioDeviceType.STREAMING
-            else -> AudioDeviceType.UNKNOWN
-        },
-        name = endpoint.endpointName.toString(),
-        id = endpoint.identifier.toString(),
-    )
+    private fun mapEndpointToAudioDevice(endpoint: CallEndpoint) =
+        AudioDevice(
+            type =
+                when (endpoint.endpointType) {
+                    CallEndpoint.TYPE_EARPIECE -> AudioDeviceType.EARPIECE
+                    CallEndpoint.TYPE_SPEAKER -> AudioDeviceType.SPEAKER
+                    CallEndpoint.TYPE_BLUETOOTH -> AudioDeviceType.BLUETOOTH
+                    CallEndpoint.TYPE_WIRED_HEADSET -> AudioDeviceType.WIRED_HEADSET
+                    CallEndpoint.TYPE_STREAMING -> AudioDeviceType.STREAMING
+                    else -> AudioDeviceType.UNKNOWN
+                },
+            name = endpoint.endpointName.toString(),
+            id = endpoint.identifier.toString(),
+        )
 
     /**
      * Converts a [CallAudioState] route into a domain [AudioDevice] model.
      */
-    private fun mapRouteToAudioDevice(route: Int) = AudioDevice(
-        type = when (route) {
-            CallAudioState.ROUTE_EARPIECE -> AudioDeviceType.EARPIECE
-            CallAudioState.ROUTE_SPEAKER -> AudioDeviceType.SPEAKER
-            CallAudioState.ROUTE_BLUETOOTH -> AudioDeviceType.BLUETOOTH
-            CallAudioState.ROUTE_WIRED_HEADSET -> AudioDeviceType.WIRED_HEADSET
-            CallAudioState.ROUTE_STREAMING -> AudioDeviceType.STREAMING
-            else -> AudioDeviceType.UNKNOWN
-        },
-    )
+    private fun mapRouteToAudioDevice(route: Int) =
+        AudioDevice(
+            type =
+                when (route) {
+                    CallAudioState.ROUTE_EARPIECE -> AudioDeviceType.EARPIECE
+                    CallAudioState.ROUTE_SPEAKER -> AudioDeviceType.SPEAKER
+                    CallAudioState.ROUTE_BLUETOOTH -> AudioDeviceType.BLUETOOTH
+                    CallAudioState.ROUTE_WIRED_HEADSET -> AudioDeviceType.WIRED_HEADSET
+                    CallAudioState.ROUTE_STREAMING -> AudioDeviceType.STREAMING
+                    else -> AudioDeviceType.UNKNOWN
+                },
+        )
 
     /**
      * Parses the supported route mask into a list of [AudioDevice] models.
@@ -730,16 +751,29 @@ class PhoneConnection internal constructor(
         logger.d("directRouteAudioDevice: type=$type, audioMode=$mode")
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && mode == android.media.AudioManager.MODE_IN_COMMUNICATION) {
-            val targetType = when (type) {
-                AudioDeviceType.SPEAKER -> android.media.AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
-                AudioDeviceType.EARPIECE -> android.media.AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
-                AudioDeviceType.BLUETOOTH -> android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO
-                AudioDeviceType.WIRED_HEADSET -> android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET
-                else -> {
-                    logger.w("directRouteAudioDevice: unsupported type=$type, skipping")
-                    return
+            val targetType =
+                when (type) {
+                    AudioDeviceType.SPEAKER -> {
+                        android.media.AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+                    }
+
+                    AudioDeviceType.EARPIECE -> {
+                        android.media.AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
+                    }
+
+                    AudioDeviceType.BLUETOOTH -> {
+                        android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+                    }
+
+                    AudioDeviceType.WIRED_HEADSET -> {
+                        android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET
+                    }
+
+                    else -> {
+                        logger.w("directRouteAudioDevice: unsupported type=$type, skipping")
+                        return
+                    }
                 }
-            }
             val deviceInfo = sysAm.getDevices(android.media.AudioManager.GET_DEVICES_OUTPUTS).firstOrNull { it.type == targetType }
             if (deviceInfo != null && sysAm.setCommunicationDevice(deviceInfo)) {
                 logger.d("directRouteAudioDevice: setCommunicationDevice succeeded for type=$type")

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.os.ParcelUuid
 import android.telecom.CallEndpoint
+import com.webtrit.callkeep.managers.AudioManager
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
 import org.junit.Test
@@ -40,6 +41,14 @@ class PhoneConnectionTest {
         val realConnection = PhoneConnection(context, dispatcher, metadata, onDisconnect)
         return spy(realConnection)
     }
+
+    /**
+     * Helper to create a PhoneConnection with a mock [AudioManager] injected.
+     */
+    private fun createConnectionWithAudioManager(
+        metadata: CallMetadata,
+        audioManager: AudioManager,
+    ): PhoneConnection = PhoneConnection(context, dispatcher, metadata, onDisconnect, audioManager = audioManager)
 
     /**
      * Helper to populate [PhoneConnection.availableCallEndpoints] so the
@@ -177,5 +186,45 @@ class PhoneConnectionTest {
         connection.updateData(update)
 
         verify(connection, never()).toggleSpeaker(true)
+    }
+
+    // -------------------------------------------------------------------------
+    // onSilence
+    // -------------------------------------------------------------------------
+
+    /**
+     * When Telecom sends a silence request (volume key pressed during RINGING),
+     * the ringtone must stop. The call stays in RINGING state — only audio stops.
+     */
+    @Test
+    fun `onSilence stops the ringtone`() {
+        val mockAudioManager = mock(AudioManager::class.java)
+        val connection =
+            createConnectionWithAudioManager(
+                metadata = CallMetadata(callId = "test-silence"),
+                audioManager = mockAudioManager,
+            )
+
+        connection.onSilence()
+
+        verify(mockAudioManager).stopRingtone()
+    }
+
+    /**
+     * Telecom fires onSilence() repeatedly while the volume key is held.
+     * Each call must stop the ringtone without side effects.
+     */
+    @Test
+    fun `onSilence called multiple times stops ringtone each time`() {
+        val mockAudioManager = mock(AudioManager::class.java)
+        val connection =
+            createConnectionWithAudioManager(
+                metadata = CallMetadata(callId = "test-silence-repeat"),
+                audioManager = mockAudioManager,
+            )
+
+        repeat(5) { connection.onSilence() }
+
+        verify(mockAudioManager, org.mockito.Mockito.times(5)).stopRingtone()
     }
 }


### PR DESCRIPTION
## Summary

- Override `Connection.onSilence()` in `PhoneConnection` to stop the ringtone when the user presses a volume key during an incoming call
- For self-managed calls, Telecom routes volume key events to the app via this callback instead of adjusting the audio stream directly — without the override the ringtone keeps playing indefinitely

## Root cause

Confirmed via logcat on two devices: Telecom repeatedly sends `Send silence to connection service` (visible in system logs) for every volume key press, but `PhoneConnection` had no `onSilence()` override, so the callback was a no-op and `CK-AudioService` kept looping `incoming-call-1.mp3`.

## Test plan

- [ ] Incoming call on Android device (Xiaomi/MIUI or Samsung) — press VOLUME_DOWN → ringtone stops, call stays ringing (caller still sees it ringing)
- [ ] Incoming call — answer normally after silencing → call connects, no audio issues
- [ ] Incoming call — reject after silencing → call ends cleanly
- [ ] Incoming call — let it ring without pressing volume → ringtone plays normally until answered/rejected