### PR TITLE
fix(android): remove Samsung setInitialized skip for outgoing calls (WT-1344)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -231,7 +231,7 @@ class PhoneConnection internal constructor(
             onDialing()
         }
 
-        // Ensure onActiveConnection is called when transitioning from transient states (DIALING/RINGING) to ACTIVE and ignore Hold -> Unhold
+        // Core Fix: Ensure onActiveConnection is called when transitioning from transient states (DIALING/RINGING) to ACTIVE and ignore Hold -> Unhold
         if ((lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING) && state == STATE_ACTIVE) {
             onActiveConnection()
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -227,11 +227,12 @@ class PhoneConnection internal constructor(
         super.onStateChanged(state)
         handleConnectionTimeout(state)
 
-        if (state == STATE_DIALING && lastKnownState != STATE_HOLDING) {
+        if (lastKnownState == STATE_NEW && state == STATE_DIALING) {
             onDialing()
         }
 
-        if (state == STATE_ACTIVE && (lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING)) {
+        // Ensure onActiveConnection is called when transitioning from transient states (DIALING/RINGING) to ACTIVE and ignore Hold -> Unhold
+        if ((lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING) && state == STATE_ACTIVE) {
             onActiveConnection()
         }
 
@@ -933,9 +934,7 @@ class PhoneConnection internal constructor(
             timeout = ConnectionTimeout.createOutgoingConnectionTimeout(context),
         ).apply {
             setCallerDisplayName(metadata.name, TelecomManager.PRESENTATION_ALLOWED)
-            if (!Build.MANUFACTURER.equals("Samsung", ignoreCase = true)) {
-                setInitialized()
-            }
+            setInitialized()
             setDialing()
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -227,12 +227,11 @@ class PhoneConnection internal constructor(
         super.onStateChanged(state)
         handleConnectionTimeout(state)
 
-        if(lastKnownState == STATE_NEW && state == STATE_DIALING){
+        if (state == STATE_DIALING && lastKnownState != STATE_HOLDING) {
             onDialing()
         }
 
-        // Core Fix: Ensure onActiveConnection is called when transitioning from transient states (DIALING/RINGING) to ACTIVE and ignore Hold -> Unhold
-        if((lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING) && state == STATE_ACTIVE){
+        if (state == STATE_ACTIVE && (lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING)) {
             onActiveConnection()
         }
 
@@ -443,11 +442,10 @@ class PhoneConnection internal constructor(
             // setAudioRoute()). Always bypass Telecom and route directly via AudioManager.
             // On AOSP, setAudioRoute() works and onCallAudioStateChanged fires authoritatively
             // to override the proactive dispatch below — idempotent.
-            
+
             directRouteAudioDevice(device.type)
             dispatcher(CallMediaEvent.AudioDeviceSet, metadata.copy(audioDevice = device))
             isHasSpeaker = device.type == AudioDeviceType.SPEAKER
-
         }
     }
 


### PR DESCRIPTION
## Problem

Outgoing calls fail with \"System Error\" on Samsung Galaxy A55 5G (One UI 8.0, Android 16) after updating to 1.15.0+445000005.

### Root cause chain

1. `createOutgoingPhoneConnection` skipped `setInitialized()` for Samsung (workaround added for A50/S9, Android 9–10 — native Phone app UI did not appear)
2. Without `setInitialized()`, the connection never reaches `STATE_NEW` — state goes directly `null → STATE_DIALING`
3. The guard from #261 (MIUI A12 hold fix) only triggers `onDialing()` on `STATE_NEW → STATE_DIALING`
4. `onDialing()` never fires → `OngoingCall` broadcast never sent → `ForegroundService` hits 5s timeout → "System Error"

## Fix

Remove the Samsung-specific `setInitialized()` skip. Call it unconditionally for all devices:

```kotlin
// Before:
if (!Build.MANUFACTURER.equals("Samsung", ignoreCase = true)) {
    setInitialized()
}
setDialing()

// After:
setInitialized()
setDialing()
```

With `setInitialized()` called, Samsung now goes through `STATE_NEW` before `STATE_DIALING`, the `lastKnownState == STATE_NEW` guard from #261 matches, and `onDialing()` fires correctly.

The original UI workaround targeted Samsung A50/S9 on Android 9–10. It has not been reproduced on modern Samsung devices (One UI 8.0, Android 16) and is no longer justified.

## Related

- YouTrack: WT-1344
- Regression introduced in: #261
- Affected: Samsung Galaxy A55 5G, One UI 8.0, Android 16 (SDK 36)