### PR TITLE
fix(android): disable automatic plugin registration on background FGS engine

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.embedding.engine.FlutterJNI
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
 import io.flutter.view.FlutterCallbackInformation
 
@@ -39,8 +38,10 @@ class FlutterEngineHelper(
             }
             flutterLoader.ensureInitializationComplete(context.applicationContext, null)
 
+            // FlutterJNI is obtained via FlutterInjector so test overrides and DI
+            // replacements are respected, matching the behaviour of the 1-arg constructor.
             backgroundEngine =
-                FlutterEngine(context.applicationContext, null, FlutterJNI(), null, false).also { engine ->
+                FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, false).also { engine ->
                     val callbackInformation =
                         FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterJNI
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
 import io.flutter.view.FlutterCallbackInformation
 
@@ -39,7 +40,7 @@ class FlutterEngineHelper(
             flutterLoader.ensureInitializationComplete(context.applicationContext, null)
 
             backgroundEngine =
-                FlutterEngine(context.applicationContext).also { engine ->
+                FlutterEngine(context.applicationContext, null, FlutterJNI(), null, false).also { engine ->
                     val callbackInformation =
                         FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 


### PR DESCRIPTION
## Summary

- Pass `automaticallyRegisterPlugins = false` to `FlutterEngine` in `FlutterEngineHelper` (line 42)
- The background FGS engine only needs raw Pigeon binary messenger channels; registering all 25+ app plugins (AudioSessionPlugin, FlutterWebRTCPlugin, etc.) initializes audio/hardware resources unnecessarily on engine startup
- Uses the 5-arg constructor `FlutterEngine(context, null, FlutterJNI(), null, false)` since `FlutterJNI` is `@NonNull`

## Test plan

- [ ] Verify incoming call push isolate starts correctly on Android
- [ ] Verify outgoing call flow works end-to-end
- [ ] Confirm no plugin-initialization errors in logcat on FGS engine startup