### PR TITLE
fix(android): cancel FGS placeholder immediately after real notification is posted

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -268,6 +268,11 @@ class IncomingCallService :
             acquireScreenWakeLockIfNeeded()
         }
         incomingCallHandler.handle(metadata)
+        // After the real call notification is posted with a call-derived ID, explicitly cancel
+        // the placeholder (ID=3) posted in onCreate(). On some OEM builds startForeground() with
+        // a new ID does not automatically remove the previous foreground notification, leaving the
+        // blank "Webtrit • now" entry visible for the entire duration of the call.
+        NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand
         // handler has no fallback for that path and Android would kill the process with


### PR DESCRIPTION
## Problem

The previous fix (PR #262) cancelled `PLACEHOLDER_NOTIFICATION_ID` (ID=3) only in `onDestroy()`. This handled cleanup at service destruction but missed a more common scenario:

On OEM builds where `startForeground()` with a new ID does **not** automatically remove the previous foreground notification, the blank placeholder (no title, no body — visible as `"Webtrit • now"`) remained visible for the **entire duration of the call**. The user would see it at the moment of call teardown when glancing at the notification panel.

## Fix

Explicitly cancel `PLACEHOLDER_NOTIFICATION_ID` right after `incomingCallHandler.handle(metadata)` posts the real call notification in `handleLaunch()`. This removes the placeholder at the earliest possible point — immediately after the real notification takes over.

The `onDestroy()` cancel from PR #262 is kept as a second safety net for any remaining edge cases.

## Test plan

- [ ] Receive incoming call → verify no blank "Webtrit • now" notification visible during ringing
- [ ] Receive incoming call → answer → hang up → notification panel is clean
- [ ] Receive incoming call → caller hangs up → notification panel is clean
- [ ] Reproduce on Android 12 OEM device with Persistent Connection enabled

Fixes: WT-1312