### PR TITLE
fix: set audio devices after hold on miui a12 broken apis

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -7,6 +7,7 @@ import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.Ringtone
 import android.media.RingtoneManager
+import android.os.Build
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.setLoopingCompat
@@ -24,6 +25,26 @@ class AudioManager(
         return devices.any { it.type == type }
     }
 
+    private fun isOutputDeviceConnected(type: Int): Boolean {
+        val devices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        return devices.any { it.type == type }
+    }
+
+    /**
+     * Check if the device supports earpiece.
+     *
+     * @return True if the device supports earpiece, false otherwise.
+     */
+    fun isSupportEarpiese(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    
+    /**
+     * Check if the device supports speakerphone.
+     *
+     * @return True if the device supports speakerphone, false otherwise.
+     */
+    fun isSupportSpeakerphone(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
+
+
     /**
      * Check if a wired headset is connected.
      *
@@ -37,6 +58,19 @@ class AudioManager(
      * @return True if a Bluetooth headset is connected, false otherwise.
      */
     fun isBluetoothConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+
+
+    /**
+     * Check if the speakerphone is currently on.
+     *
+     * @return True if the speakerphone is on, false otherwise.
+     */
+    fun isSpeakerphoneOn(): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        audioManager.communicationDevice?.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+    } else {
+        audioManager.isSpeakerphoneOn
+    }
+
 
     /**
      * Start playing the ringtone.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -63,6 +63,8 @@ class PhoneConnection internal constructor(
     private var availableCallEndpoints: List<CallEndpoint> = emptyList()
     private val notificationManager = NotificationManager()
 
+    private var lastKnownState: Int? = null
+
     val callId: String
         get() = metadata.callId
 
@@ -225,10 +227,16 @@ class PhoneConnection internal constructor(
         super.onStateChanged(state)
         handleConnectionTimeout(state)
 
-        when (state) {
-            STATE_DIALING -> onDialing()
-            STATE_ACTIVE -> onActiveConnection()
+        if(lastKnownState == STATE_NEW && state == STATE_DIALING){
+            onDialing()
         }
+
+        // Core Fix: Ensure onActiveConnection is called when transitioning from transient states (DIALING/RINGING) to ACTIVE and ignore Hold -> Unhold
+        if((lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING) && state == STATE_ACTIVE){
+            onActiveConnection()
+        }
+
+        lastKnownState = state
     }
 
     /**
@@ -299,8 +307,8 @@ class PhoneConnection internal constructor(
         logger.w("dispatchFallbackAudioState: callAudioState not set by system — building device list from AudioManager")
         val supportedDevices =
             buildList {
-                add(AudioDevice(AudioDeviceType.EARPIECE))
-                add(AudioDevice(AudioDeviceType.SPEAKER))
+                if (audioManager.isSupportEarpiese()) add(AudioDevice(AudioDeviceType.EARPIECE))
+                if (audioManager.isSupportSpeakerphone()) add(AudioDevice(AudioDeviceType.SPEAKER))
                 if (audioManager.isWiredHeadsetConnected()) add(AudioDevice(AudioDeviceType.WIRED_HEADSET))
                 if (audioManager.isBluetoothConnected()) add(AudioDevice(AudioDeviceType.BLUETOOTH))
             }
@@ -310,6 +318,7 @@ class PhoneConnection internal constructor(
             when {
                 audioManager.isBluetoothConnected() -> AudioDevice(AudioDeviceType.BLUETOOTH)
                 audioManager.isWiredHeadsetConnected() -> AudioDevice(AudioDeviceType.WIRED_HEADSET)
+                audioManager.isSpeakerphoneOn() -> AudioDevice(AudioDeviceType.SPEAKER)
                 else -> AudioDevice(AudioDeviceType.EARPIECE)
             }
         dispatcher(CallMediaEvent.AudioDeviceSet, metadata.copy(audioDevice = currentDevice))
@@ -424,22 +433,21 @@ class PhoneConnection internal constructor(
                 )
             }
         } else {
-            setAudioRoute(mapDeviceTypeToRoute(device.type))
+            val targetRoute = mapDeviceTypeToRoute(device.type)
+            setAudioRoute(targetRoute)
 
-            if (callAudioState == null) {
-                logger.w("callAudioState is null after setAudioRoute.")
-                // MIUI Android 12 (and similar OEM Telecom implementations) silently ignores
-                // setAudioRoute() for self-managed outgoing calls — the hardware never switches.
-                // Bypass Telecom and route audio directly via AudioManager so the device actually
-                // changes. On AOSP, setAudioRoute() works and onCallAudioStateChanged fires
-                // authoritatively; the direct call is redundant but idempotent there.
-                directRouteAudioDevice(device.type)
+            // MIUI Android 12 (and similar OEM Telecom implementations) silently ignores
+            // setAudioRoute() — both for outgoing calls (where callAudioState is always null)
+            // and for incoming calls after hold/unhold (where MIUI re-seeds callAudioState
+            // when ACTIVE is re-confirmed, making callAudioState non-null, yet still ignores
+            // setAudioRoute()). Always bypass Telecom and route directly via AudioManager.
+            // On AOSP, setAudioRoute() works and onCallAudioStateChanged fires authoritatively
+            // to override the proactive dispatch below — idempotent.
+            
+            directRouteAudioDevice(device.type)
+            dispatcher(CallMediaEvent.AudioDeviceSet, metadata.copy(audioDevice = device))
+            isHasSpeaker = device.type == AudioDeviceType.SPEAKER
 
-                // Proactively dispatch AudioDeviceSet because onCallAudioStateChanged never fires
-                // on MIUI. On AOSP, the callback fires and overrides this — idempotent.
-                dispatcher(CallMediaEvent.AudioDeviceSet, metadata.copy(audioDevice = device))
-                isHasSpeaker = device.type == AudioDeviceType.SPEAKER
-            }
         }
     }
 


### PR DESCRIPTION
## Description

Fix changing audio devices after hold on miui a12 broken apis

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
