### PR TITLE
docs(android): improve FlutterEngineHelper comment for FGS engine init

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
@@ -38,8 +38,12 @@ class FlutterEngineHelper(
             }
             flutterLoader.ensureInitializationComplete(context.applicationContext, null)
 
-            // FlutterJNI is obtained via FlutterInjector so test overrides and DI
-            // replacements are respected, matching the behaviour of the 1-arg constructor.
+            // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
+            // registering all app plugins on this background FGS engine. On Android 16
+            // REMOTE_MESSAGING services, audio/hardware init in onAttachedToEngine can
+            // block the Dart VM from running the background entry point.
+            // FlutterJNI is obtained via FlutterInjector so DI overrides are respected,
+            // matching the internal behaviour of the 1-arg FlutterEngine constructor.
             backgroundEngine =
                 FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, false).also { engine ->
                     val callbackInformation =


### PR DESCRIPTION
## Summary

Expand the `automaticallyRegisterPlugins=false` comment in `FlutterEngineHelper.kt` to explain:
- Why audio/hardware plugin init on Android 16 `REMOTE_MESSAGING` FGS services can block the Dart VM entry point
- Why `FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI()` is the correct way to obtain a `FlutterJNI` instance (mirrors the 1-arg constructor, respects DI overrides)

No functional changes — the code already uses `FlutterInjector` correctly (introduced in PR #268).

This documents the reasoning so future reviewers understand why a bare `FlutterJNI()` should NOT be used here (a mistake that caused a regression in the sibling signaling service package).

## Test plan

- [ ] No runtime behaviour change — verify existing tests pass