### PR TITLE
fix(android): bypass VoipCallMonitor by starting activity directly from onShowIncomingCallUi

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -119,11 +119,26 @@ class PhoneConnection internal constructor(
 
     /**
      * Invoked by the system when the incoming call interface should be displayed.
+     *
+     * On Android 14+, VoipCallMonitor intercepts FSI delivery for CallStyle notifications.
+     * It fires the FSI only when it can match the notification to a tracked call. Self-managed
+     * connections (PROPERTY_SELF_MANAGED) are excluded from VoipCallMonitor's registry, so for
+     * our calls it never fires the FSI — it suppresses it instead.
+     *
+     * The fix is to start the app activity directly. ConnectionService is granted a
+     * background-activity-start exemption during onShowIncomingCallUi(), so this works reliably
+     * on all API levels regardless of USE_FULL_SCREEN_INTENT permission state.
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
         audioManager.startRingtone(metadata.ringtonePath)
+
+        Platform.getLaunchActivity(context)?.let { launchIntent ->
+            logger.d("onShowIncomingCallUi: starting activity directly for incoming call UI")
+            context.startActivity(launchIntent)
+        } ?: logger.w("onShowIncomingCallUi: no launch activity found, incoming call UI may not appear")
+
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
     }
 


### PR DESCRIPTION
## Problem

On Android 14+, VoipCallMonitor intercepts FSI delivery for all CallStyle notifications. It fires the FSI only when it can match the notification to a tracked call in its internal registry. Self-managed connections (PROPERTY_SELF_MANAGED) are excluded from onCallAdded(), so the registry never contains our call — VoipCallMonitor sees the notification and suppresses FSI instead of firing it.

Observed on Pixel 9 / Android 16: incoming call notification appears but the full-screen call UI never shows.

## Root cause

VoipCallMonitor.onCallAdded skips self-managed calls entirely. Our PhoneConnectionService registers calls with PROPERTY_SELF_MANAGED, so mVoipCalls is always empty for our calls. On each notification post, VoipCallMonitor logs "could not find a call for sbn.id=[2]" and suppresses the FSI.

## Fix

ConnectionService receives a background-activity-start exemption during onShowIncomingCallUi(). Start the app activity directly here instead of relying on VoipCallMonitor to fire the FSI.

This is the intended pattern for self-managed VoIP apps (same approach already used in establish() for active calls). Works on all API levels regardless of USE_FULL_SCREEN_INTENT permission state.

## Change

Single-file change in PhoneConnection.onShowIncomingCallUi() — adds a direct activity start via Platform.getLaunchActivity(context).

## Testing

Verified on Pixel 9 / Android 16 — full-screen call UI now appears on incoming calls.