### PR TITLE
fix(ios): implement getConnection via NSUserDefaults for offline call cleanup (WT-1347)

### DIFF
--- a/webtrit_callkeep/lib/src/callkeep_connections.dart
+++ b/webtrit_callkeep/lib/src/callkeep_connections.dart
@@ -18,7 +18,7 @@ class CallkeepConnections {
   ///
   /// Returns a [Future] resolving to a [CallkeepConnection] if found, or null otherwise.
   Future<CallkeepConnection?> getConnection(String callId) {
-    if (!kIsWeb && defaultTargetPlatform != TargetPlatform.android) {
+    if (!kIsWeb && defaultTargetPlatform != TargetPlatform.android && defaultTargetPlatform != TargetPlatform.iOS) {
       return Future.value(null);
     }
 

--- a/webtrit_callkeep_ios/ios/Classes/Generated.h
+++ b/webtrit_callkeep_ios/ios/Classes/Generated.h
@@ -81,6 +81,19 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
 - (instancetype)initWithValue:(WTPCallRequestErrorEnum)value;
 @end
 
+typedef NS_ENUM(NSUInteger, WTPCallkeepConnectionState) {
+  WTPCallkeepConnectionStateStateNew = 0,
+  WTPCallkeepConnectionStateStateActive = 1,
+  WTPCallkeepConnectionStateStateHolding = 2,
+  WTPCallkeepConnectionStateStateDisconnected = 3,
+};
+
+/// Wrapper for WTPCallkeepConnectionState to allow for nullability.
+@interface WTPCallkeepConnectionStateBox : NSObject
+@property(nonatomic, assign) WTPCallkeepConnectionState value;
+- (instancetype)initWithValue:(WTPCallkeepConnectionState)value;
+@end
+
 @class WTPIOSOptions;
 @class WTPAndroidOptions;
 @class WTPOptions;
@@ -88,6 +101,7 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
 @class WTPEndCallReason;
 @class WTPIncomingCallError;
 @class WTPCallRequestError;
+@class WTPCallkeepConnection;
 
 @interface WTPIOSOptions : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
@@ -164,6 +178,15 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
 @property(nonatomic, assign) WTPCallRequestErrorEnum value;
 @end
 
+@interface WTPCallkeepConnection : NSObject
+/// `init` unavailable to enforce nonnull fields, see the `make` class method.
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)makeWithCallId:(NSString *)callId
+    state:(WTPCallkeepConnectionState)state;
+@property(nonatomic, copy) NSString * callId;
+@property(nonatomic, assign) WTPCallkeepConnectionState state;
+@end
+
 /// The codec used by all APIs.
 NSObject<FlutterMessageCodec> *WTGetGeneratedCodec(void);
 
@@ -194,6 +217,7 @@ extern void SetUpWTPHostAndroidServiceApiWithSuffix(id<FlutterBinaryMessenger> b
 - (void)setMuted:(NSString *)uuidString muted:(BOOL)muted completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;
 - (void)setSpeaker:(NSString *)uuidString enabled:(BOOL)enabled completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;
 - (void)sendDTMF:(NSString *)uuidString key:(NSString *)key completion:(void (^)(WTPCallRequestError *_Nullable, FlutterError *_Nullable))completion;
+- (void)getConnectionWithUuidString:(NSString *)uuidString completion:(void (^)(WTPCallkeepConnection *_Nullable, FlutterError *_Nullable))completion;
 @end
 
 extern void SetUpWTPHostApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<WTPHostApi> *_Nullable api);

--- a/webtrit_callkeep_ios/ios/Classes/Generated.m
+++ b/webtrit_callkeep_ios/ios/Classes/Generated.m
@@ -81,6 +81,16 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
+@implementation WTPCallkeepConnectionStateBox
+- (instancetype)initWithValue:(WTPCallkeepConnectionState)value {
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+@end
+
 @interface WTPIOSOptions ()
 + (WTPIOSOptions *)fromList:(NSArray<id> *)list;
 + (nullable WTPIOSOptions *)nullableFromList:(NSArray<id> *)list;
@@ -120,6 +130,12 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 @interface WTPCallRequestError ()
 + (WTPCallRequestError *)fromList:(NSArray<id> *)list;
 + (nullable WTPCallRequestError *)nullableFromList:(NSArray<id> *)list;
+- (NSArray<id> *)toList;
+@end
+
+@interface WTPCallkeepConnection ()
++ (WTPCallkeepConnection *)fromList:(NSArray<id> *)list;
++ (nullable WTPCallkeepConnection *)nullableFromList:(NSArray<id> *)list;
 - (NSArray<id> *)toList;
 @end
 
@@ -330,6 +346,32 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 }
 @end
 
+@implementation WTPCallkeepConnection
++ (instancetype)makeWithCallId:(NSString *)callId
+    state:(WTPCallkeepConnectionState)state {
+  WTPCallkeepConnection* pigeonResult = [[WTPCallkeepConnection alloc] init];
+  pigeonResult.callId = callId;
+  pigeonResult.state = state;
+  return pigeonResult;
+}
++ (WTPCallkeepConnection *)fromList:(NSArray<id> *)list {
+  WTPCallkeepConnection *pigeonResult = [[WTPCallkeepConnection alloc] init];
+  pigeonResult.callId = GetNullableObjectAtIndex(list, 0);
+  WTPCallkeepConnectionStateBox *boxedWTPCallkeepConnectionState = GetNullableObjectAtIndex(list, 1);
+  pigeonResult.state = boxedWTPCallkeepConnectionState.value;
+  return pigeonResult;
+}
++ (nullable WTPCallkeepConnection *)nullableFromList:(NSArray<id> *)list {
+  return (list) ? [WTPCallkeepConnection fromList:list] : nil;
+}
+- (NSArray<id> *)toList {
+  return @[
+    self.callId ?: [NSNull null],
+    [[WTPCallkeepConnectionStateBox alloc] initWithValue:self.state],
+  ];
+}
+@end
+
 @interface WTGeneratedPigeonCodecReader : FlutterStandardReader
 @end
 @implementation WTGeneratedPigeonCodecReader
@@ -355,20 +397,26 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
       NSNumber *enumAsNumber = [self readValue];
       return enumAsNumber == nil ? nil : [[WTPCallRequestErrorEnumBox alloc] initWithValue:[enumAsNumber integerValue]];
     }
-    case 134: 
-      return [WTPIOSOptions fromList:[self readValue]];
+    case 134: {
+      NSNumber *enumAsNumber = [self readValue];
+      return enumAsNumber == nil ? nil : [[WTPCallkeepConnectionStateBox alloc] initWithValue:[enumAsNumber integerValue]];
+    }
     case 135: 
-      return [WTPAndroidOptions fromList:[self readValue]];
+      return [WTPIOSOptions fromList:[self readValue]];
     case 136: 
-      return [WTPOptions fromList:[self readValue]];
+      return [WTPAndroidOptions fromList:[self readValue]];
     case 137: 
-      return [WTPHandle fromList:[self readValue]];
+      return [WTPOptions fromList:[self readValue]];
     case 138: 
-      return [WTPEndCallReason fromList:[self readValue]];
+      return [WTPHandle fromList:[self readValue]];
     case 139: 
-      return [WTPIncomingCallError fromList:[self readValue]];
+      return [WTPEndCallReason fromList:[self readValue]];
     case 140: 
+      return [WTPIncomingCallError fromList:[self readValue]];
+    case 141: 
       return [WTPCallRequestError fromList:[self readValue]];
+    case 142: 
+      return [WTPCallkeepConnection fromList:[self readValue]];
     default:
       return [super readValueOfType:type];
   }
@@ -399,26 +447,33 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     WTPCallRequestErrorEnumBox *box = (WTPCallRequestErrorEnumBox *)value;
     [self writeByte:133];
     [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
-  } else if ([value isKindOfClass:[WTPIOSOptions class]]) {
+  } else if ([value isKindOfClass:[WTPCallkeepConnectionStateBox class]]) {
+    WTPCallkeepConnectionStateBox *box = (WTPCallkeepConnectionStateBox *)value;
     [self writeByte:134];
-    [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPAndroidOptions class]]) {
+    [self writeValue:(value == nil ? [NSNull null] : [NSNumber numberWithInteger:box.value])];
+  } else if ([value isKindOfClass:[WTPIOSOptions class]]) {
     [self writeByte:135];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPOptions class]]) {
+  } else if ([value isKindOfClass:[WTPAndroidOptions class]]) {
     [self writeByte:136];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPHandle class]]) {
+  } else if ([value isKindOfClass:[WTPOptions class]]) {
     [self writeByte:137];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPEndCallReason class]]) {
+  } else if ([value isKindOfClass:[WTPHandle class]]) {
     [self writeByte:138];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPIncomingCallError class]]) {
+  } else if ([value isKindOfClass:[WTPEndCallReason class]]) {
     [self writeByte:139];
     [self writeValue:[value toList]];
-  } else if ([value isKindOfClass:[WTPCallRequestError class]]) {
+  } else if ([value isKindOfClass:[WTPIncomingCallError class]]) {
     [self writeByte:140];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[WTPCallRequestError class]]) {
+    [self writeByte:141];
+    [self writeValue:[value toList]];
+  } else if ([value isKindOfClass:[WTPCallkeepConnection class]]) {
+    [self writeByte:142];
     [self writeValue:[value toList]];
   } else {
     [super writeValue:value];
@@ -793,6 +848,25 @@ void SetUpWTPHostApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, NSObj
         NSString *arg_uuidString = GetNullableObjectAtIndex(args, 0);
         NSString *arg_key = GetNullableObjectAtIndex(args, 1);
         [api sendDTMF:arg_uuidString key:arg_key completion:^(WTPCallRequestError *_Nullable output, FlutterError *_Nullable error) {
+          callback(wrapResult(output, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.webtrit_callkeep_ios.PHostApi.getConnection", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:WTGetGeneratedCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(getConnectionWithUuidString:completion:)], @"WTPHostApi api (%@) doesn't respond to @selector(getConnectionWithUuidString:completion:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray<id> *args = message;
+        NSString *arg_uuidString = GetNullableObjectAtIndex(args, 0);
+        [api getConnectionWithUuidString:arg_uuidString completion:^(WTPCallkeepConnection *_Nullable output, FlutterError *_Nullable error) {
           callback(wrapResult(output, error));
         }];
       }];

--- a/webtrit_callkeep_ios/ios/Classes/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/Classes/WebtritCallkeepPlugin.m
@@ -472,8 +472,17 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     return;
   }
 
+  // callId carries the UUID string here — the Dart layer substitutes the real callId
+  // before exposing the CallkeepConnection to callers (see webtrit_callkeep_ios.dart getConnection).
   completion([WTPCallkeepConnection makeWithCallId:uuidString state:state], nil);
 }
+
+// NOTE: missed/auto-unanswered calls are covered by both write paths:
+// 1. App-initiated: reportEndCall (Dart) → _markUUIDEnded (this file)
+// 2. System-initiated (user swipes/CallKit timeout) → provider:performEndCallAction: → _markUUIDEnded
+// A gap exists only if CallKit ends the call before _markUUIDActive was written (e.g. rejected
+// at the CallKit level during reportNewIncomingCall). In that case getConnection returns nil,
+// and HandshakeProcessor falls through to the orphan-outgoing branch for cleanup.
 
 #pragma mark - WTPHostApi - helpers
 
@@ -690,6 +699,9 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                     }
                                   }
 
+                                  if (incomingCallError == nil) {
+                                    [self _markUUIDActive:[uuid UUIDString]];
+                                  }
                                   [self->_delegateFlutterApi didPushIncomingCallHandle:[callUpdate.remoteHandle toPigeon]
                                                                            displayName:callUpdate.localizedCallerName
                                                                                  video:callUpdate.hasVideo

--- a/webtrit_callkeep_ios/ios/Classes/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/Classes/WebtritCallkeepPlugin.m
@@ -11,6 +11,8 @@
 #import "NSUUID+v5.h"
 
 static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
+static NSString *const kActiveCallUUIDsKey = @"WebtritCallkeepActiveCallUUIDs";
+static NSString *const kEndedCallUUIDsKey  = @"WebtritCallkeepEndedCallUUIDs";
 
 @interface WebtritCallkeepPlugin ()<PKPushRegistryDelegate, CXProviderDelegate, WTPPushRegistryHostApi, WTPHostApi, WTPHostSoundApi>
 @end
@@ -178,6 +180,40 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   completion(nil);
 }
 
+// MARK: - Call state persistence (WT-1347)
+
+- (void)_markUUIDActive:(NSString *)uuidString {
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSMutableArray *active = [([ud arrayForKey:kActiveCallUUIDsKey] ?: @[]) mutableCopy];
+  if (![active containsObject:uuidString]) [active addObject:uuidString];
+  [ud setObject:active forKey:kActiveCallUUIDsKey];
+  NSMutableDictionary *ended = [([ud dictionaryForKey:kEndedCallUUIDsKey] ?: @{}) mutableCopy];
+  [ended removeObjectForKey:uuidString];
+  [ud setObject:ended forKey:kEndedCallUUIDsKey];
+}
+
+- (void)_markUUIDEnded:(NSString *)uuidString {
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSMutableArray *active = [([ud arrayForKey:kActiveCallUUIDsKey] ?: @[]) mutableCopy];
+  [active removeObject:uuidString];
+  [ud setObject:active forKey:kActiveCallUUIDsKey];
+  NSMutableDictionary *ended = [([ud dictionaryForKey:kEndedCallUUIDsKey] ?: @{}) mutableCopy];
+  ended[uuidString] = @([[NSDate date] timeIntervalSince1970]);
+  [ud setObject:ended forKey:kEndedCallUUIDsKey];
+}
+
+- (void)_pruneEndedUUIDs {
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSMutableDictionary *ended = [([ud dictionaryForKey:kEndedCallUUIDsKey] ?: @{}) mutableCopy];
+  NSTimeInterval cutoff = [[NSDate date] timeIntervalSince1970] - 86400;
+  for (NSString *key in ended.allKeys) {
+    if ([ended[key] doubleValue] < cutoff) [ended removeObjectForKey:key];
+  }
+  [ud setObject:ended forKey:kEndedCallUUIDsKey];
+}
+
+// MARK: - WTPHostApi
+
 - (void)reportNewIncomingCall:(NSString *)uuidString
                        handle:(WTPHandle *)handle
                   displayName:(NSString *)displayName
@@ -198,6 +234,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
                                     update:callUpdate
                                 completion:^(NSError *error) {
                                   if (error == nil) {
+                                    [self _markUUIDActive:uuidString];
                                     [self assignIdleTimerDisabled:callUpdate.hasVideo];
                                     completion(nil, nil);
                                   } else if ([error.domain isEqualToString:CXErrorDomainIncomingCall]) {
@@ -215,6 +252,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 #ifdef DEBUG
   NSLog(@"[Callkeep][reportConnectingOutgoingCall] uuidString = %@", uuidString);
 #endif
+  [self _markUUIDActive:uuidString];
   [_provider reportOutgoingCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
                 startedConnectingAtDate:nil];
   completion(nil);
@@ -272,7 +310,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 #ifdef DEBUG
   NSLog(@"[Callkeep][reportEndCall] uuidString = %@", uuidString);
 #endif
-    
+  [self _markUUIDEnded:uuidString];
   [_provider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
                     endedAtDate:nil
                          reason:[reason toCallKit]];
@@ -415,6 +453,26 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
   [self requestTransaction:transaction completion:completion];
+}
+
+- (void)getConnectionWithUuidString:(NSString *)uuidString
+                         completion:(void (^)(WTPCallkeepConnection *_Nullable, FlutterError *_Nullable))completion {
+  [self _pruneEndedUUIDs];
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSDictionary *ended = [ud dictionaryForKey:kEndedCallUUIDsKey] ?: @{};
+  NSArray *active = [ud arrayForKey:kActiveCallUUIDsKey] ?: @[];
+
+  WTPCallkeepConnectionState state;
+  if (ended[uuidString]) {
+    state = WTPCallkeepConnectionStateStateDisconnected;
+  } else if ([active containsObject:uuidString]) {
+    state = WTPCallkeepConnectionStateStateActive;
+  } else {
+    completion(nil, nil);
+    return;
+  }
+
+  completion([WTPCallkeepConnection makeWithCallId:uuidString state:state], nil);
 }
 
 #pragma mark - WTPHostApi - helpers
@@ -718,6 +776,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performEndCallAction:]");
 #endif
+  [self _markUUIDEnded:action.callUUID.UUIDString];
   [_delegateFlutterApi performEndCall:action.callUUID.UUIDString
                            completion:^(NSNumber *fulfill, FlutterError *error) {
                              if (error != nil || [fulfill boolValue] != YES) {

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -63,6 +63,8 @@ enum PCallRequestErrorEnum {
   internal,
 }
 
+enum PCallkeepConnectionState { stateNew, stateActive, stateHolding, stateDisconnected }
+
 class PIOSOptions {
   PIOSOptions({
     required this.localizedName,
@@ -375,6 +377,43 @@ class PCallRequestError {
   int get hashCode => Object.hashAll(_toList());
 }
 
+class PCallkeepConnection {
+  PCallkeepConnection({required this.callId, required this.state});
+
+  String callId;
+
+  PCallkeepConnectionState state;
+
+  List<Object?> _toList() {
+    return <Object?>[callId, state];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static PCallkeepConnection decode(Object result) {
+    result as List<Object?>;
+    return PCallkeepConnection(callId: result[0]! as String, state: result[1]! as PCallkeepConnectionState);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! PCallkeepConnection || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -397,26 +436,32 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallRequestErrorEnum) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PIOSOptions) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(134);
-      writeValue(buffer, value.encode());
-    } else if (value is PAndroidOptions) {
+      writeValue(buffer, value.index);
+    } else if (value is PIOSOptions) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is POptions) {
+    } else if (value is PAndroidOptions) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PHandle) {
+    } else if (value is POptions) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PEndCallReason) {
+    } else if (value is PHandle) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PIncomingCallError) {
+    } else if (value is PEndCallReason) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PCallRequestError) {
+    } else if (value is PIncomingCallError) {
       buffer.putUint8(140);
+      writeValue(buffer, value.encode());
+    } else if (value is PCallRequestError) {
+      buffer.putUint8(141);
+      writeValue(buffer, value.encode());
+    } else if (value is PCallkeepConnection) {
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -442,19 +487,24 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallRequestErrorEnum.values[value];
       case 134:
-        return PIOSOptions.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 135:
-        return PAndroidOptions.decode(readValue(buffer)!);
+        return PIOSOptions.decode(readValue(buffer)!);
       case 136:
-        return POptions.decode(readValue(buffer)!);
+        return PAndroidOptions.decode(readValue(buffer)!);
       case 137:
-        return PHandle.decode(readValue(buffer)!);
+        return POptions.decode(readValue(buffer)!);
       case 138:
-        return PEndCallReason.decode(readValue(buffer)!);
+        return PHandle.decode(readValue(buffer)!);
       case 139:
-        return PIncomingCallError.decode(readValue(buffer)!);
+        return PEndCallReason.decode(readValue(buffer)!);
       case 140:
+        return PIncomingCallError.decode(readValue(buffer)!);
+      case 141:
         return PCallRequestError.decode(readValue(buffer)!);
+      case 142:
+        return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -927,6 +977,29 @@ class PHostApi {
       );
     } else {
       return (pigeonVar_replyList[0] as PCallRequestError?);
+    }
+  }
+
+  Future<PCallkeepConnection?> getConnection(String uuidString) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_ios.PHostApi.getConnection$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuidString]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return (pigeonVar_replyList[0] as PCallkeepConnection?);
     }
   }
 }

--- a/webtrit_callkeep_ios/lib/src/common/converters.dart
+++ b/webtrit_callkeep_ios/lib/src/common/converters.dart
@@ -129,3 +129,18 @@ extension CallkeepAndroidOptionsConverter on CallkeepAndroidOptions {
     return PAndroidOptions();
   }
 }
+
+extension PCallkeepConnectionStateConverter on PCallkeepConnectionState {
+  CallkeepConnectionState toCallkeep() {
+    switch (this) {
+      case PCallkeepConnectionState.stateNew:
+        return CallkeepConnectionState.stateNew;
+      case PCallkeepConnectionState.stateActive:
+        return CallkeepConnectionState.stateActive;
+      case PCallkeepConnectionState.stateHolding:
+        return CallkeepConnectionState.stateHolding;
+      case PCallkeepConnectionState.stateDisconnected:
+        return CallkeepConnectionState.stateDisconnected;
+    }
+  }
+}

--- a/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
+++ b/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
@@ -176,6 +176,14 @@ class WebtritCallkeep extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<CallkeepConnection?> getConnection(String callId) async {
+    final uuid = _uuidToCallIdMapping.put(callId: callId);
+    final conn = await _api.getConnection(uuid);
+    if (conn == null) return null;
+    return CallkeepConnection(callId: callId, state: conn.state.toCallkeep(), disconnectCause: null);
+  }
+
+  @override
   Future<void> playRingbackSound() {
     return _soundApi.playRingbackSound();
   }

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -6,9 +6,7 @@ import 'package:pigeon/pigeon.dart';
     dartTestOut: 'test/src/common/test_callkeep.pigeon.dart',
     objcHeaderOut: 'ios/Classes/Generated.h',
     objcSourceOut: 'ios/Classes/Generated.m',
-    objcOptions: ObjcOptions(
-      prefix: 'WT',
-    ),
+    objcOptions: ObjcOptions(prefix: 'WT'),
   ),
 )
 class PIOSOptions {
@@ -36,33 +34,16 @@ class POptions {
   late PAndroidOptions android;
 }
 
-enum PHandleTypeEnum {
-  generic,
-  number,
-  email,
-}
+enum PHandleTypeEnum { generic, number, email }
 
-enum PCallInfoConsts {
-  uuid,
-  dtmf,
-  isVideo,
-  number,
-  name,
-}
+enum PCallInfoConsts { uuid, dtmf, isVideo, number, name }
 
 class PHandle {
   late PHandleTypeEnum type;
   late String value;
 }
 
-enum PEndCallReasonEnum {
-  failed,
-  remoteEnded,
-  unanswered,
-  answeredElsewhere,
-  declinedElsewhere,
-  missed,
-}
+enum PEndCallReasonEnum { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed }
 
 // TODO: See https://github.com/flutter/flutter/issues/87307
 class PEndCallReason {
@@ -97,23 +78,21 @@ class PCallRequestError {
   late PCallRequestErrorEnum value;
 }
 
+enum PCallkeepConnectionState { stateNew, stateActive, stateHolding, stateDisconnected }
+
+class PCallkeepConnection {
+  late String callId;
+  late PCallkeepConnectionState state;
+}
+
 // TODO: Rename to background service
 @HostApi()
 abstract class PHostAndroidServiceApi {
   @async
-  void hungUp(
-    String callId,
-    String uuidString,
-  );
+  void hungUp(String callId, String uuidString);
 
   @async
-  void incomingCall(
-    String callId,
-    String uuidString,
-    PHandle handle,
-    String? displayName,
-    bool hasVideo,
-  );
+  void incomingCall(String callId, String uuidString, PHandle handle, String? displayName, bool hasVideo);
 }
 
 @HostApi()
@@ -131,12 +110,7 @@ abstract class PHostApi {
 
   @ObjCSelector('reportNewIncomingCall:handle:displayName:hasVideo:')
   @async
-  PIncomingCallError? reportNewIncomingCall(
-    String uuidString,
-    PHandle handle,
-    String? displayName,
-    bool hasVideo,
-  );
+  PIncomingCallError? reportNewIncomingCall(String uuidString, PHandle handle, String? displayName, bool hasVideo);
 
   @ObjCSelector('reportConnectingOutgoingCall:')
   @async
@@ -193,16 +167,16 @@ abstract class PHostApi {
   @ObjCSelector('sendDTMF:key:')
   @async
   PCallRequestError? sendDTMF(String uuidString, String key);
+
+  @ObjCSelector('getConnectionWithUuidString:')
+  @async
+  PCallkeepConnection? getConnection(String uuidString);
 }
 
 @FlutterApi()
 abstract class PDelegateFlutterApi {
   @ObjCSelector('continueStartCallIntentHandle:displayName:video:')
-  void continueStartCallIntent(
-    PHandle handle,
-    String? displayName,
-    bool video,
-  );
+  void continueStartCallIntent(PHandle handle, String? displayName, bool video);
 
   @ObjCSelector('didPushIncomingCallHandle:displayName:video:callId:uuid:error:')
   void didPushIncomingCall(
@@ -216,12 +190,7 @@ abstract class PDelegateFlutterApi {
 
   @ObjCSelector('performStartCall:handle:displayNameOrContactIdentifier:video:')
   @async
-  bool performStartCall(
-    String uuidString,
-    PHandle handle,
-    String? displayNameOrContactIdentifier,
-    bool video,
-  );
+  bool performStartCall(String uuidString, PHandle handle, String? displayNameOrContactIdentifier, bool video);
 
   @ObjCSelector('performAnswerCall:')
   @async

--- a/webtrit_callkeep_ios/test/src/common/test_callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/test/src/common/test_callkeep.pigeon.dart
@@ -32,26 +32,32 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallRequestErrorEnum) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is PIOSOptions) {
+    } else if (value is PCallkeepConnectionState) {
       buffer.putUint8(134);
-      writeValue(buffer, value.encode());
-    } else if (value is PAndroidOptions) {
+      writeValue(buffer, value.index);
+    } else if (value is PIOSOptions) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is POptions) {
+    } else if (value is PAndroidOptions) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PHandle) {
+    } else if (value is POptions) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PEndCallReason) {
+    } else if (value is PHandle) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PIncomingCallError) {
+    } else if (value is PEndCallReason) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PCallRequestError) {
+    } else if (value is PIncomingCallError) {
       buffer.putUint8(140);
+      writeValue(buffer, value.encode());
+    } else if (value is PCallRequestError) {
+      buffer.putUint8(141);
+      writeValue(buffer, value.encode());
+    } else if (value is PCallkeepConnection) {
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -77,19 +83,24 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PCallRequestErrorEnum.values[value];
       case 134:
-        return PIOSOptions.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : PCallkeepConnectionState.values[value];
       case 135:
-        return PAndroidOptions.decode(readValue(buffer)!);
+        return PIOSOptions.decode(readValue(buffer)!);
       case 136:
-        return POptions.decode(readValue(buffer)!);
+        return PAndroidOptions.decode(readValue(buffer)!);
       case 137:
-        return PHandle.decode(readValue(buffer)!);
+        return POptions.decode(readValue(buffer)!);
       case 138:
-        return PEndCallReason.decode(readValue(buffer)!);
+        return PHandle.decode(readValue(buffer)!);
       case 139:
-        return PIncomingCallError.decode(readValue(buffer)!);
+        return PEndCallReason.decode(readValue(buffer)!);
       case 140:
+        return PIncomingCallError.decode(readValue(buffer)!);
+      case 141:
         return PCallRequestError.decode(readValue(buffer)!);
+      case 142:
+        return PCallkeepConnection.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }


### PR DESCRIPTION
## Summary

- Implements `getConnection(callId)` on iOS so `HandshakeProcessor` in `webtrit_phone` can detect calls that ended locally during offline mode and clean up server state after reconnect
- Persists active/ended UUID sets in `NSUserDefaults` — no new dependencies
- Removes iOS guard from `CallkeepConnections.getConnection()`

## Problem

When a call ends during airplane mode / no network, the server never receives the hangup. After connectivity restores, the signaling handshake arrives and tries to restore the call. `HandshakeProcessor` checks `getConnection(callId)` to detect `stateDisconnected` and send `DeclineSignalingAction` / `HangupSignalingAction` — but on iOS this method always returned `null`, so incoming calls that were declined offline would be incorrectly "restored".

## Changes

**`webtrit_callkeep_ios/pigeons/callkeep.messages.dart`**
- Add `PCallkeepConnectionState` enum and `PCallkeepConnection` class
- Add `getConnection(uuidString)` to `PHostApi`
- Regenerate `Generated.h` / `Generated.m`

**`WebtritCallkeepPlugin.m`**
- Add `_markUUIDActive:` / `_markUUIDEnded:` / `_pruneEndedUUIDs` helpers (NSUserDefaults keys: `WebtritCallkeepActiveCallUUIDs`, `WebtritCallkeepEndedCallUUIDs`)
- Hook `_markUUIDActive` in `reportNewIncomingCall` (on CallKit success) and `reportConnectingOutgoingCall`
- Hook `_markUUIDEnded` in `reportEndCall` and `provider:performEndCallAction:`
- Implement `getConnectionWithUuidString:completion:`

**`converters.dart`** — add `PCallkeepConnectionState.toCallkeep()`

**`webtrit_callkeep_ios.dart`** — add `getConnection()` override

**`callkeep_connections.dart`** — extend guard to allow iOS through to platform implementation

## How it works

UUID is deterministic (v5 from callId), so `getConnection(callId)` computes the UUID and queries NSUserDefaults:
- UUID in ended dict → returns `stateDisconnected` → `HandshakeProcessor` sends Decline/Hangup to server
- UUID in active array → returns `stateActive`
- UUID unknown → returns null (unchanged behaviour)

Ended entries are pruned after 24h. Both write paths (`reportEndCall` app-side + `performEndCallAction` system-side) are covered so the state is persisted even when the user ends the call via the native CallKit UI.

## No changes in webtrit_phone

`HandshakeProcessor` already handles `stateDisconnected` correctly — it just needed real data from iOS.

YouTrack: [WT-1347](https://youtrack.portaone.com/issue/WT-1347)