### PR TITLE
fix(android): guard releaseCall against terminating active Telecom connections

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateApi
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.incoming_call.CallConnectionController
 import com.webtrit.callkeep.services.services.incoming_call.FlutterIsolateCommunicator
 
@@ -130,8 +131,29 @@ class CallLifecycleHandler(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        Log.d(TAG, "releaseCall: $callId - terminate connection and stop service")
-        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        // releaseCall() is called by the push-notification isolate when it is done with
+        // background processing (signaling sync, missed-call notification, call log).
+        // It must NOT terminate the Telecom connection when the call is still active or
+        // pending — doing so declines a call that the user has not yet interacted with.
+        //
+        // This happens when the push-notification isolate connects to the signaling hub
+        // and receives a handshake with no active lines (e.g. the main-process signaling
+        // session already consumed the IncomingCallEvent, or a duplicate FCM delivery
+        // triggers a second isolate run). In that case _onNoActiveLines() fires and calls
+        // releaseCall(), but Telecom still has the call in RINGING state.
+        //
+        // Guard: if the call is promoted or pending in CallkeepCore, stop the FGS only.
+        // The Telecom connection stays alive and the user can still answer or decline.
+        val core = CallkeepCore.instance
+        val isActiveOrPending =
+            core.getAll().any { it.callId == callId } || core.getPendingCallIds().contains(callId)
+
+        if (isActiveOrPending) {
+            Log.d(TAG, "releaseCall: $callId is active/pending in Telecom — stopping service only, skipping terminate")
+        } else {
+            Log.d(TAG, "releaseCall: $callId - no active connection, terminating and stopping service")
+            terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        }
         stopService()
         callback(Result.success(Unit))
     }


### PR DESCRIPTION
## Summary

- `CallLifecycleHandler.releaseCall()` previously called `terminateCall()` unconditionally, which declined an active Telecom call whenever the push-notification isolate finished its background work.
- Added a guard: if the call is still active or pending in `CallkeepCore`, only the FGS service is stopped — the Telecom connection is not touched.
- `terminateCall()` still runs on the legitimate missed-call / server-decline path (no active connection in `CallkeepCore`).

## Root cause (from logcat analysis)

When the push-notification isolate connects to the signaling hub, it may receive a handshake with `lines=[null, null]` (no active lines) in two scenarios:
1. The main-process signaling session already consumed the `IncomingCallEvent` before the push isolate connected.
2. A duplicate FCM delivery triggered a second isolate run — the second `reportNewIncomingCall` returns `CALL_ID_ALREADY_EXISTS`, signaling connects and shows no active lines.

In both cases `_onNoActiveLines()` fires → `releaseCall(callId)` → old code: `terminateCall()` → `DeclineCall` dispatched → Telecom call TC@N goes `RINGING -> DISCONNECTED` without any user action.

**Logcat trace (auto-decline scenario):**
```
releaseCall: C0EATgq6... - terminate connection and stop service
Dispatching ServiceAction: DeclineCall | CallId: C0EATgq6...
CallsManager: setCallState RINGING -> DISCONNECTED, call: TC@118
Release action IC_RELEASE_WITH_DECLINE initiated.
```

## Changed file

`CallLifecycleHandler.kt` — `releaseCall()` method only.

All other paths (`endCall`, `terminateCall`, `performEndCall`, `handleRelease`) are unchanged.

## Context

Discovered during WT-1306 testing. Log file: `Google-Pixel-9-Android-16_2026-04-15_132752_auto_decline.logcat`. Bug report: `bugs/open/2026-04-15-wt-1306-incoming-call-no-screen/auto-decline-duplicate-fcm.md`.