### PR TITLE
fix(android): move screen wakelock to main process — fix video call screen-off (WT-1366)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -41,6 +41,14 @@ interface ConnectionTracker {
         onHold: Boolean,
     )
 
+    /**
+     * Merge [metadata] into the stored record for [metadata.callId].
+     * No-op if the call is not yet promoted to connections (still pending).
+     * Used to propagate mid-call updates (e.g. hasVideo toggle) to the shadow
+     * without going through a full promote() cycle.
+     */
+    fun updateMetadata(metadata: CallMetadata)
+
     /** Mark [callId] as terminated, removing it from the active connections map. */
     fun markTerminated(callId: String)
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -47,7 +47,7 @@ interface ConnectionTracker {
      * Used to propagate mid-call updates (e.g. hasVideo toggle) to the shadow
      * without going through a full promote() cycle.
      */
-    fun updateMetadata(metadata: CallMetadata)
+    fun updateMetadata(metadata: CallMetadata) {}
 
     /** Mark [callId] as terminated, removing it from the active connections map. */
     fun markTerminated(callId: String)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -255,7 +255,10 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
 
     override fun startEstablishCall(metadata: CallMetadata) = router.startEstablishCall(metadata)
 
-    override fun startUpdateCall(metadata: CallMetadata) = router.startUpdateCall(metadata)
+    override fun startUpdateCall(metadata: CallMetadata) {
+        tracker.updateMetadata(metadata)
+        router.startUpdateCall(metadata)
+    }
 
     override fun startSendDtmfCall(metadata: CallMetadata) = router.startSendDtmfCall(metadata)
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -155,6 +155,12 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
             }
     }
 
+    override fun updateMetadata(metadata: CallMetadata) {
+        connections.computeIfPresent(metadata.callId) { _, existing ->
+            existing.mergeWith(metadata)
+        }
+    }
+
     /**
      * Mark [callId] as terminated. Removes it from all active tracking sets so that
      * [isTerminated] returns true (derived: absent from all sets = terminated).

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -13,7 +13,6 @@ import android.telecom.PhoneAccount
 import android.telecom.PhoneAccountHandle
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PIncomingCallError
-import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
@@ -58,7 +57,6 @@ class PhoneConnectionService : ConnectionService() {
         // Set the service state to true when the system starts the service.
         isRunning = true
 
-        val activityWakelockManager = ActivityWakelockManager(ActivityHolder)
         val proximitySensorManager =
             ProximitySensorManager(applicationContext, PhoneConnectionConsts())
 
@@ -66,7 +64,6 @@ class PhoneConnectionService : ConnectionService() {
             PhoneConnectionServiceDispatcher(
                 connectionManager,
                 ::performEventHandle,
-                activityWakelockManager,
                 proximitySensorManager,
             )
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
@@ -3,7 +3,6 @@ package com.webtrit.callkeep.services.services.connection.dispatchers
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
-import com.webtrit.callkeep.services.services.connection.ActivityWakelockManager
 import com.webtrit.callkeep.services.services.connection.ConnectionManager
 import com.webtrit.callkeep.services.services.connection.PhoneConnection
 import com.webtrit.callkeep.services.services.connection.ProximitySensorManager
@@ -19,7 +18,7 @@ enum class ConnectionLifecycleAction {
 /**
  * Dispatcher responsible for routing ServiceAction requests to PhoneConnection instances
  * managed by the [ConnectionManager], and for coordinating ancillary managers such as
- * [ProximitySensorManager] and [ActivityWakelockManager].
+ * [ProximitySensorManager].
  *
  * If the targeted connection cannot be found, the provided [PerformDispatchHandle]
  * (`dispatcher`) is invoked to propagate the event to the higher layer (for example, Flutter)
@@ -27,13 +26,11 @@ enum class ConnectionLifecycleAction {
  *
  * @property connectionManager Manages active phone connections.
  * @property dispatcher Callback invoked when a connection is not found.
- * @property activityWakelockManager Controls screen wake locks (used for video calls).
  * @property proximitySensorManager Controls proximity sensor behavior.
  */
 class PhoneConnectionServiceDispatcher(
     private val connectionManager: ConnectionManager,
     private val dispatcher: PerformDispatchHandle,
-    private val activityWakelockManager: ActivityWakelockManager,
     private val proximitySensorManager: ProximitySensorManager,
 ) {
     /**
@@ -217,22 +214,10 @@ class PhoneConnectionServiceDispatcher(
         logger.i("Service destroyed. Disposing resources.")
 
         runCatching {
-            activityWakelockManager.releaseScreenWakeLock()
-        }.onFailure { e ->
-            logger.e("Failed to release screen wake lock", e)
-        }
-
-        runCatching {
             proximitySensorManager.setShouldListenProximity(false)
             proximitySensorManager.stopListening()
         }.onFailure { e ->
             logger.e("Failed to stop proximity sensor", e)
-        }
-
-        runCatching {
-            activityWakelockManager.dispose()
-        }.onFailure { e ->
-            logger.e("Failed to dispose wakelock manager", e)
         }
 
         runCatching {
@@ -251,12 +236,12 @@ class PhoneConnectionServiceDispatcher(
     }
 
     /**
-     * Centralized logic to manage Proximity Sensor and Screen WakeLock based on
+     * Centralized logic to manage Proximity Sensor based on
      * the global state of all connections.
      *
      * Rule:
-     * 1. If ANY video connection exists -> Screen ON (WakeLock), Proximity OFF.
-     * 2. If NO video but ANY audio connection -> Screen managed by Proximity (WakeLock OFF).
+     * 1. If ANY video connection exists -> Proximity OFF.
+     * 2. If NO video but ANY audio connection -> Screen managed by Proximity.
      * 3. If NO connections -> All sensors OFF.
      */
     private fun updateSensorsState() {
@@ -277,12 +262,9 @@ class PhoneConnectionServiceDispatcher(
             "Updating sensors state. HasVideo: $hasVideo, HasAnyConnection: $hasAnyConnection, ShouldEnableProximity: $shouldEnableProximity",
         )
         if (hasVideo) {
-            activityWakelockManager.acquireScreenWakeLock()
             proximitySensorManager.setShouldListenProximity(false)
             proximitySensorManager.stopListening()
         } else {
-            activityWakelockManager.releaseScreenWakeLock()
-
             if (shouldEnableProximity) {
                 proximitySensorManager.setShouldListenProximity(true)
                 proximitySensorManager.startListening()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ActivityWakelockManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ActivityWakelockManager.kt
@@ -1,4 +1,4 @@
-package com.webtrit.callkeep.services.services.connection
+package com.webtrit.callkeep.services.services.foreground
 
 import android.app.Activity
 import android.view.WindowManager
@@ -10,12 +10,19 @@ class ActivityWakelockManager(
 ) {
     private val operationQueue = mutableListOf<(Activity) -> Unit>()
 
+    @Volatile private var isScreenOnDesired = false
+
     // Reference to the listener for unsubscribing later
     private val activityChangeListener: (Activity?) -> Unit = { activity ->
         val activityName = activity?.componentName?.shortClassName ?: "null"
         logger.d("Activity lifecycle change detected. Current Activity: $activityName")
 
-        activity?.let { executePendingOperations(it) }
+        activity?.let {
+            if (isScreenOnDesired) {
+                it.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+            executePendingOperations(it)
+        }
     }
 
     init {
@@ -27,6 +34,7 @@ class ActivityWakelockManager(
      * Keeps the screen on by applying the FLAG_KEEP_SCREEN_ON to the current activity.
      */
     fun acquireScreenWakeLock() {
+        isScreenOnDesired = true
         executeOrQueue("Acquire FLAG_KEEP_SCREEN_ON") { activity ->
             logger.v("Applying window flag FLAG_KEEP_SCREEN_ON to ${activity.componentName.shortClassName}")
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -37,6 +45,7 @@ class ActivityWakelockManager(
      * Releases the wake lock by clearing the FLAG_KEEP_SCREEN_ON from the current activity.
      */
     fun releaseScreenWakeLock() {
+        isScreenOnDesired = false
         executeOrQueue("Release FLAG_KEEP_SCREEN_ON") { activity ->
             logger.v("Clearing window flag FLAG_KEEP_SCREEN_ON from ${activity.componentName.shortClassName}")
             activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -99,6 +108,8 @@ class ActivityWakelockManager(
      */
     fun dispose() {
         logger.d("Disposing ActivityWakelockManager. Cleanup started.")
+
+        isScreenOnDesired = false
 
         activityProvider.getActivity()?.let { activity ->
             runCatching {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ActivityWakelockManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ActivityWakelockManager.kt
@@ -2,6 +2,7 @@ package com.webtrit.callkeep.services.services.foreground
 
 import android.app.Activity
 import android.view.WindowManager
+import androidx.annotation.MainThread
 import com.webtrit.callkeep.common.ActivityProvider
 import com.webtrit.callkeep.common.Log
 
@@ -10,7 +11,7 @@ class ActivityWakelockManager(
 ) {
     private val operationQueue = mutableListOf<(Activity) -> Unit>()
 
-    @Volatile private var isScreenOnDesired = false
+    private var isScreenOnDesired = false
 
     // Reference to the listener for unsubscribing later
     private val activityChangeListener: (Activity?) -> Unit = { activity ->
@@ -33,6 +34,7 @@ class ActivityWakelockManager(
     /**
      * Keeps the screen on by applying the FLAG_KEEP_SCREEN_ON to the current activity.
      */
+    @MainThread
     fun acquireScreenWakeLock() {
         isScreenOnDesired = true
         executeOrQueue("Acquire FLAG_KEEP_SCREEN_ON") { activity ->
@@ -44,6 +46,7 @@ class ActivityWakelockManager(
     /**
      * Releases the wake lock by clearing the FLAG_KEEP_SCREEN_ON from the current activity.
      */
+    @MainThread
     fun releaseScreenWakeLock() {
         isScreenOnDesired = false
         executeOrQueue("Release FLAG_KEEP_SCREEN_ON") { activity ->
@@ -106,6 +109,7 @@ class ActivityWakelockManager(
      * Disposes of the WakelockManager by unsubscribing from ActivityHolder updates.
      * Forcefully clears the keep-screen-on flag before disposing resources to prevent leaks.
      */
+    @MainThread
     fun dispose() {
         logger.d("Disposing ActivityWakelockManager. Cleanup started.")
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -74,6 +74,8 @@ class ForegroundService :
     ConnectionEventListener {
     private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
 
+    private val activityWakelockManager = ActivityWakelockManager(ActivityHolder)
+
     // Stored as fields so onDestroy() can cancel the timeout and unregister the receiver
     // if the service is destroyed before the TearDownComplete ack arrives.
     private var tearDownAckReceiver: BroadcastReceiver? = null
@@ -323,6 +325,7 @@ class ForegroundService :
                             logger.i("$logContext: ongoing call confirmed by CS")
                             // Outgoing call is now active in Telecom — promote from pending.
                             core.promote(callMetaData.callId, callMetaData, PCallkeepConnectionState.STATE_DIALING)
+                            syncScreenWakelock()
                             flutterDelegateApi?.performStartCall(
                                 callMetaData.callId,
                                 callMetaData.handle!!.toPHandle(),
@@ -705,6 +708,7 @@ class ForegroundService :
             tearDownAckReceiver = null
             // Step 6: Reset tracker state for the next session.
             core.clear()
+            syncScreenWakelock()
             // Keep PhoneConnectionService alive for the next session so that its next
             // incoming intents (e.g. AnswerCall) arrive at a live service instance.
             core.tearDownService()
@@ -780,6 +784,7 @@ class ForegroundService :
                 proximityEnabled = proximityEnabled,
             )
         core.startUpdateCall(metadata)
+        syncScreenWakelock()
         callback.invoke(Result.success(Unit))
     }
 
@@ -935,12 +940,22 @@ class ForegroundService :
     // --------------------------------
     //
 
+    private fun syncScreenWakelock() {
+        val hasVideo = core.getAll().any { it.hasVideo == true }
+        if (hasVideo) {
+            activityWakelockManager.acquireScreenWakeLock()
+        } else {
+            activityWakelockManager.releaseScreenWakeLock()
+        }
+    }
+
     private fun handleCSReportDidPushIncomingCall(extras: Bundle?) {
         logger.d("handleCSReportDidPushIncomingCall")
         extras?.let {
             val metadata = CallMetadata.fromBundle(it)
             // Promote from pending to fully registered incoming connection.
             core.promote(metadata.callId, metadata, PCallkeepConnectionState.STATE_RINGING)
+            syncScreenWakelock()
 
             // Resolve any deferred reportNewIncomingCall Pigeon callback waiting for this
             // Telecom confirmation. This is the success path: Telecom accepted the call,
@@ -1022,6 +1037,7 @@ class ForegroundService :
             // AND the endCall re-fire path fires it a second time — producing a duplicate
             // delegate callback.
             core.clearAndMarkEndCallDispatched(callId)
+            syncScreenWakelock()
 
             flutterDelegateApi?.performEndCall(callId) {}
             flutterDelegateApi?.didDeactivateAudioSession {}
@@ -1175,6 +1191,8 @@ class ForegroundService :
             }
         }
         tearDownAckReceiver = null
+
+        activityWakelockManager.dispose()
 
         // Phone account registration is tied to the user session, not the service lifecycle.
         // Unregistration happens only in finishTearDown() (explicit logout/tearDown call).

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionServiceDispatcherTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionServiceDispatcherTest.kt
@@ -32,8 +32,7 @@ import org.robolectric.annotation.Config
  * TearDown only synchronises sensor state — connection cleanup is performed synchronously
  * by ForegroundService.tearDown() before the TearDown intent is sent.
  *
- * [ActivityWakelockManager] and [ProximitySensorManager] are mocked so tests run without
- * a real Activity or proximity sensor hardware.
+ * [ProximitySensorManager] is mocked so tests run without real proximity sensor hardware.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
@@ -43,7 +42,6 @@ class PhoneConnectionServiceDispatcherTest {
     private val capturedEvents = mutableListOf<ConnectionEvent>()
     private val captureDispatcher: PerformDispatchHandle = { event, _ -> capturedEvents.add(event) }
 
-    private val wakelockManager: ActivityWakelockManager = mock()
     private val proximitySensorManager: ProximitySensorManager = mock()
 
     private lateinit var connectionManager: ConnectionManager
@@ -58,7 +56,6 @@ class PhoneConnectionServiceDispatcherTest {
             PhoneConnectionServiceDispatcher(
                 connectionManager,
                 captureDispatcher,
-                wakelockManager,
                 proximitySensorManager,
             )
     }


### PR DESCRIPTION
## Summary

- `ActivityWakelockManager` was in `:callkeep_core` (`PhoneConnectionServiceDispatcher`) where `ActivityHolder.getActivity()` always returns `null` — `FLAG_KEEP_SCREEN_ON` was never applied during video calls
- Root cause introduced by PR #200 (dual-process split)
- Moved `ActivityWakelockManager` to `foreground` package (main process, correct JVM)
- Added `isScreenOnDesired` field so Activity recreation re-applies the flag
- Added `updateMetadata()` to `ConnectionTracker` interface so mid-call video upgrades are reflected in the shadow
- `ForegroundService` now owns wakelock and syncs at 5 lifecycle points: incoming promote, outgoing promote, update call, call terminated, tearDown
- Removed dead wakelock code from `PhoneConnectionServiceDispatcher` and `PhoneConnectionService`

## YouTrack

https://youtrack.portaone.com/issue/WT-1366

## Files changed

| File | Change |
|------|--------|
| `ActivityWakelockManager.kt` | Moved to `foreground` package, added `isScreenOnDesired` |
| `ConnectionTracker.kt` | Added `updateMetadata()` |
| `MainProcessConnectionTracker.kt` | Implemented `updateMetadata()` |
| `InProcessCallkeepCore.kt` | Call `tracker.updateMetadata()` in `startUpdateCall()` |
| `ForegroundService.kt` | Add wakelock field, `syncScreenWakelock()`, 5 call sites, dispose |
| `PhoneConnectionService.kt` | Remove `ActivityWakelockManager` init |
| `PhoneConnectionServiceDispatcher.kt` | Remove wakelock param and calls |
| `PhoneConnectionServiceDispatcherTest.kt` | Remove wakelock mock |

## Test plan

- [ ] Video call from start (outgoing) — screen stays on throughout
- [ ] Video call from start (incoming) — screen stays on throughout
- [ ] Audio call -> mid-call video upgrade — screen stays on after upgrade
- [ ] Video call -> mid-call video downgrade — screen allowed to turn off
- [ ] Video call ends — screen allowed to turn off
- [ ] Audio-only call — screen NOT kept on (proximity still works)
- [ ] App goes to background during video call and returns — screen flag re-applied
- [ ] tearDown during active video call — wakelock released cleanly