### PR TITLE
fix(android): start activity from onShowIncomingCallUi to bypass VoipCallMonitor (WT-1306)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -1,11 +1,13 @@
 package com.webtrit.callkeep.services.services.connection
 
+import android.app.KeyguardManager
 import android.content.Context
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.OutcomeReceiver
 import android.os.ParcelUuid
+import android.os.PowerManager
 import android.telecom.CallAudioState
 import android.telecom.CallEndpoint
 import android.telecom.CallEndpointException
@@ -121,18 +123,26 @@ class PhoneConnection internal constructor(
      * Invoked by the system when the incoming call interface should be displayed.
      *
      * Android grants a Background Activity Launch (BAL) exemption to the ConnectionService
-     * during this callback. We use it to start the activity directly, bypassing the
-     * VoipCallMonitor introduced in Android 14 which intercepts FSI delivery for self-managed
-     * calls and prevents the full-screen call UI from appearing.
+     * during this callback. When the screen is off or the device is locked, we start the
+     * activity directly to bypass the VoipCallMonitor introduced in Android 14, which
+     * intercepts FSI delivery for self-managed calls and prevents the full-screen call UI
+     * from appearing.
+     *
+     * When the screen is on and the device is unlocked, the notification is sufficient —
+     * the app handles the call UI via the DidPushIncomingCall event.
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
         audioManager.startRingtone(metadata.ringtonePath)
-        Platform.getLaunchActivity(context)?.let { launchIntent ->
-            logger.d("onShowIncomingCallUi: starting activity directly for incoming call UI")
-            context.startActivity(launchIntent)
-        } ?: logger.w("onShowIncomingCallUi: no launch activity found, incoming call UI may not appear")
+        val power = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val keyguard = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        if (!power.isInteractive || keyguard.isKeyguardLocked) {
+            Platform.getLaunchActivity(context)?.let { launchIntent ->
+                logger.d("onShowIncomingCallUi: starting activity directly (screen off or locked)")
+                context.startActivity(launchIntent)
+            } ?: logger.w("onShowIncomingCallUi: no launch activity found, incoming call UI may not appear")
+        }
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -119,11 +119,20 @@ class PhoneConnection internal constructor(
 
     /**
      * Invoked by the system when the incoming call interface should be displayed.
+     *
+     * Android grants a Background Activity Launch (BAL) exemption to the ConnectionService
+     * during this callback. We use it to start the activity directly, bypassing the
+     * VoipCallMonitor introduced in Android 14 which intercepts FSI delivery for self-managed
+     * calls and prevents the full-screen call UI from appearing.
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
         audioManager.startRingtone(metadata.ringtonePath)
+        Platform.getLaunchActivity(context)?.let { launchIntent ->
+            logger.d("onShowIncomingCallUi: starting activity directly for incoming call UI")
+            context.startActivity(launchIntent)
+        } ?: logger.w("onShowIncomingCallUi: no launch activity found, incoming call UI may not appear")
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
     }
 


### PR DESCRIPTION
## Problem

Android 14 introduced `VoipCallMonitor` in the Telecom framework (`system_server`). It intercepts FSI delivery for all `category=call` / `CallStyle` notifications but explicitly skips self-managed `ConnectionService` calls (`PROPERTY_SELF_MANAGED`). The result:

```
VoipCallMonitor: onNotificationPosted: could not find a call for sbn.id=[2]
```

FSI never fires → full-screen incoming call UI does not appear on locked devices.

**Root cause of the regression** (PR #217): `IncomingCallService` was given a `SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP` before the notification was posted. This woke the device from Doze before FSI arrived. On an already-awake device, SystemUI doesn't fire FSI independently — VoipCallMonitor intercepts and discards it.

In 0.4.1 the device was still in Doze when the notification arrived, so SystemUI fired FSI before VoipCallMonitor got a chance to block it. PR #217 broke that race.

## Fix

`ConnectionService.onShowIncomingCallUi()` receives a Background Activity Launch (BAL) exemption from the Android framework. Starting the main activity directly from this callback:

- Bypasses VoipCallMonitor entirely
- Works on all API levels
- Is device-state-independent (no Doze/awake race, no `USE_FULL_SCREEN_INTENT` permission dependency)
- The BAL exemption is UID-scoped, so `startActivity()` from the `:callkeep_core` process works correctly

`establish()` for outgoing calls already used the same `context.startActivity(Platform.getLaunchActivity(context))` pattern. This PR applies it to incoming calls.

## Changes

**`PhoneConnection.kt`** — `onShowIncomingCallUi()`: add `context.startActivity(Platform.getLaunchActivity(context))` before dispatching `DidPushIncomingCall`

## Testing

1. Screen OFF → incoming call → expected: screen lights up, full-screen call UI appears
2. Screen OFF → call 1 → answer → end → immediately call 2 → expected: screen lights up again
3. Check logcat for: `onShowIncomingCallUi: starting activity directly for incoming call UI`

## Related

- YouTrack: [WT-1306](https://youtrack.portaone.com/issue/WT-1306)
- Regression introduced by: PR #217
- Previous attempt (draft, different branch): PR #252