### PR TITLE
fix(android): log USE_FULL_SCREEN_INTENT permission state on incoming call (WT-1349)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -21,6 +21,7 @@ class PermissionsHelper(
             }
             granted
         } else {
+            Log.d(TAG, "USE_FULL_SCREEN_INTENT permission check skipped (Android < 14); assuming granted")
             true
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -15,9 +15,12 @@ class PermissionsHelper(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val notificationManager =
                 context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.canUseFullScreenIntent()
+            val granted = notificationManager.canUseFullScreenIntent()
+            if (!granted) {
+                Log.w(TAG, "USE_FULL_SCREEN_INTENT permission is not granted (Android 14+); full-screen incoming call UI will not appear on lock screen")
+            }
+            granted
         } else {
-            Log.i(TAG, "Can't check full screen intent permission on this device")
             true
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -1,6 +1,7 @@
 package com.webtrit.callkeep.common
 
 import android.content.Context
+import android.util.Log
 
 /**
  * A delegate for managing SharedPreferences related to incoming and root routes.
@@ -56,7 +57,10 @@ object StorageDelegate {
             sharedPreferences(context).edit().putBoolean(FULL_SCREEN, enabled).apply()
         }
 
-        fun isFullScreen(context: Context): Boolean = sharedPreferences(context).getBoolean(FULL_SCREEN, true)
+        fun isFullScreen(context: Context): Boolean =
+            sharedPreferences(context).getBoolean(FULL_SCREEN, true).also {
+                Log.d("StorageDelegate", "IncomingCall.isFullScreen=$it")
+            }
     }
 
     object IncomingCallService {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -95,9 +95,13 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
                 // third-party apps.  Passing a full-screen intent when the permission is
                 // denied has no effect and produces a log warning, so we skip it and rely on
                 // the WakeLock acquired in IncomingCallService as the fallback wake mechanism.
-                val canUseFullScreen =
-                    StorageDelegate.IncomingCall.isFullScreen(context) &&
-                        PermissionsHelper(context).canUseFullScreenIntent()
+                val isFullScreenEnabled = StorageDelegate.IncomingCall.isFullScreen(context)
+                val hasFullScreenPermission = PermissionsHelper(context).canUseFullScreenIntent()
+                val canUseFullScreen = isFullScreenEnabled && hasFullScreenPermission
+                Log.d(
+                    TAG,
+                    "fullScreenIntent: enabled=$isFullScreenEnabled permissionGranted=$hasFullScreenPermission → applied=$canUseFullScreen",
+                )
                 if (canUseFullScreen) {
                     setFullScreenIntent(buildOpenAppIntent(context), true)
                 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -257,7 +257,9 @@ class IncomingCallService :
         //
         // When FSI is unavailable the WakeLock is the only mechanism to turn the screen
         // on; the notification provides the call UI instead of a full-screen Activity.
-        if (!isFullScreenIntentAvailable()) {
+        val fsiAvailable = isFullScreenIntentAvailable()
+        Log.d(TAG, "handleLaunch: isFullScreenIntentAvailable=$fsiAvailable → ${if (fsiAvailable) "relying on FSI" else "acquiring WakeLock fallback"}")
+        if (!fsiAvailable) {
             acquireScreenWakeLockIfNeeded()
         }
         incomingCallHandler.handle(metadata)
@@ -325,9 +327,14 @@ class IncomingCallService :
      * When denied, canUseFullScreenIntent() returns false and we fall back to the WakeLock.
      */
     private fun isFullScreenIntentAvailable(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Log.d(TAG, "isFullScreenIntentAvailable: SDK ${Build.VERSION.SDK_INT} < 34, returning false (WakeLock path)")
+            return false
+        }
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
-        return nm.canUseFullScreenIntent()
+        val available = nm.canUseFullScreenIntent()
+        Log.d(TAG, "isFullScreenIntentAvailable: SDK ${Build.VERSION.SDK_INT}, canUseFullScreenIntent=$available")
+        return available
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `Log.d` in `IncomingCallNotificationBuilder` — prints `enabled`, `permissionGranted`, `applied` on every incoming call
- Add `Log.w` in `PermissionsHelper.canUseFullScreenIntent()` when permission is denied on Android 14+ — makes root cause visible in logcat immediately

## Why

WT-1349 investigation (Xiaomi 12, Android 14): incoming call showed as compact lock-screen notification instead of full-screen UI. The code already silently skips `setFullScreenIntent` when `canUseFullScreenIntent()` = false — but nothing was logged, making it impossible to confirm from logcat.

Expected log when permission is denied:
```
W PermissionsHelper: USE_FULL_SCREEN_INTENT permission is not granted (Android 14+); full-screen incoming call UI will not appear on lock screen
D INCOMING_CALL_NOTIFICATION: fullScreenIntent: enabled=true permissionGranted=false → applied=false
```

## Test plan

- [ ] Xiaomi Android 14 — confirm `W PermissionsHelper` appears in logcat on incoming call
- [ ] Android 13 — no warning, full-screen UI works
- [ ] Android 14 with permission granted — no warning, full-screen UI works