### PR TITLE
fix(android): restore FSI for incoming calls on Android 14+ (WT-1306)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -172,11 +172,24 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
 
     @SuppressLint("MissingPermission")
     fun updateToReleaseIncomingCallNotification() {
-        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, buildReleaseNotification())
+        val id = callMetaData?.callId?.let { notificationId(it) } ?: NOTIFICATION_ID
+        NotificationManagerCompat.from(context).notify(id, buildReleaseNotification())
     }
 
     companion object {
         const val TAG = "INCOMING_CALL_NOTIFICATION"
+
+        // Legacy fixed ID kept only as a fallback when callId is unavailable.
+        // Prefer notificationId(callId) for all new code.
         const val NOTIFICATION_ID = 2
+
+        /**
+         * Returns a stable notification ID for the given call ID.
+         * Using a per-call ID ensures each incoming call is treated as a new
+         * notification by the system, so the fullScreenIntent fires correctly
+         * even when a previous call's notification with the same fixed ID still
+         * exists (or existed as a placeholder).
+         */
+        fun notificationId(callId: String): Int = callId.hashCode()
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -172,16 +172,14 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
 
     @SuppressLint("MissingPermission")
     fun updateToReleaseIncomingCallNotification() {
-        val id = callMetaData?.callId?.let { notificationId(it) } ?: NOTIFICATION_ID
-        NotificationManagerCompat.from(context).notify(id, buildReleaseNotification())
+        NotificationManagerCompat.from(context).notify(
+            notificationId(callMetaData!!.callId),
+            buildReleaseNotification(),
+        )
     }
 
     companion object {
         const val TAG = "INCOMING_CALL_NOTIFICATION"
-
-        // Legacy fixed ID kept only as a fallback when callId is unavailable.
-        // Prefer notificationId(callId) for all new code.
-        const val NOTIFICATION_ID = 2
 
         /**
          * Returns a stable notification ID for the given call ID.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -172,10 +172,8 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
 
     @SuppressLint("MissingPermission")
     fun updateToReleaseIncomingCallNotification() {
-        NotificationManagerCompat.from(context).notify(
-            notificationId(callMetaData!!.callId),
-            buildReleaseNotification(),
-        )
+        val meta = requireNotNull(callMetaData) { "Call metadata must be set before updating the notification." }
+        NotificationManagerCompat.from(context).notify(notificationId(meta.callId), buildReleaseNotification())
     }
 
     companion object {
@@ -183,11 +181,19 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
 
         /**
          * Returns a stable notification ID for the given call ID.
+         *
          * Using a per-call ID ensures each incoming call is treated as a new
          * notification by the system, so the fullScreenIntent fires correctly
-         * even when a previous call's notification with the same fixed ID still
-         * exists (or existed as a placeholder).
+         * regardless of any previous call's notification.
+         *
+         * IDs are remapped into [MIN_CALL_NOTIFICATION_ID, Int.MAX_VALUE] to guarantee
+         * they never collide with reserved IDs used elsewhere in the app
+         * (FGS placeholder = 3, ActiveCallNotificationBuilder = 1, StandaloneCallService = 97).
          */
-        fun notificationId(callId: String): Int = callId.hashCode()
+        fun notificationId(callId: String): Int = (callId.hashCode() and Int.MAX_VALUE).coerceAtLeast(MIN_CALL_NOTIFICATION_ID)
+
+        // All per-call notification IDs are kept above this threshold so they never
+        // collide with small reserved IDs used by other services in this package.
+        private const val MIN_CALL_NOTIFICATION_ID = 1000
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -5,6 +5,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
@@ -238,7 +239,20 @@ class IncomingCallService :
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
         callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
-        acquireScreenWakeLockIfNeeded()
+        // Acquire the screen WakeLock only when USE_FULL_SCREEN_INTENT is unavailable
+        // (e.g. MIUI/HyperOS where the permission is denied by default).
+        //
+        // When FSI is granted, acquiring a WakeLock here wakes the device from Doze
+        // *before* the FSI notification is posted. On an already-awake device, SystemUI
+        // no longer fires FSI as part of a Doze-exit sequence — VoipCallMonitor
+        // (Android 14+) then intercepts the notification and silently suppresses FSI
+        // because self-managed connections are not tracked in its call registry.
+        //
+        // When FSI is unavailable the WakeLock is the only mechanism to turn the screen
+        // on; the notification provides the call UI instead of a full-screen Activity.
+        if (!isFullScreenIntentAvailable()) {
+            acquireScreenWakeLockIfNeeded()
+        }
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand
@@ -292,18 +306,30 @@ class IncomingCallService :
     }
 
     /**
-     * Acquires a wake lock that turns on the screen when an incoming call arrives.
+     * Returns true if the app is allowed to post full-screen intent notifications.
+     *
+     * On Android 14+ (API 34) this maps to the USE_FULL_SCREEN_INTENT permission, which
+     * some OEM ROMs (MIUI/HyperOS) deny by default. On older Android versions FSI is
+     * always available so this method returns false (WakeLock fallback is used).
+     */
+    private fun isFullScreenIntentAvailable(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+        return nm.canUseFullScreenIntent()
+    }
+
+    /**
+     * Acquires a wake lock that turns on the screen when an incoming call arrives on
+     * devices where USE_FULL_SCREEN_INTENT is unavailable (e.g. MIUI/HyperOS).
      *
      * SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP is required to physically turn the
-     * screen on via PowerManager. This is complementary to the full-screen intent — the
-     * intent launches the incoming call UI; the wake lock turns the screen on so the UI
-     * is visible. They must both be used together.
+     * screen on via PowerManager. On these devices the notification provides the call UI
+     * instead of a full-screen Activity; the wake lock makes it visible.
      *
-     * The two mechanisms are NOT mutually exclusive. When the app is in the foreground
-     * with the screen locked (Activity state ON_STOP), Android may suppress the
-     * full-screen intent Activity launch because the app is already "visible". In that
-     * case only the wake lock can turn the screen on. Skipping it when full-screen intent
-     * is available causes the ringtone to play on a dark screen with no call UI shown.
+     * This must NOT be acquired before the FSI notification is posted on devices where
+     * FSI is available. Waking the device from Doze first changes the timing so that
+     * VoipCallMonitor (Android 14+) intercepts the FSI notification on an already-awake
+     * device, preventing SystemUI from firing it as part of the Doze-exit sequence.
      *
      * The lock expires automatically after WAKELOCK_TIMEOUT_MS to prevent battery
      * drain if the release path is skipped.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -313,11 +313,16 @@ class IncomingCallService :
     }
 
     /**
-     * Returns true if the app is allowed to post full-screen intent notifications.
+     * Returns true if the system will fire a full-screen intent for this app's notifications,
+     * meaning the WakeLock is not needed to wake the screen.
      *
-     * On Android 14+ (API 34) this maps to the USE_FULL_SCREEN_INTENT permission, which
-     * some OEM ROMs (MIUI/HyperOS) deny by default. On older Android versions FSI is
-     * always available so this method returns false (WakeLock fallback is used).
+     * On Android 13 and below there is no VoipCallMonitor and no USE_FULL_SCREEN_INTENT
+     * permission gate, but acquiring the WakeLock on those versions is harmless and keeps
+     * the pre-existing behavior. Returning false here causes handleLaunch() to always acquire
+     * the WakeLock on API < 34, which is intentional.
+     *
+     * On Android 14+ (API 34) the permission can be denied by OEM ROMs (MIUI/HyperOS).
+     * When denied, canUseFullScreenIntent() returns false and we fall back to the WakeLock.
      */
     private fun isFullScreenIntentAvailable(): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -95,8 +95,15 @@ class IncomingCallService :
         // during Flutter cold-start) or if IC_RELEASE arrives before IC_INITIALIZE. Calling
         // startForeground() here — in onCreate() — prevents ForegroundServiceDidNotStartInTimeException
         // regardless of which action onStartCommand() processes first.
-        // When IC_INITIALIZE later arrives, incomingCallHandler.handle() calls startForeground()
-        // again with the full incoming-call notification, which simply replaces this placeholder.
+        //
+        // IMPORTANT: use PLACEHOLDER_NOTIFICATION_ID (not NOTIFICATION_ID) here. The real
+        // incoming-call notification uses NOTIFICATION_ID and carries a fullScreenIntent. If both
+        // use the same ID, the system sees the real notification as an UPDATE to the placeholder
+        // and suppresses the fullScreenIntent (FSI fires only for newly-posted notification IDs,
+        // not for updates to existing ones). Using a distinct placeholder ID ensures that when
+        // IncomingCallHandler later calls startForeground(NOTIFICATION_ID, ...), the system
+        // treats it as a brand-new notification — allowing the FSI to fire and wake the screen.
+        // Android removes the placeholder automatically when the FGS transitions to NOTIFICATION_ID.
         val placeholder =
             Notification
                 .Builder(this, NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
@@ -106,7 +113,7 @@ class IncomingCallService :
                 .build()
         startForegroundServiceCompat(
             this,
-            IncomingCallNotificationBuilder.NOTIFICATION_ID,
+            PLACEHOLDER_NOTIFICATION_ID,
             placeholder,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
         )
@@ -365,6 +372,12 @@ class IncomingCallService :
         private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
+
+        // Notification ID used for the FGS placeholder in onCreate(). Must differ from
+        // IncomingCallNotificationBuilder.NOTIFICATION_ID so that the real incoming-call
+        // notification (which carries a fullScreenIntent) is posted as a new notification
+        // rather than an update — FSI fires only on newly-posted notification IDs.
+        private const val PLACEHOLDER_NOTIFICATION_ID = IncomingCallNotificationBuilder.NOTIFICATION_ID + 10
 
         @Volatile
         var isRunning = false

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -96,14 +96,14 @@ class IncomingCallService :
         // startForeground() here — in onCreate() — prevents ForegroundServiceDidNotStartInTimeException
         // regardless of which action onStartCommand() processes first.
         //
-        // IMPORTANT: use PLACEHOLDER_NOTIFICATION_ID (not NOTIFICATION_ID) here. The real
-        // incoming-call notification uses NOTIFICATION_ID and carries a fullScreenIntent. If both
-        // use the same ID, the system sees the real notification as an UPDATE to the placeholder
-        // and suppresses the fullScreenIntent (FSI fires only for newly-posted notification IDs,
-        // not for updates to existing ones). Using a distinct placeholder ID ensures that when
-        // IncomingCallHandler later calls startForeground(NOTIFICATION_ID, ...), the system
-        // treats it as a brand-new notification — allowing the FSI to fire and wake the screen.
-        // Android removes the placeholder automatically when the FGS transitions to NOTIFICATION_ID.
+        // IMPORTANT: use PLACEHOLDER_NOTIFICATION_ID here, NOT a call-derived notification ID.
+        // The real incoming-call notification is posted by IncomingCallHandler with an ID derived
+        // from the call ID (IncomingCallNotificationBuilder.notificationId(callId)). If the
+        // placeholder used the same ID, the system would treat the real notification as an UPDATE
+        // to the placeholder and suppress the fullScreenIntent — FSI fires only for newly-posted
+        // notification IDs, not for updates to existing ones. A distinct placeholder ID ensures
+        // that the real notification is always new from the system's perspective.
+        // Android removes the placeholder automatically when the FGS transitions to the new ID.
         val placeholder =
             Notification
                 .Builder(this, NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
@@ -373,11 +373,13 @@ class IncomingCallService :
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
 
-        // Notification ID used for the FGS placeholder in onCreate(). Must differ from
-        // IncomingCallNotificationBuilder.NOTIFICATION_ID so that the real incoming-call
-        // notification (which carries a fullScreenIntent) is posted as a new notification
-        // rather than an update — FSI fires only on newly-posted notification IDs.
-        private const val PLACEHOLDER_NOTIFICATION_ID = IncomingCallNotificationBuilder.NOTIFICATION_ID + 10
+        // Stable notification ID for the FGS placeholder posted in onCreate(). Must not
+        // collide with IDs produced by IncomingCallNotificationBuilder.notificationId(callId)
+        // (which are String.hashCode() values). Using a fixed sentinel keeps it simple; the
+        // placeholder lives only until IncomingCallHandler replaces it with the real call
+        // notification, so a hash collision (probability ~1 in 4 billion) would cause no
+        // visible problem — the placeholder is removed either way.
+        private const val PLACEHOLDER_NOTIFICATION_ID = 3
 
         @Volatile
         var isRunning = false

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -32,6 +32,14 @@ class IncomingCallHandler(
     private var lastMetadata: CallMetadata? = null
     private val notifier by lazy { NotificationManagerCompat.from(service) }
 
+    // Derived from the current call's ID so each incoming call gets a unique notification ID.
+    // A unique ID guarantees the system treats the notification as new — not an update to a
+    // previous one — which is required for fullScreenIntent to fire on Android 14+.
+    private val currentNotificationId: Int
+        get() =
+            lastMetadata?.callId?.let { IncomingCallNotificationBuilder.notificationId(it) }
+                ?: currentNotificationId
+
     /**
      * Entry point to process a fresh incoming call.
      * Shows the ringing notification and starts background handling unless the main app is active.
@@ -71,7 +79,7 @@ class IncomingCallHandler(
     @SuppressLint("MissingPermission")
     fun muteIncomingCallNotification() {
         stopForegroundDetach()
-        notifier.cancel(IncomingCallNotificationBuilder.NOTIFICATION_ID)
+        notifier.cancel(currentNotificationId)
         startForegroundCompat(notificationBuilder.buildSilent())
     }
 
@@ -82,7 +90,7 @@ class IncomingCallHandler(
         val notification = notificationBuilder.apply { setCallMetaData(metadata) }.build()
         service.startForegroundServiceCompat(
             service,
-            IncomingCallNotificationBuilder.NOTIFICATION_ID,
+            currentNotificationId,
             notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
         )
@@ -115,12 +123,12 @@ class IncomingCallHandler(
     private fun startForegroundCompat(notification: Notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             service.startForeground(
-                IncomingCallNotificationBuilder.NOTIFICATION_ID,
+                currentNotificationId,
                 notification,
                 android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
             )
         } else {
-            service.startForeground(IncomingCallNotificationBuilder.NOTIFICATION_ID, notification)
+            service.startForeground(currentNotificationId, notification)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -38,7 +38,7 @@ class IncomingCallHandler(
     private val currentNotificationId: Int
         get() =
             lastMetadata?.callId?.let { IncomingCallNotificationBuilder.notificationId(it) }
-                ?: currentNotificationId
+                ?: IncomingCallNotificationBuilder.NOTIFICATION_ID
 
     /**
      * Entry point to process a fresh incoming call.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -35,10 +35,11 @@ class IncomingCallHandler(
     // Derived from the current call's ID so each incoming call gets a unique notification ID.
     // A unique ID guarantees the system treats the notification as new — not an update to a
     // previous one — which is required for fullScreenIntent to fire on Android 14+.
+    // lastMetadata is always non-null when this property is read: showNotification() sets it
+    // before accessing currentNotificationId, and all other callers are guarded by the
+    // lastMetadata != null check in releaseIncomingCallNotification().
     private val currentNotificationId: Int
-        get() =
-            lastMetadata?.callId?.let { IncomingCallNotificationBuilder.notificationId(it) }
-                ?: IncomingCallNotificationBuilder.NOTIFICATION_ID
+        get() = IncomingCallNotificationBuilder.notificationId(lastMetadata!!.callId)
 
     /**
      * Entry point to process a fresh incoming call.


### PR DESCRIPTION
## Problem

Full-screen incoming call UI stopped appearing on Android 14+ devices. Only the notification was visible; the screen did not wake up with the call UI.

## How FSI works

FSI is a mechanism to wake a sleeping device. The system fires it only when it makes sense:

| Device state | FSI | Who shows the call UI |
|---|---|---|
| Screen OFF (Doze) | Fires — our fix restored this | SystemUI → activity launch |
| Screen ON + locked | Blocked by VoipCallMonitor on Android 14+ | Notification only |
| Screen ON + unlocked | Suppressed by system intentionally | Flutter via DidPushIncomingCall |

When the device is already awake and unlocked, FSI does not fire — this is correct behavior. The app handles the call UI directly via `DidPushIncomingCall`.

## Root Causes

### 1. WakeLock woke the device before the FSI notification was posted (PR #217 regression)

PR #217 added `SCREEN_BRIGHT_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP` unconditionally in `IC_INITIALIZE`, waking the device from Doze **before** the FSI notification was posted.

On an already-awake device, SystemUI does not fire FSI as part of a Doze-exit sequence. VoipCallMonitor (Android 14+) intercepts the CallStyle notification and suppresses FSI — self-managed connections (`PROPERTY_SELF_MANAGED`) are not tracked in its registry, so it logs `"could not find a call"` and returns.

In callkeep 0.4.1 the device was still in Doze when the notification arrived → SystemUI fired FSI first, winning the race against VoipCallMonitor.

**Fix:** skip WakeLock when `NotificationManager.canUseFullScreenIntent()` returns `true`. The device must stay in Doze until the notification is posted so SystemUI can fire FSI. When FSI is denied (MIUI/HyperOS), WakeLock stays as the only wake mechanism.

### 2. Placeholder notification used the same ID as the real incoming-call notification

`IncomingCallService.onCreate()` posts a placeholder (to satisfy Android's 5-second `startForeground()` deadline) using the **same ID=2** as the real incoming-call notification posted later by `IncomingCallHandler`.

When `IncomingCallHandler` called `startForeground(id=2, realNotification_with_FSI)`, the system treated it as an **update** — FSI fires only for newly-posted notification IDs, not updates.

In 0.4.1 there was no placeholder: `startForeground(id=2)` was the first call with that ID → system treated it as new → FSI fired.

**Fix:** placeholder uses a fixed sentinel ID=3. The real notification gets a per-call ID.

### 3. Fixed notification ID caused FSI suppression on back-to-back calls

Even with fix #2, consecutive calls reused the same fixed ID for the real notification → second call treated as update → FSI suppressed.

**Fix:** derive notification ID from call ID: `callId.hashCode()`. Each call gets a unique ID → system always sees a new notification → FSI fires for every call.

## Changes

**`IncomingCallService.kt`** — skip WakeLock when FSI is available; placeholder uses sentinel ID=3

**`IncomingCallNotificationBuilder.kt`** — `notificationId(callId)` replaces fixed `NOTIFICATION_ID=2`

**`IncomingCallHandler.kt`** — `currentNotificationId` computed from `lastMetadata!!.callId`

## Related

- YouTrack: [WT-1306](https://youtrack.portaone.com/issue/WT-1306)
- WakeLock regression: PR #217
- Closed wrong approach: PR #257