### PR TITLE
fix(android): skip PhoneConnection teardown in releaseCall for answered calls

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -176,6 +176,19 @@ class WebtritCallkeepPlugin :
     private var delegateLogsFlutterApi: PDelegateLogsFlutterApi? = null
     private var permissionsApi: PermissionsApi? = null
 
+    // The BinaryMessenger that belongs to the Activity's Flutter engine, captured
+    // synchronously in onAttachedToActivity BEFORE bindForegroundService() runs.
+    //
+    // WebtritCallkeepPlugin.messenger is a shared mutable field overwritten by every
+    // onAttachedToEngine() call. Push-notification isolates (IncomingCallService) each
+    // run in their own FlutterEngine and trigger onAttachedToEngine() independently.
+    // If a push isolate's onAttachedToEngine fires BETWEEN onAttachedToActivity() and
+    // the async onServiceConnected() callback, messenger will be pointing to the push
+    // engine's BinaryMessenger when flutterDelegateApi is created — causing
+    // performAnswerCall to be sent to the wrong engine where it is silently dropped.
+    // Capturing the Activity's messenger here, before any async gap, prevents this race.
+    private var activityBinaryMessenger: BinaryMessenger? = null
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         // Store binnyMessenger for later use if instance of the flutter engine belongs to main isolate OR call service isolate
         messenger = flutterPluginBinding.binaryMessenger
@@ -234,6 +247,10 @@ class WebtritCallkeepPlugin :
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         Log.i(TAG, "onAttachedToActivity id:${binding.hashCode()}")
         this.activityPluginBinding = binding
+        // Capture Activity's messenger before bindForegroundService() to prevent the race
+        // where a push-isolate onAttachedToEngine() overwrites messenger before
+        // onServiceConnected() fires and reads it to create flutterDelegateApi.
+        activityBinaryMessenger = messenger
 
         ActivityHolder.setActivity(binding.activity)
 
@@ -257,6 +274,7 @@ class WebtritCallkeepPlugin :
 
     override fun onDetachedFromActivity() {
         Log.i(TAG, "onDetachedFromActivity id:${activityPluginBinding?.hashCode()}")
+        activityBinaryMessenger = null
         ActivityHolder.setActivity(null)
 
         permissionsApi?.let {
@@ -381,7 +399,11 @@ class WebtritCallkeepPlugin :
                     Log.i(TAG, "ForegroundService connected: ${service?.javaClass?.name}")
                     val binder = service as ForegroundService.LocalBinder
                     foregroundService = binder.getService()
-                    foregroundService?.flutterDelegateApi = PDelegateFlutterApi(messenger)
+                    // Use activityBinaryMessenger (captured synchronously in onAttachedToActivity)
+                    // rather than the shared messenger field which may have been overwritten by a
+                    // push-isolate engine that started after onAttachedToActivity but before this
+                    // async callback fired.
+                    foregroundService?.flutterDelegateApi = PDelegateFlutterApi(activityBinaryMessenger ?: messenger)
                     // Flush any setUp() call that arrived before the service connected.
                     pendingSetUp?.let { (options, callback) ->
                         Log.i(TAG, "ForegroundService connected: replaying queued setUp()")

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -136,6 +136,7 @@ class IncomingCallService :
                 connectionController = DefaultCallConnectionController(),
                 stopService = { stopSelf() },
                 isolateHandler = isolateHandler,
+                isCallAnswered = { callId -> CallkeepCore.instance.isAnswered(callId) },
             )
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -18,6 +18,10 @@ class CallLifecycleHandler(
     private val connectionController: CallConnectionController,
     private val stopService: () -> Unit,
     private var isolateHandler: FlutterIsolateHandler,
+    // Returns true if the call with [callId] has already been answered via the push
+    // notification path. Used by releaseCall() to skip terminateCall() for handoff —
+    // the PhoneConnection must stay alive so the Activity can adopt it.
+    private val isCallAnswered: (callId: String) -> Boolean = { false },
 ) : PHostBackgroundPushNotificationIsolateApi {
     internal var flutterApi: FlutterIsolateCommunicator? = null
 
@@ -130,8 +134,18 @@ class CallLifecycleHandler(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        Log.d(TAG, "releaseCall: $callId - terminate connection and stop service")
-        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        // releaseCall() means "the push isolate is done with this call".
+        // For unanswered calls (missed, declined, server hangup) this means terminate the
+        // PhoneConnection and stop the service.
+        // For answered calls the PhoneConnection must stay alive — the Activity is about
+        // to adopt it via reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+        // Only stop the service; do not touch the connection.
+        if (!isCallAnswered(callId)) {
+            Log.d(TAG, "releaseCall: $callId — not answered, terminating connection")
+            terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        } else {
+            Log.d(TAG, "releaseCall: $callId — already answered, skipping terminate (Activity handoff)")
+        }
         stopService()
         callback(Result.success(Unit))
     }


### PR DESCRIPTION
## Problem

When a user answers an incoming call via push notification, the push isolate (`PushNotificationIsolateManager`) hands the call off to the Activity by closing itself. The closing sequence calls `releaseCall(callId)` via Pigeon — but `CallLifecycleHandler.releaseCall()` unconditionally called `terminateCall()`, destroying the `PhoneConnection` before the Activity could adopt it.

The failure was invisible for the **first push call** because `ForegroundService` was not yet running at the moment the `HungUp` broadcast fired — so the broadcast was missed, `STATE_ACTIVE` was never cleared, and the Activity's `reportNewIncomingCall` correctly detected `CALL_ID_ALREADY_EXISTS_AND_ANSWERED`. This was a coincidence, not a guarantee.

For **calls arriving within the 10-second pushBound grace window** (second incoming call while Activity is already open), `ForegroundService` was already running with its `BroadcastReceiver` registered. The `HungUp` broadcast was processed immediately → `handleCSReportDeclineCall` → `STATE_ACTIVE` cleared → `reportNewIncomingCall` registered a fresh incoming call → `CallBloc` stuck at `incomingFromOffer` with `performAnswerCall` never delivered.

### Timeline of the broken case

```
push isolate: answered → PhoneConnection ACTIVE → markAnswered(callId)
push isolate: close() → releaseCall(callId) → terminateCall() → PhoneConnection DISCONNECTED
FGS (already running): HungUp broadcast → handleCSReportDeclineCall → STATE_ACTIVE cleared
Activity: reportNewIncomingCall → checkIncomingDuplicate → null → startIncomingCall → stuck
```

### Why a second race was present in WebtritCallkeepPlugin

`WebtritCallkeepPlugin.messenger` is a shared mutable field overwritten by every `onAttachedToEngine()` call. Push-notification isolates each run in their own `FlutterEngine` and trigger `onAttachedToEngine()` independently. If a push isolate started between `onAttachedToActivity()` and the async `onServiceConnected()` callback, `flutterDelegateApi` was created with the push engine's `BinaryMessenger` — causing `performAnswerCall` to be sent to an engine with no registered handler (silently dropped).

---

## Fix

### `CallLifecycleHandler` — `isCallAnswered` lambda

Added an `isCallAnswered: (callId: String) -> Boolean` constructor parameter (defaults to `{ false }`). `releaseCall()` now skips `terminateCall()` when the call was already answered:

```kotlin
if (!isCallAnswered(callId)) {
    terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
}
stopService()
```

### `IncomingCallService` — wire to `CallkeepCore`

Passes the lambda pointing to the authoritative in-process tracker:

```kotlin
isCallAnswered = { callId -> CallkeepCore.instance.isAnswered(callId) }
```

`CallkeepCore.instance.isAnswered()` is a synchronous query on `MainProcessConnectionTracker.answeredCallIds` — no IPC, set by `handleCSReportAnswerCall` before `IC_RELEASE_WITH_ANSWER` fires.

### `WebtritCallkeepPlugin` — `activityBinaryMessenger`

Captures the Activity engine's `BinaryMessenger` synchronously in `onAttachedToActivity()` (before `bindForegroundService()`). Uses it in `onServiceConnected()` when creating `PDelegateFlutterApi` instead of the shared `messenger` field:

```kotlin
foregroundService?.flutterDelegateApi = PDelegateFlutterApi(activityBinaryMessenger ?: messenger)
```

---

## Result

```
push isolate: answered → PhoneConnection ACTIVE → markAnswered(callId)
push isolate: close() → releaseCall(callId) → isAnswered=true → skip terminateCall → stopService only
PhoneConnection: stays ACTIVE, no HungUp broadcast
Activity: reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED → adopt → performAnswerCall delivered
CallBloc: incomingFromOffer → incomingAnswering → connected
```

Works for both the first call and calls within the 10-second pushBound grace window.

---

## Files changed

| File | Change |
|------|--------|
| `CallLifecycleHandler.kt` | Add `isCallAnswered` lambda; conditional `terminateCall` in `releaseCall()` |
| `IncomingCallService.kt` | Wire `isCallAnswered` to `CallkeepCore.instance.isAnswered()` |
| `WebtritCallkeepPlugin.kt` | Add `activityBinaryMessenger`; use it in `onServiceConnected` |

## Testing

Verified on Google Pixel 9 (Android 16):
- Answer via push notification (first call) — `reportNewIncomingCall: adopted already-answered call` → `connected` ✓
- Answer via push notification (second call within 10s grace window) — same path ✓
- Unanswered / missed call — `releaseCall` still calls `terminateCall` correctly ✓