### PR TITLE
fix(android/wt-1306): move WakeLock acquisition to Telecom layer

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -72,15 +72,32 @@ class IncomingCallService :
         event: ConnectionEvent,
         data: Bundle?,
     ) {
-        // Only handle AnswerCall. DeclineCall and HungUp are handled via IC_RELEASE_WITH_DECLINE
-        // intent (triggered from PhoneConnection.onDisconnect -> cancelIncomingNotification).
+        // DidPushIncomingCall: acquire the wake lock here — after Telecom has confirmed the
+        // call and onShowIncomingCallUi() has been called — rather than at IC_INITIALIZE
+        // (FCM transport layer). Acquiring it at the transport layer woke the device before
+        // the FSI notification was posted, causing VoipCallMonitor (Android 14+) to process
+        // the notification on an already-awake device and block FSI delivery.
+        // DidPushIncomingCall travels cross-process from :callkeep_core via
+        // ConnectionServicePerformBroadcaster (system broadcast) and is listed in
+        // GLOBAL_LISTENER_EVENTS, so this listener receives it correctly in the main process.
+        //
+        // DeclineCall and HungUp are handled via IC_RELEASE_WITH_DECLINE intent
+        // (triggered from PhoneConnection.onDisconnect -> cancelIncomingNotification).
         // Handling them here as well would cause a double performEndCall: once from handleRelease
         // and once from this listener, racing to tear down the WebSocket before the SIP BYE is
         // sent. The IC_RELEASE_WITH_DECLINE path is the single authoritative source for decline
         // teardown.
-        if (event == CallLifecycleEvent.AnswerCall) {
-            val metadata = data?.let(CallMetadata::fromBundleOrNull) ?: return
-            performAnswerCall(metadata)
+        when (event) {
+            CallLifecycleEvent.DidPushIncomingCall -> {
+                acquireScreenWakeLockIfNeeded()
+            }
+
+            CallLifecycleEvent.AnswerCall -> {
+                val metadata = data?.let(CallMetadata::fromBundleOrNull) ?: return
+                performAnswerCall(metadata)
+            }
+
+            else -> {}
         }
     }
 
@@ -238,7 +255,6 @@ class IncomingCallService :
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
-        acquireScreenWakeLockIfNeeded()
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand


### PR DESCRIPTION
## Summary

Moves `acquireScreenWakeLockIfNeeded()` from `IC_INITIALIZE` (FCM transport layer) to `onConnectionEvent(DidPushIncomingCall)` (Telecom layer).

**Root cause:** WakeLock with `SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP` was acquired in `handleLaunch()` before Telecom confirmed the call. This woke the device before the FSI notification was posted. On Android 14+, `VoipCallMonitor` processes `CallStyle` notifications and skips self-managed calls (`PROPERTY_SELF_MANAGED`) — but only when the device is already awake does it win the race against SystemUI. FSI was suppressed as a result.

**Fix:** acquire WakeLock in `onConnectionEvent(DidPushIncomingCall)`, which fires after `PhoneConnection.onShowIncomingCallUi()` is called by Telecom. WakeLock now belongs at the Telecom confirmation layer, not the FCM transport layer.

**Cross-process correctness:** `DidPushIncomingCall` is listed in `GLOBAL_LISTENER_EVENTS` (`InProcessCallkeepCore.kt`) and dispatched via `ConnectionServicePerformBroadcaster` (system broadcast, crosses process boundaries). `IncomingCallService` registers its listener in `onCreate()` before `DidPushIncomingCall` can arrive, so ordering is safe.

## Changes

- `IncomingCallService.onConnectionEvent()`: replaced `if (event == AnswerCall)` with `when` block, added `DidPushIncomingCall -> acquireScreenWakeLockIfNeeded()`
- `IncomingCallService.handleLaunch()`: removed `acquireScreenWakeLockIfNeeded()` call

## What is NOT changed

- Release paths: `handleRelease()`, `onDestroy()` — unchanged
- `WAKELOCK_TIMEOUT_MS = 30_000L` — unchanged
- WakeLock tag `com.webtrit.callkeep:IncomingCallWakeLock` — unchanged
- MIUI fallback semantics — unchanged

## Context

Part of WT-1306 investigation. This PR covers T2 only — architectural cleanup, not a standalone functional fix.