### PR TITLE
ci: add automated code review workflow triggered by mention

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,30 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.WEBTRIT_ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-review.yml` for AI-assisted code review
- Workflow triggers on `issue_comment`, `pull_request_review_comment`, and `pull_request_review` events
- Job runs only when the comment/review body contains `@claude`
- Uses `WEBTRIT_ANTHROPIC_API_KEY` secret for authentication

## Workflow conditions

```
(github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
(github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
```

## Test plan

- [ ] Open a PR, leave a comment containing `@claude` — workflow should trigger
- [ ] Leave a review with `@claude` in the body — workflow should trigger
- [ ] Leave a comment without `@claude` — workflow should NOT trigger
- [ ] Verify `WEBTRIT_ANTHROPIC_API_KEY` secret is set in repository settings