### PR TITLE
docs(handoff-call): document Activity full-screen intent takeover in handoffCall

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -140,10 +140,12 @@ class CallLifecycleHandler(
         callId: String,
         callback: (Result<Unit>) -> Unit,
     ) {
-        // The call was answered via push notification and the Activity is taking over.
-        // The PhoneConnection must stay alive for the Activity to adopt it via
-        // reportNewIncomingCall → CALL_ID_ALREADY_EXISTS_AND_ANSWERED.
-        Log.d(TAG, "handoffCall: $callId — answered, stopping service only (Activity handoff)")
+        // Called when the Activity is taking over the call — either because the user
+        // answered via push-notification UI, or because the Activity launched as a
+        // full-screen intent and the push isolate's budget expired while the call was
+        // still ringing. In both cases the PhoneConnection must stay alive; only
+        // IncomingCallService is stopped so the Activity can handle the call normally.
+        Log.d(TAG, "handoffCall: $callId — stopping service only, connection stays alive (Activity handoff)")
         stopService()
         callback(Result.success(Unit))
     }


### PR DESCRIPTION
## Summary

Updates the `handoffCall` comment in `CallLifecycleHandler` to cover both cases where it is called:

1. User answered via push-notification UI (existing case)
2. Activity launched as a full-screen intent and the push isolate's 20 s budget expired while the call was still ringing (new case, fixed in webtrit_phone)

In both cases `handoffCall` only calls `stopService()` — the `PhoneConnection` stays alive for the Activity to adopt.