### PR TITLE
fix(android): prevent blank FGS notifications on Samsung/OEM devices (WT-1312)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -21,6 +21,14 @@
     -->
     <!-- <uses-permission android:name="android.permission.RECEIVE_SMS" /> -->
 
+    <!--
+        Signature-level permission used to protect internal IC_RELEASE broadcasts.
+        Only components signed with the same key can send or receive these broadcasts.
+    -->
+    <permission
+        android:name="com.webtrit.callkeep.INTERNAL_BROADCAST"
+        android:protectionLevel="signature" />
+
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />

--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -28,6 +28,12 @@
     <permission
         android:name="com.webtrit.callkeep.INTERNAL_BROADCAST"
         android:protectionLevel="signature" />
+    <!--
+        The app must also hold the permission it declares so that intra-app
+        sendBroadcast(intent, permission) passes the receiver permission check,
+        and registerReceiver(broadcastPermission) passes the sender permission check.
+    -->
+    <uses-permission android:name="com.webtrit.callkeep.INTERNAL_BROADCAST" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Extensions.kt
@@ -100,12 +100,13 @@ fun Context.registerReceiverCompat(
     receiver: BroadcastReceiver,
     intentFilter: IntentFilter,
     exported: Boolean = true,
+    permission: String? = null,
 ) {
     if (SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         val flags = if (exported) Context.RECEIVER_EXPORTED else Context.RECEIVER_NOT_EXPORTED
-        registerReceiver(receiver, intentFilter, flags)
+        registerReceiver(receiver, intentFilter, permission, null, flags)
     } else {
-        registerReceiver(receiver, intentFilter)
+        registerReceiver(receiver, intentFilter, permission, null)
     }
 }
 
@@ -118,13 +119,14 @@ fun Context.registerReceiverCompat(
 fun Context.sendInternalBroadcast(
     action: String,
     extras: Bundle? = null,
+    permission: String? = null,
 ) {
     Intent(action)
         .apply {
             setPackage(packageName)
             addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
             extras?.let { putExtras(it) }
-        }.also { sendBroadcast(it) }
+        }.also { sendBroadcast(it, permission) }
 }
 
 fun Lifecycle.Event.toPCallkeepLifecycleType(): PCallkeepLifecycleEvent =

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -135,7 +135,10 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
         return NotificationCompat
             .Builder(context, INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
-            .setCategory(NotificationCompat.CATEGORY_CALL)
+            // Intentionally no CATEGORY_CALL here: Samsung/MIUI force all CATEGORY_CALL
+            // notifications to show as heads-up regardless of priority or silent flag.
+            // This notification is a transitional FGS keepalive during teardown and must
+            // not be visible to the user.
             .setContentTitle(title)
             .setContentText(description)
             .setOnlyAlertOnce(true)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -93,4 +93,9 @@ class ActiveCallService : Service() {
         }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -115,6 +115,7 @@ class IncomingCallService :
                 addAction(IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name)
             },
             exported = false,
+            permission = RELEASE_BROADCAST_PERMISSION,
         )
 
         CallkeepCore.instance.addConnectionEventListener(this)
@@ -376,6 +377,7 @@ class IncomingCallService :
         private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
+        private const val RELEASE_BROADCAST_PERMISSION = "com.webtrit.callkeep.INTERNAL_BROADCAST"
 
         @Volatile
         var isRunning = false
@@ -417,7 +419,7 @@ class IncomingCallService :
             // sendInternalBroadcast() uses setPackage(packageName) + FLAG_RECEIVER_FOREGROUND,
             // so it crosses the :callkeep_core → main-process boundary safely and is
             // delivered only to this app.
-            context.sendInternalBroadcast(type.name)
+            context.sendInternalBroadcast(type.name, permission = RELEASE_BROADCAST_PERMISSION)
             Log.d(TAG, "Release action $type initiated via broadcast.")
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -305,15 +305,12 @@ class IncomingCallService :
             acquireScreenWakeLockIfNeeded()
         }
         // Remove the placeholder before posting the real notification.
-        // STOP_FOREGROUND_REMOVE guarantees the placeholder is fully gone before
-        // startForeground() in handle() posts the real notification.
-        //
-        // The previous approach (DETACH + cancel) was unreliable: NotificationManager.cancel()
-        // is silently ignored when Android still considers the notification FGS-bound within
-        // the same dispatch cycle, leaving the placeholder visible alongside the real notification.
-        //
-        // REMOVE + immediate startForeground() is safe: both calls are synchronous on the
-        // main thread, so the service is never truly backgrounded between them.
+        // NotificationManager.cancel() cannot remove an FGS-bound notification — it is
+        // silently ignored when Android still considers the notification foreground-attached.
+        // STOP_FOREGROUND_REMOVE removes the binding and the notification atomically,
+        // guaranteeing the placeholder is gone before startForeground() in handle() posts
+        // the real ringing notification. Both calls are synchronous on the main thread so
+        // the service is never truly backgrounded between them.
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -305,17 +305,16 @@ class IncomingCallService :
             acquireScreenWakeLockIfNeeded()
         }
         // Remove the placeholder before posting the real notification.
-        // Samsung (and other OEMs) force-show all CATEGORY_CALL notifications as heads-up,
-        // ignoring setPriority/setSilent. Without this, the placeholder (no buttons) appears
-        // as a brief heads-up before the real notification (with buttons) replaces it —
-        // the user perceives two sequential call notifications.
+        // STOP_FOREGROUND_REMOVE guarantees the placeholder is fully gone before
+        // startForeground() in handle() posts the real notification.
         //
-        // DETACH first: converts the placeholder from an FGS-bound notification (which
-        // NotificationManager.cancel() cannot remove) into a regular cancellable one.
-        // All three calls are synchronous on the main thread so the service is never
-        // truly backgrounded — startForeground() in handle() re-binds FGS immediately.
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
-        NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
+        // The previous approach (DETACH + cancel) was unreliable: NotificationManager.cancel()
+        // is silently ignored when Android still considers the notification FGS-bound within
+        // the same dispatch cycle, leaving the placeholder visible alongside the real notification.
+        //
+        // REMOVE + immediate startForeground() is safe: both calls are synchronous on the
+        // main thread, so the service is never truly backgrounded between them.
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -1,12 +1,10 @@
 package com.webtrit.callkeep.services.services.incoming_call
 
-import android.app.Notification
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -14,9 +12,6 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.PowerManager
 import androidx.annotation.Keep
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
-import androidx.core.app.ServiceCompat
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
@@ -26,8 +21,6 @@ import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.registerReceiverCompat
 import com.webtrit.callkeep.common.sendInternalBroadcast
-import com.webtrit.callkeep.common.startForegroundServiceCompat
-import com.webtrit.callkeep.managers.NotificationChannelManager
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.models.toPCallkeepIncomingCallData
@@ -112,39 +105,6 @@ class IncomingCallService :
         super.onCreate()
         setRunning(true)
         ContextHolder.init(applicationContext)
-
-        // Satisfy Android's 5-second startForeground() requirement immediately.
-        // onStartCommand() may be delayed if the main thread is busy (e.g. platform-channel IPC
-        // during Flutter cold-start) or if IC_RELEASE arrives before IC_INITIALIZE. Calling
-        // startForeground() here — in onCreate() — prevents ForegroundServiceDidNotStartInTimeException
-        // regardless of which action onStartCommand() processes first.
-        //
-        // IMPORTANT: use PLACEHOLDER_NOTIFICATION_ID here, NOT a call-derived notification ID.
-        // The real incoming-call notification is posted by IncomingCallHandler with an ID derived
-        // from the call ID (IncomingCallNotificationBuilder.notificationId(callId)). If the
-        // placeholder used the same ID, the system would treat the real notification as an UPDATE
-        // to the placeholder and suppress the fullScreenIntent — FSI fires only for newly-posted
-        // notification IDs, not for updates to existing ones. A distinct placeholder ID ensures
-        // that the real notification is always new from the system's perspective.
-        // Android removes the placeholder automatically when the FGS transitions to the new ID.
-        val placeholder =
-            Notification
-                .Builder(this, NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_notification)
-                // No CATEGORY_CALL: Samsung/MIUI force all CATEGORY_CALL notifications to
-                // show as heads-up even without title or text, producing a blank notification.
-                // The placeholder is a technical FGS keepalive only — the real ringing
-                // notification posted in handleLaunch() still uses CATEGORY_CALL.
-                .setContentTitle(getString(R.string.incoming_call_title))
-                .setContentText(getString(R.string.incoming_call_connecting))
-                .setOngoing(true)
-                .build()
-        startForegroundServiceCompat(
-            this,
-            PLACEHOLDER_NOTIFICATION_ID,
-            placeholder,
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
-        )
 
         Log.d(TAG, "IncomingCallService created")
 
@@ -239,11 +199,6 @@ class IncomingCallService :
         if (::incomingCallHandler.isInitialized) {
             incomingCallHandler.cancelCurrentNotification()
         }
-        // Explicitly cancel the placeholder notification (ID=3) posted in onCreate().
-        // If the FGS transitioned to a call-derived ID before this point, the placeholder
-        // may not be auto-cancelled by Android on all OEM builds, leaving a blank
-        // "Webtrit • now" notification that the user cannot dismiss (setOngoing=true).
-        NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
         isolateHandler.cleanup()
         super.onDestroy()
     }
@@ -304,14 +259,6 @@ class IncomingCallService :
         if (!isFullScreenIntentAvailable()) {
             acquireScreenWakeLockIfNeeded()
         }
-        // Remove the placeholder before posting the real notification.
-        // NotificationManager.cancel() cannot remove an FGS-bound notification — it is
-        // silently ignored when Android still considers the notification foreground-attached.
-        // STOP_FOREGROUND_REMOVE removes the binding and the notification atomically,
-        // guaranteeing the placeholder is gone before startForeground() in handle() posts
-        // the real ringing notification. Both calls are synchronous on the main thread so
-        // the service is never truly backgrounded between them.
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand
@@ -429,14 +376,6 @@ class IncomingCallService :
         private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
-
-        // Stable notification ID for the FGS placeholder posted in onCreate(). Must not
-        // collide with IDs produced by IncomingCallNotificationBuilder.notificationId(callId)
-        // (which are String.hashCode() values). Using a fixed sentinel keeps it simple; the
-        // placeholder lives only until IncomingCallHandler replaces it with the real call
-        // notification, so a hash collision (probability ~1 in 4 billion) would cause no
-        // visible problem — the placeholder is removed either way.
-        private const val PLACEHOLDER_NOTIFICATION_ID = 3
 
         @Volatile
         var isRunning = false

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -14,6 +14,7 @@ import android.os.PowerManager
 import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
@@ -109,7 +110,12 @@ class IncomingCallService :
             Notification
                 .Builder(this, NotificationChannelManager.INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification)
-                .setCategory(NotificationCompat.CATEGORY_CALL)
+                // No CATEGORY_CALL: Samsung/MIUI force all CATEGORY_CALL notifications to
+                // show as heads-up even without title or text, producing a blank notification.
+                // The placeholder is a technical FGS keepalive only — the real ringing
+                // notification posted in handleLaunch() still uses CATEGORY_CALL.
+                .setContentTitle(getString(R.string.incoming_call_title))
+                .setContentText(getString(R.string.incoming_call_connecting))
                 .setOngoing(true)
                 .build()
         startForegroundServiceCompat(
@@ -164,8 +170,18 @@ class IncomingCallService :
             return START_NOT_STICKY
         }
 
-        if (!isInitialized && action == IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name) {
-            Log.w(TAG, "onStartCommand: IC_RELEASE_WITH_DECLINE received before IC_INITIALIZE — service was restarted after stop, ignoring")
+        if (!isInitialized && (
+                action == IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name ||
+                    action == IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name
+            )
+        ) {
+            Log.w(TAG, "onStartCommand: $action received before IC_INITIALIZE — service was restarted after stop, ignoring")
+            // Remove the placeholder notification immediately — do not wait for onDestroy().
+            // Without this, the blank placeholder posted in onCreate() remains visible in the
+            // notification shade until the Looper processes onDestroy(), which on Samsung Android 11
+            // can take 1–2 seconds and shows as a blank "Webtrit" notification to the user.
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
             stopSelf()
             return START_NOT_STICKY
         }
@@ -201,8 +217,14 @@ class IncomingCallService :
         CallkeepCore.instance.removeConnectionEventListener(this)
 
         stopForeground(STOP_FOREGROUND_REMOVE)
+        // Explicitly cancel the call-derived notification (ID ≥ 1000).
+        // stopForeground(REMOVE) does not reliably remove the FGS notification on some
+        // Samsung builds (Android 11), leaving buildSilent() or the ringing notification
+        // lingering in the shade. cancelCurrentNotification() handles this explicitly.
+        if (::incomingCallHandler.isInitialized) {
+            incomingCallHandler.cancelCurrentNotification()
+        }
         // Explicitly cancel the placeholder notification (ID=3) posted in onCreate().
-        // stopForeground(REMOVE) only removes the *current* foreground notification.
         // If the FGS transitioned to a call-derived ID before this point, the placeholder
         // may not be auto-cancelled by Android on all OEM builds, leaving a blank
         // "Webtrit • now" notification that the user cannot dismiss (setOngoing=true).
@@ -267,6 +289,18 @@ class IncomingCallService :
         if (!isFullScreenIntentAvailable()) {
             acquireScreenWakeLockIfNeeded()
         }
+        // Remove the placeholder before posting the real notification.
+        // Samsung (and other OEMs) force-show all CATEGORY_CALL notifications as heads-up,
+        // ignoring setPriority/setSilent. Without this, the placeholder (no buttons) appears
+        // as a brief heads-up before the real notification (with buttons) replaces it —
+        // the user perceives two sequential call notifications.
+        //
+        // DETACH first: converts the placeholder from an FGS-bound notification (which
+        // NotificationManager.cancel() cannot remove) into a regular cancellable one.
+        // All three calls are synchronous on the main thread so the service is never
+        // truly backgrounded — startForeground() in handle() re-binds FGS immediately.
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
+        NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
         incomingCallHandler.handle(metadata)
         // START_NOT_STICKY: if the OS kills this service after the incoming call is set up,
         // do not restart it. A restart would deliver a null intent — the current onStartCommand

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -2,8 +2,10 @@ package com.webtrit.callkeep.services.services.incoming_call
 
 import android.app.Notification
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
@@ -22,6 +24,8 @@ import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.StorageDelegate
+import com.webtrit.callkeep.common.registerReceiverCompat
+import com.webtrit.callkeep.common.sendInternalBroadcast
 import com.webtrit.callkeep.common.startForegroundServiceCompat
 import com.webtrit.callkeep.managers.NotificationChannelManager
 import com.webtrit.callkeep.models.CallMetadata
@@ -47,10 +51,27 @@ class IncomingCallService :
     // denied). Released in onDestroy() or when the call is answered/declined.
     private var screenWakeLock: PowerManager.WakeLock? = null
 
-    // Set to true only after IC_INITIALIZE is handled. Guards against spurious IC_RELEASE_WITH_DECLINE
-    // intents that restart the service after it has already been stopped (e.g. when releaseCall()
-    // calls stopSelf() and Telecom later triggers PhoneConnection.onDisconnect → startService).
+    // Set to true only after IC_INITIALIZE is handled. Guards against a duplicate IC_INITIALIZE
+    // arriving while the service is still processing a call (e.g. a second push while the first
+    // call is still in the teardown window).
     private var isInitialized = false
+
+    // Receives IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE from release().
+    // Registered in onCreate() and unregistered in onDestroy() so it only lives while the
+    // service is alive. If the service is not running the broadcast goes nowhere — no zombie
+    // restart, no placeholder notification appearing after the call ends.
+    private val releaseReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context?,
+                intent: Intent?,
+            ) {
+                when (intent?.action) {
+                    IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name -> handleRelease(answered = false)
+                    IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name -> handleRelease(answered = true)
+                }
+            }
+        }
 
     private val timeoutHandler = Handler(Looper.getMainLooper())
     private val stopTimeoutRunnable =
@@ -127,6 +148,15 @@ class IncomingCallService :
 
         Log.d(TAG, "IncomingCallService created")
 
+        registerReceiverCompat(
+            releaseReceiver,
+            IntentFilter().apply {
+                addAction(IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name)
+                addAction(IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name)
+            },
+            exported = false,
+        )
+
         CallkeepCore.instance.addConnectionEventListener(this)
 
         isolateHandler =
@@ -170,29 +200,13 @@ class IncomingCallService :
             return START_NOT_STICKY
         }
 
-        if (!isInitialized && (
-                action == IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name ||
-                    action == IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name
-            )
-        ) {
-            Log.w(TAG, "onStartCommand: $action received before IC_INITIALIZE — service was restarted after stop, ignoring")
-            // Remove the placeholder notification immediately — do not wait for onDestroy().
-            // Without this, the blank placeholder posted in onCreate() remains visible in the
-            // notification shade until the Looper processes onDestroy(), which on Samsung Android 11
-            // can take 1–2 seconds and shows as a blank "Webtrit" notification to the user.
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            NotificationManagerCompat.from(this).cancel(PLACEHOLDER_NOTIFICATION_ID)
-            stopSelf()
-            return START_NOT_STICKY
-        }
-
         return when (action) {
-            // Listen foreground service actions
             PushNotificationServiceEnums.IC_INITIALIZE.name -> handleLaunch(metadata!!)
 
-            IncomingCallRelease.IC_RELEASE_WITH_DECLINE.name -> handleRelease(answered = false)
-
-            IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name -> handleRelease(answered = true)
+            // IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE are now delivered via
+            // releaseReceiver (BroadcastReceiver registered in onCreate). They no longer
+            // arrive through onStartCommand — release() uses sendInternalBroadcast() instead
+            // of startService(), so the service is never restarted after it has stopped.
 
             // Listen push notification actions (Only notify connection service)
             NotificationAction.Answer.action -> reportAnswerToConnectionService(metadata!!)
@@ -214,6 +228,7 @@ class IncomingCallService :
 
         setRunning(false)
         releaseScreenWakeLock()
+        unregisterReceiver(releaseReceiver)
         CallkeepCore.instance.removeConnectionEventListener(this)
 
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -458,34 +473,17 @@ class IncomingCallService :
             context: Context,
             type: IncomingCallRelease,
         ) {
-            // Do NOT guard on isRunning here. isRunning is a static field set only in the
-            // main-process JVM. After the :callkeep_core process split, PhoneConnection
-            // (which runs in :callkeep_core) calls this method; in that JVM isRunning is
-            // always false, so the guard would silently drop every cancel request and leave
-            // the incoming-call notification frozen after answer/decline.
+            // Deliver via broadcast instead of startService().
+            // releaseReceiver is registered in onCreate() and unregistered in onDestroy(),
+            // so it is alive only while the service is running. If the service has already
+            // stopped the broadcast goes nowhere — no zombie restart, no placeholder
+            // notification appearing after the call ends.
             //
-            // startService() is intentional here, NOT startForegroundService().
-            //
-            // IC_RELEASE is only meaningful when IncomingCallService is already running
-            // as a foreground service (started by IC_INITIALIZE). While that service is
-            // alive the process is not treated as background by Android, so plain
-            // startService() is allowed and delivers the action to onStartCommand().
-            //
-            // If IncomingCallService is NOT running we must not start it via
-            // startForegroundService(): the release code path never calls startForeground(),
-            // so Android would kill the app after the 5-second deadline with
-            // ForegroundServiceDidNotStartInTimeException.
-            // startService() instead fails with a caught IllegalStateException (background-
-            // start restriction) which is the correct no-op: the notification is already
-            // gone because the service was never running.
-            runCatching {
-                context.startService(
-                    Intent(context, IncomingCallService::class.java).apply { this.action = type.name },
-                )
-                Log.d(TAG, "Release action $type initiated.")
-            }.onFailure { e ->
-                Log.w(TAG, "Release action $type: startService failed: $e")
-            }
+            // sendInternalBroadcast() uses setPackage(packageName) + FLAG_RECEIVER_FOREGROUND,
+            // so it crosses the :callkeep_core → main-process boundary safely and is
+            // delivered only to this app.
+            context.sendInternalBroadcast(type.name)
+            Log.d(TAG, "Release action $type initiated via broadcast.")
         }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -74,6 +74,18 @@ class IncomingCallHandler(
     }
 
     /**
+     * Explicitly cancels the call-derived notification (ID ≥ 1000) if a call was handled.
+     * Called from IncomingCallService.onDestroy() as a belt-and-suspenders cleanup:
+     * stopForeground(REMOVE) does not reliably cancel the FGS notification on some Samsung
+     * builds, so we cancel it directly to prevent a lingering notification in the shade.
+     */
+    @SuppressLint("MissingPermission")
+    fun cancelCurrentNotification() {
+        if (lastMetadata == null) return
+        notifier.cancel(currentNotificationId)
+    }
+
+    /**
      * Transitions the foreground Service to a silent call notification
      * (keeps the service in foreground, but cancels the loud ringing one).
      */

--- a/webtrit_callkeep_android/android/src/main/res/values/strings.xml
+++ b/webtrit_callkeep_android/android/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="push_notification_foreground_call_service_description">This service keeps the call active in the background</string>
     <string name="incoming_call_declined_title">Call Declined</string>
     <string name="incoming_call_declined_text">Declined an incoming call from %1$s</string>
+    <string name="incoming_call_connecting">Connecting…</string>
 </resources>


### PR DESCRIPTION
## Summary

Fixes blank/partial notifications appearing on Samsung and other OEM devices after an incoming call ends (WT-1312).

The root cause is Samsung's forced heads-up display for all `CATEGORY_CALL` notifications — including technical FGS placeholder and transitional silent notifications that have no content.

- **Remove `CATEGORY_CALL` from FGS placeholder** (`onCreate`): Samsung forced a blank heads-up from the placeholder on zombie service restarts (delayed `IC_RELEASE` from `:callkeep_core` Telecom callback)
- **Add title/text to placeholder** ("Incoming call / Connecting...") so it is readable if briefly visible in the notification shade
- **Remove `CATEGORY_CALL` from `buildSilent()`**: same Samsung behavior caused a brief blank heads-up during the 2-second teardown window after a call is answered
- **Add `IncomingCallHandler.cancelCurrentNotification()`**: explicit cancel of the call-derived notification ID (>=1000) in `onDestroy()` for Samsung builds where `stopForeground(REMOVE)` does not reliably remove the FGS notification
- **Extend `isInitialized` guard to cover `IC_RELEASE_WITH_ANSWER`**: zombie service restarts triggered by both answer and decline paths are now caught
- **DETACH placeholder before posting real notification** in `handleLaunch()`: FGS-bound notifications cannot be cancelled by `NotificationManager.cancel()`; DETACH converts the placeholder to a regular cancellable notification first, preventing a double heads-up on Samsung

## Test plan

- [ ] Incoming call -> caller hangs up -> notification shade is clean
- [ ] Incoming call -> answer -> hang up -> no blank heads-up after answer
- [ ] Incoming call -> decline -> no blank heads-up, shade cleans up
- [ ] Samsung Android 11 (SM-A505FN): repeat all above
- [ ] `adb shell dumpsys notification | grep -A5 "Webtrit"` after each scenario — no stale notifications

## YouTrack

https://youtrack.portaone.com/issue/WT-1312

## Note

A follow-up PR will replace `startService()` in `release()` with a `BroadcastReceiver` to fully eliminate the zombie service restart at the source.