### PR TITLE
fix(android): split releaseCall / handoffCall in push isolate Pigeon API

### DIFF
--- a/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
+++ b/webtrit_callkeep/lib/src/android/services/background_push_notification_service.dart
@@ -40,12 +40,23 @@ class BackgroundPushNotificationService {
     return platform.endCallsBackgroundPushNotificationService();
   }
 
-  /// Unconditionally releases the incoming call service for [callId] (Android only).
+  /// Terminates the PhoneConnection and stops IncomingCallService for [callId] (Android only).
   ///
-  /// Call this after all isolate work is done (notifications shown, logs written).
-  /// Stops [IncomingCallService] regardless of Telecom connection state.
+  /// Use for unanswered calls: missed, declined by server, signaling error, or hangup
+  /// received before the user answered. Sends a decline signal to the ConnectionService
+  /// which destroys the PhoneConnection before stopping the service.
   Future<dynamic> releaseCall(String callId) {
     if (kIsWeb || !Platform.isAndroid) return Future.value();
     return platform.releaseCallBackgroundPushNotificationService(callId);
+  }
+
+  /// Stops IncomingCallService for [callId] without terminating the PhoneConnection (Android only).
+  ///
+  /// Use when the call was already answered via the push notification path and the Activity
+  /// is taking over. The PhoneConnection stays alive so the Activity can adopt it via
+  /// the CALL_ID_ALREADY_EXISTS_AND_ANSWERED path in reportNewIncomingCall.
+  Future<dynamic> handoffCall(String callId) {
+    if (kIsWeb || !Platform.isAndroid) return Future.value();
+    return platform.handoffCallBackgroundPushNotificationService(callId);
   }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -1198,7 +1198,23 @@ interface PHostBackgroundPushNotificationIsolateApi {
 
     fun endAllCalls(callback: (Result<Unit>) -> Unit)
 
+    /**
+     * Terminates the PhoneConnection and stops IncomingCallService.
+     * Called when the push isolate is done with an unanswered call
+     * (missed, declined, server hangup, signaling error).
+     */
     fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    )
+
+    /**
+     * Stops IncomingCallService without touching the PhoneConnection.
+     * Called when the push isolate hands off an already-answered call
+     * to the Activity. The PhoneConnection must stay alive so the
+     * Activity can adopt it via CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+     */
+    fun handoffCall(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     )
@@ -1260,6 +1276,25 @@ interface PHostBackgroundPushNotificationIsolateApi {
                         val args = message as List<Any?>
                         val callIdArg = args[0] as String
                         api.releaseCall(callIdArg) { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.handoffCall$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { message, reply ->
+                        val args = message as List<Any?>
+                        val callIdArg = args[0] as String
+                        api.handoffCall(callIdArg) { result: Result<Unit> ->
                             val error = result.exceptionOrNull()
                             if (error != null) {
                                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -176,6 +176,19 @@ class WebtritCallkeepPlugin :
     private var delegateLogsFlutterApi: PDelegateLogsFlutterApi? = null
     private var permissionsApi: PermissionsApi? = null
 
+    // The BinaryMessenger that belongs to the Activity's Flutter engine, captured
+    // synchronously in onAttachedToActivity BEFORE bindForegroundService() runs.
+    //
+    // WebtritCallkeepPlugin.messenger is a shared mutable field overwritten by every
+    // onAttachedToEngine() call. Push-notification isolates (IncomingCallService) each
+    // run in their own FlutterEngine and trigger onAttachedToEngine() independently.
+    // If a push isolate's onAttachedToEngine fires BETWEEN onAttachedToActivity() and
+    // the async onServiceConnected() callback, messenger will be pointing to the push
+    // engine's BinaryMessenger when flutterDelegateApi is created — causing
+    // performAnswerCall to be sent to the wrong engine where it is silently dropped.
+    // Capturing the Activity's messenger here, before any async gap, prevents this race.
+    private var activityBinaryMessenger: BinaryMessenger? = null
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         // Store binnyMessenger for later use if instance of the flutter engine belongs to main isolate OR call service isolate
         messenger = flutterPluginBinding.binaryMessenger
@@ -234,6 +247,10 @@ class WebtritCallkeepPlugin :
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         Log.i(TAG, "onAttachedToActivity id:${binding.hashCode()}")
         this.activityPluginBinding = binding
+        // Capture Activity's messenger before bindForegroundService() to prevent the race
+        // where a push-isolate onAttachedToEngine() overwrites messenger before
+        // onServiceConnected() fires and reads it to create flutterDelegateApi.
+        activityBinaryMessenger = messenger
 
         ActivityHolder.setActivity(binding.activity)
 
@@ -257,6 +274,7 @@ class WebtritCallkeepPlugin :
 
     override fun onDetachedFromActivity() {
         Log.i(TAG, "onDetachedFromActivity id:${activityPluginBinding?.hashCode()}")
+        activityBinaryMessenger = null
         ActivityHolder.setActivity(null)
 
         permissionsApi?.let {
@@ -381,7 +399,11 @@ class WebtritCallkeepPlugin :
                     Log.i(TAG, "ForegroundService connected: ${service?.javaClass?.name}")
                     val binder = service as ForegroundService.LocalBinder
                     foregroundService = binder.getService()
-                    foregroundService?.flutterDelegateApi = PDelegateFlutterApi(messenger)
+                    // Use activityBinaryMessenger (captured synchronously in onAttachedToActivity)
+                    // rather than the shared messenger field which may have been overwritten by a
+                    // push-isolate engine that started after onAttachedToActivity but before this
+                    // async callback fired.
+                    foregroundService?.flutterDelegateApi = PDelegateFlutterApi(activityBinaryMessenger ?: messenger)
                     // Flush any setUp() call that arrived before the service connected.
                     pendingSetUp?.let { (options, callback) ->
                         Log.i(TAG, "ForegroundService connected: replaying queued setUp()")

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -136,7 +136,6 @@ class IncomingCallService :
                 connectionController = DefaultCallConnectionController(),
                 stopService = { stopSelf() },
                 isolateHandler = isolateHandler,
-                isCallAnswered = { callId -> CallkeepCore.instance.isAnswered(callId) },
             )
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -136,6 +136,7 @@ class IncomingCallService :
                 connectionController = DefaultCallConnectionController(),
                 stopService = { stopSelf() },
                 isolateHandler = isolateHandler,
+                isCallAnswered = { callId -> CallkeepCore.instance.isAnswered(callId) },
             )
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -18,10 +18,6 @@ class CallLifecycleHandler(
     private val connectionController: CallConnectionController,
     private val stopService: () -> Unit,
     private var isolateHandler: FlutterIsolateHandler,
-    // Returns true if the call with [callId] has already been answered via the push
-    // notification path. Used by releaseCall() to skip terminateCall() for handoff —
-    // the PhoneConnection must stay alive so the Activity can adopt it.
-    private val isCallAnswered: (callId: String) -> Boolean = { false },
 ) : PHostBackgroundPushNotificationIsolateApi {
     internal var flutterApi: FlutterIsolateCommunicator? = null
 
@@ -134,18 +130,20 @@ class CallLifecycleHandler(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        // releaseCall() means "the push isolate is done with this call".
-        // For unanswered calls (missed, declined, server hangup) this means terminate the
-        // PhoneConnection and stop the service.
-        // For answered calls the PhoneConnection must stay alive — the Activity is about
-        // to adopt it via reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
-        // Only stop the service; do not touch the connection.
-        if (!isCallAnswered(callId)) {
-            Log.d(TAG, "releaseCall: $callId — not answered, terminating connection")
-            terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
-        } else {
-            Log.d(TAG, "releaseCall: $callId — already answered, skipping terminate (Activity handoff)")
-        }
+        Log.d(TAG, "releaseCall: $callId — unanswered, terminating connection and stopping service")
+        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        stopService()
+        callback(Result.success(Unit))
+    }
+
+    override fun handoffCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        // The call was answered via push notification and the Activity is taking over.
+        // The PhoneConnection must stay alive for the Activity to adopt it via
+        // reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+        Log.d(TAG, "handoffCall: $callId — answered, stopping service only (Activity handoff)")
         stopService()
         callback(Result.success(Unit))
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -18,6 +18,10 @@ class CallLifecycleHandler(
     private val connectionController: CallConnectionController,
     private val stopService: () -> Unit,
     private var isolateHandler: FlutterIsolateHandler,
+    // Returns true if the call with [callId] has already been answered via the push
+    // notification path. Used by releaseCall() to skip terminateCall() for handoff —
+    // the PhoneConnection must stay alive so the Activity can adopt it.
+    private val isCallAnswered: (callId: String) -> Boolean = { false },
 ) : PHostBackgroundPushNotificationIsolateApi {
     internal var flutterApi: FlutterIsolateCommunicator? = null
 
@@ -130,8 +134,18 @@ class CallLifecycleHandler(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        Log.d(TAG, "releaseCall: $callId - terminate connection and stop service")
-        terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        // releaseCall() means "the push isolate is done with this call".
+        // For unanswered calls (missed, declined, server hangup) this means terminate the
+        // PhoneConnection and stop the service.
+        // For answered calls the PhoneConnection must stay alive — the Activity is about
+        // to adopt it via reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+        // Only stop the service; do not touch the connection.
+        if (!isCallAnswered(callId)) {
+            Log.d(TAG, "releaseCall: $callId — not answered, terminating connection")
+            terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
+        } else {
+            Log.d(TAG, "releaseCall: $callId — already answered, skipping terminate (Activity handoff)")
+        }
         stopService()
         callback(Result.success(Unit))
     }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -1031,9 +1031,39 @@ class PHostBackgroundPushNotificationIsolateApi {
     }
   }
 
+  /// Terminates the PhoneConnection and stops IncomingCallService.
+  /// Called when the push isolate is done with an unanswered call
+  /// (missed, declined, server hangup, signaling error).
   Future<void> releaseCall(String callId) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.releaseCall$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callId]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Stops IncomingCallService without touching the PhoneConnection.
+  /// Called when the push isolate hands off an already-answered call
+  /// to the Activity. The PhoneConnection must stay alive so the
+  /// Activity can adopt it via CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+  Future<void> handoffCall(String callId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostBackgroundPushNotificationIsolateApi.handoffCall$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -301,6 +301,11 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
     return _backgroundPushNotificationIsolateApi.releaseCall(callId);
   }
 
+  @override
+  Future<dynamic> handoffCallBackgroundPushNotificationService(String callId) {
+    return _backgroundPushNotificationIsolateApi.handoffCall(callId);
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android background push notification service
 

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -225,8 +225,18 @@ abstract class PHostBackgroundPushNotificationIsolateApi {
   @async
   void endAllCalls();
 
+  /// Terminates the PhoneConnection and stops IncomingCallService.
+  /// Called when the push isolate is done with an unanswered call
+  /// (missed, declined, server hangup, signaling error).
   @async
   void releaseCall(String callId);
+
+  /// Stops IncomingCallService without touching the PhoneConnection.
+  /// Called when the push isolate hands off an already-answered call
+  /// to the Activity. The PhoneConnection must stay alive so the
+  /// Activity can adopt it via CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
+  @async
+  void handoffCall(String callId);
 }
 
 @HostApi()

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -303,6 +303,10 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('releaseCallBackgroundPushNotificationService() has not been implemented.');
   }
 
+  Future<dynamic> handoffCallBackgroundPushNotificationService(String callId) {
+    throw UnimplementedError('handoffCallBackgroundPushNotificationService() has not been implemented.');
+  }
+
   // ------------------------------------------------------------------------------------------------
   // Android SMS reception section
   // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`CallLifecycleHandler.releaseCall()` was called in two fundamentally different situations but had only one implementation — `terminateCall() + stopService()`:

| Situation | Intent | What happened |
|-----------|--------|---------------|
| Unanswered call (missed, declined, server hangup) | Terminate PhoneConnection + stop service | Correct |
| Answered call, Activity taking over | Stop service only, keep PhoneConnection alive | **Wrong** — PhoneConnection destroyed |

When the push isolate closes after an answered call, `close() -> releaseCall(callId)` destroyed the PhoneConnection before the Activity could adopt it. The Activity's `reportNewIncomingCall` then saw no answered state and registered a fresh incoming connection — `CallBloc` stuck at `incomingFromOffer`, `performAnswerCall` never delivered.

The failure was masked for the **first push call** because `ForegroundService` was not yet running when the `HungUp` broadcast fired (broadcast missed, `STATE_ACTIVE` stayed intact). For **calls within the 10-second pushBound grace window** `ForegroundService` was already running, processed the broadcast immediately, cleared `STATE_ACTIVE`, and the Activity had no recovery path.

## Fix

Split the single overloaded method into two with explicit, non-overlapping semantics:

```kotlin
override fun releaseCall(callId, callback) {
    // Unanswered call — terminate PhoneConnection and stop IncomingCallService
    terminateCall(CallMetadata(callId = callId), DeclineSource.SERVER)
    stopService()
    callback(Result.success(Unit))
}

override fun handoffCall(callId, callback) {
    // Answered call — Activity is taking over, stop IncomingCallService only.
    // PhoneConnection stays ACTIVE for CALL_ID_ALREADY_EXISTS_AND_ANSWERED adopt path.
    stopService()
    callback(Result.success(Unit))
}
```

Dart caller (`PushNotificationIsolateManager.close()` in `webtrit_phone`) will call `handoffCall()` when `_callAnswered == true`, `releaseCall()` otherwise. See companion PR in webtrit_phone.

## Result

```
push isolate: answered -> PhoneConnection ACTIVE
push isolate: close() -> handoffCall(callId) -> stopService() only
PhoneConnection: stays ACTIVE, no HungUp broadcast
Activity: reportNewIncomingCall -> CALL_ID_ALREADY_EXISTS_AND_ANSWERED -> adopt -> performAnswerCall
CallBloc: incomingFromOffer -> incomingAnswering -> connected
```

Works identically for first call and calls within the 10-second pushBound grace window.

## Also included

**BinaryMessenger race fix in `WebtritCallkeepPlugin`**: the shared `messenger` field is overwritten by every `onAttachedToEngine()` call (Activity + push isolates each have their own `FlutterEngine`). If a push isolate's `onAttachedToEngine` fired between `onAttachedToActivity()` and the async `onServiceConnected()`, `flutterDelegateApi` was created with the push engine's messenger — `performAnswerCall` silently dropped. Fixed by capturing `activityBinaryMessenger` synchronously in `onAttachedToActivity`.

## Files changed

| File | Change |
|------|--------|
| `pigeons/callkeep.messages.dart` | Add `handoffCall` to `PHostBackgroundPushNotificationIsolateApi` |
| `Generated.kt` / `callkeep.pigeon.dart` | Regenerated Pigeon output |
| `CallLifecycleHandler.kt` | Implement `handoffCall` (stopService only); restore `releaseCall` to single purpose |
| `IncomingCallService.kt` | Remove `isCallAnswered` lambda (no longer needed) |
| `BackgroundPushNotificationService.dart` | Expose `handoffCall()` with documentation |
| `WebtritCallkeepPlatformInterface.dart` | Add `handoffCallBackgroundPushNotificationService` |
| `WebtritCallkeepAndroid.dart` | Wire `handoffCall()` to Pigeon |
| `WebtritCallkeepPlugin.kt` | `activityBinaryMessenger` messenger race fix |

## Companion change

`webtrit_phone`: `PushNotificationIsolateManager.close()` must call `handoffCall()` instead of `releaseCall()` when `_callAnswered == true`.