### PR TITLE
fix(android): cancel FGS placeholder notification on service destroy

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -13,6 +13,7 @@ import android.os.Looper
 import android.os.PowerManager
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
@@ -200,6 +201,12 @@ class IncomingCallService :
         CallkeepCore.instance.removeConnectionEventListener(this)
 
         stopForeground(STOP_FOREGROUND_REMOVE)
+        // Explicitly cancel the placeholder notification (ID=3) posted in onCreate().
+        // stopForeground(REMOVE) only removes the *current* foreground notification.
+        // If the FGS transitioned to a call-derived ID before this point, the placeholder
+        // may not be auto-cancelled by Android on all OEM builds, leaving a blank
+        // "Webtrit • now" notification that the user cannot dismiss (setOngoing=true).
+        NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
         isolateHandler.cleanup()
         super.onDestroy()
     }


### PR DESCRIPTION
## Summary

- `IncomingCallService.onCreate()` posts a placeholder notification (ID=3) with no title and no body to satisfy Android's 5-second `startForeground()` requirement
- When the service transitions to a call-derived notification ID (1000+), the code relies on Android automatically cancelling ID=3 — this is not reliable on all OEM Android 12 builds
- `stopForeground(STOP_FOREGROUND_REMOVE)` in `onDestroy()` only removes the *current* foreground notification, leaving ID=3 behind
- With `setOngoing(true)`, the stuck notification cannot be dismissed by the user and shows as a blank "Webtrit • now" entry in the notification panel

**Fix:** add `NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)` in `onDestroy()` as an explicit safety net.

## Test plan

- [ ] Receive incoming call → caller hangs up before answer → notification panel is clean
- [ ] Receive incoming call → answer → hang up → notification panel is clean
- [ ] Reproduce on Android 12 device with Persistent Connection enabled
- [ ] `adb shell dumpsys notification | grep -A5 "Webtrit"` shows no leftover notification after each scenario

Fixes: WT-1312