### PR TITLE
fix(WT-1388): play call-waiting tone instead of ringtone during active call

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -7,7 +7,10 @@ import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.Ringtone
 import android.media.RingtoneManager
+import android.media.ToneGenerator
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.setLoopingCompat
@@ -19,6 +22,15 @@ class AudioManager(
         requireNotNull(context.getSystemService(Context.AUDIO_SERVICE) as AudioManager)
     private var ringtone: Ringtone? = null
     private var ringBack: MediaPlayer? = null
+    private var callWaitingToneGenerator: ToneGenerator? = null
+    private val callWaitingHandler = Handler(Looper.getMainLooper())
+    private val callWaitingRunnable =
+        object : Runnable {
+            override fun run() {
+                callWaitingToneGenerator?.startTone(ToneGenerator.TONE_SUP_CALL_WAITING, 1000)
+                callWaitingHandler.postDelayed(this, 3000)
+            }
+        }
 
     private fun isInputDeviceConnected(type: Int): Boolean {
         val devices = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
@@ -36,14 +48,13 @@ class AudioManager(
      * @return True if the device supports earpiece, false otherwise.
      */
     fun isSupportEarpiese(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
-    
+
     /**
      * Check if the device supports speakerphone.
      *
      * @return True if the device supports speakerphone, false otherwise.
      */
     fun isSupportSpeakerphone(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
-
 
     /**
      * Check if a wired headset is connected.
@@ -59,18 +70,17 @@ class AudioManager(
      */
     fun isBluetoothConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
 
-
     /**
      * Check if the speakerphone is currently on.
      *
      * @return True if the speakerphone is on, false otherwise.
      */
-    fun isSpeakerphoneOn(): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        audioManager.communicationDevice?.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
-    } else {
-        audioManager.isSpeakerphoneOn
-    }
-
+    fun isSpeakerphoneOn(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            audioManager.communicationDevice?.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+        } else {
+            audioManager.isSpeakerphoneOn
+        }
 
     /**
      * Start playing the ringtone.
@@ -148,5 +158,30 @@ class AudioManager(
         } finally {
             ringBack = null
         }
+    }
+
+    /**
+     * Play a soft call-waiting beep through the voice call audio stream.
+     *
+     * Uses STREAM_VOICE_CALL so the tone respects in-call volume and routes through
+     * the earpiece/headset — not the ringtone stream, which would blast at full
+     * ringtone volume while the user has the phone to their ear.
+     *
+     * Repeats every 3 seconds until [stopCallWaitingTone] is called.
+     */
+    fun startCallWaitingTone() {
+        stopCallWaitingTone()
+        callWaitingToneGenerator = ToneGenerator(AudioManager.STREAM_VOICE_CALL, ToneGenerator.MAX_VOLUME / 2)
+        callWaitingRunnable.run()
+    }
+
+    /**
+     * Stop the call-waiting beep and release the tone generator.
+     */
+    fun stopCallWaitingTone() {
+        callWaitingHandler.removeCallbacks(callWaitingRunnable)
+        callWaitingToneGenerator?.stopTone()
+        callWaitingToneGenerator?.release()
+        callWaitingToneGenerator = null
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -313,6 +313,23 @@ class ConnectionManager {
         }
     }
 
+    /**
+     * Checks whether there is already an active or held connection.
+     *
+     * Used to decide whether a new incoming call should play a soft call-waiting tone
+     * instead of the full ringtone, preventing the ringtone from blasting through the
+     * earpiece during an ongoing conversation.
+     *
+     * @return `true` if any connection is in `STATE_ACTIVE` or `STATE_HOLDING`.
+     */
+    fun hasActiveOrHoldingConnection(): Boolean {
+        synchronized(connectionResourceLock) {
+            return connections.values.any {
+                it.state == Connection.STATE_ACTIVE || it.state == Connection.STATE_HOLDING
+            }
+        }
+    }
+
     fun cleanConnections() {
         synchronized(connectionResourceLock) {
             connections.values.forEach { it.destroy() }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -121,11 +121,21 @@ class PhoneConnection internal constructor(
 
     /**
      * Invoked by the system when the incoming call interface should be displayed.
+     *
+     * If there is already an active or held call, play a soft call-waiting tone through
+     * the voice call stream instead of the full ringtone. The ringtone uses TYPE_RINGTONE
+     * which routes through the earpiece at full ringtone volume during an active call,
+     * and can cause pain if the user has the phone pressed to their ear (WT-1388).
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
-        audioManager.startRingtone(metadata.ringtonePath)
+        if (PhoneConnectionService.connectionManager.hasActiveOrHoldingConnection()) {
+            logger.d("Active call detected — playing call-waiting tone instead of ringtone for callId: $callId")
+            audioManager.startCallWaitingTone()
+        } else {
+            audioManager.startRingtone(metadata.ringtonePath)
+        }
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
     }
 
@@ -140,6 +150,7 @@ class PhoneConnection internal constructor(
     override fun onSilence() {
         logger.d("Silencing ringtone for callId: $callId")
         audioManager.stopRingtone()
+        audioManager.stopCallWaitingTone()
     }
 
     /**
@@ -174,6 +185,7 @@ class PhoneConnection internal constructor(
         notificationManager.cancelIncomingNotification(hasAnswered)
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
+        audioManager.stopCallWaitingTone()
 
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
@@ -589,6 +601,7 @@ class PhoneConnection internal constructor(
     private fun onActiveConnection() {
         logger.i("Connection became active for callId: $callId")
         audioManager.stopRingtone()
+        audioManager.stopCallWaitingTone()
         // IncomingCallService release (IC_RELEASE_WITH_ANSWER) is intentionally NOT triggered
         // here from :callkeep_core. ForegroundService.handleCSReportAnswerCall() owns that
         // trigger and sets pendingReleaseCallback before firing it, ensuring performAnswerCall

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -209,7 +209,12 @@ class StandaloneCallService : Service() {
         promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
         answeredCallIds.remove(metadata.callId)
-        ringtoneManager.startRingtone(metadata.ringtonePath)
+        if (answeredCallIds.isNotEmpty()) {
+            Log.d(TAG, "handleIncomingCall: active call detected — playing call-waiting tone for callId=${metadata.callId}")
+            ringtoneManager.startCallWaitingTone()
+        } else {
+            ringtoneManager.startRingtone(metadata.ringtonePath)
+        }
 
         // Replace the placeholder foreground notification (posted by promoteToForeground) with
         // a full incoming call notification — including Answer/Decline buttons and CallStyle on
@@ -254,6 +259,7 @@ class StandaloneCallService : Service() {
     private fun handleEstablishCall(metadata: CallMetadata) {
         Log.i(TAG, "handleEstablishCall: callId=${metadata.callId}")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
         callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
         answeredCallIds.add(metadata.callId)
@@ -268,6 +274,7 @@ class StandaloneCallService : Service() {
     private fun handleAnswerCall(metadata: CallMetadata) {
         Log.i(TAG, "handleAnswerCall: callId=${metadata.callId}")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         val full = (callMetadataMap[metadata.callId] ?: metadata).mergeWith(metadata)
         callMetadataMap[metadata.callId] = full.copy(acceptedTime = System.currentTimeMillis())
         answeredCallIds.add(metadata.callId)
@@ -282,6 +289,7 @@ class StandaloneCallService : Service() {
     private fun handleDeclineCall(metadata: CallMetadata) {
         Log.i(TAG, "handleDeclineCall: callId=${metadata.callId}")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
     }
@@ -289,6 +297,7 @@ class StandaloneCallService : Service() {
     private fun handleHungUpCall(metadata: CallMetadata) {
         Log.i(TAG, "handleHungUpCall: callId=${metadata.callId}")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
     }
@@ -323,6 +332,7 @@ class StandaloneCallService : Service() {
     private fun handleTearDownConnections() {
         Log.i(TAG, "handleTearDownConnections: cleaning up ${callMetadataMap.size} calls")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         callMetadataMap.keys.toList().forEach { callId ->
             val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
             core.notifyConnectionEvent(CallLifecycleEvent.HungUp, meta.toBundle())

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -161,6 +161,7 @@ class StandaloneCallService : Service() {
     override fun onDestroy() {
         Log.i(TAG, "onDestroy")
         ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
         isRunning = false
         isForeground = false
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -351,6 +352,7 @@ class StandaloneCallService : Service() {
         answeredCallIds.clear()
         pendingAnswers.clear()
         deactivateAudio(force = true)
+        ringtoneManager.stopCallWaitingTone()
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManagerTest.kt
@@ -375,6 +375,50 @@ class ConnectionManagerTest {
     }
 
     // -------------------------------------------------------------------------
+    // hasActiveOrHoldingConnection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `hasActiveOrHoldingConnection returns false when manager is empty`() {
+        assertFalse(createManager().hasActiveOrHoldingConnection())
+    }
+
+    @Test
+    fun `hasActiveOrHoldingConnection returns false when connection is ringing`() {
+        val manager = createManager()
+        manager.addConnection("call-1", createRingingConnection())
+        assertFalse(manager.hasActiveOrHoldingConnection())
+    }
+
+    @Test
+    fun `hasActiveOrHoldingConnection returns true when connection is active`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        conn.setActive()
+        manager.addConnection("call-1", conn)
+        assertTrue(manager.hasActiveOrHoldingConnection())
+    }
+
+    @Test
+    fun `hasActiveOrHoldingConnection returns true when connection is on hold`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        conn.setOnHold()
+        manager.addConnection("call-1", conn)
+        assertTrue(manager.hasActiveOrHoldingConnection())
+    }
+
+    @Test
+    fun `hasActiveOrHoldingConnection returns false after active connection disconnects`() {
+        val manager = createManager()
+        val conn = createRingingConnection()
+        conn.setActive()
+        manager.addConnection("call-1", conn)
+        conn.setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
+        assertFalse(manager.hasActiveOrHoldingConnection())
+    }
+
+    // -------------------------------------------------------------------------
     // pendingCallIds — basic behaviour
     // -------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionCallWaitingTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionCallWaitingTest.kt
@@ -1,0 +1,156 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Context
+import android.os.Build
+import android.telecom.DisconnectCause
+import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.managers.AudioManager
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.models.PerformDispatchHandle
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for the call-waiting audio branching logic (WT-1388).
+ *
+ * When a second incoming call arrives while one call is already active or held,
+ * [PhoneConnection.onShowIncomingCallUi] must play a soft call-waiting tone via
+ * [AudioManager.startCallWaitingTone] instead of the full ringtone. The ringtone
+ * uses TYPE_RINGTONE which routes through the earpiece at full ringtone volume and
+ * can hurt the user's ear during an active call.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class PhoneConnectionCallWaitingTest {
+    private val context: Context = RuntimeEnvironment.getApplication()
+    private val noop: PerformDispatchHandle = { _, _ -> }
+    private val noopCallback: (PhoneConnection) -> Unit = {}
+
+    @Before
+    fun setUp() {
+        ContextHolder.init(context)
+        PhoneConnectionService.connectionManager = ConnectionManager()
+    }
+
+    private fun createConnectionWithAudio(audioManager: AudioManager): PhoneConnection =
+        PhoneConnection(
+            context = context,
+            dispatcher = noop,
+            metadata = CallMetadata(callId = "incoming-2"),
+            onDisconnectCallback = noopCallback,
+            audioManager = audioManager,
+        )
+
+    private fun managerWithActiveCall(): ConnectionManager {
+        val manager = ConnectionManager()
+        val conn =
+            PhoneConnection.createIncomingPhoneConnection(
+                context = context,
+                dispatcher = noop,
+                metadata = CallMetadata(callId = "active-1"),
+                onDisconnect = noopCallback,
+            )
+        conn.setActive()
+        manager.addConnection("active-1", conn)
+        return manager
+    }
+
+    private fun managerWithHeldCall(): ConnectionManager {
+        val manager = ConnectionManager()
+        val conn =
+            PhoneConnection.createIncomingPhoneConnection(
+                context = context,
+                dispatcher = noop,
+                metadata = CallMetadata(callId = "held-1"),
+                onDisconnect = noopCallback,
+            )
+        conn.setOnHold()
+        manager.addConnection("held-1", conn)
+        return manager
+    }
+
+    // -------------------------------------------------------------------------
+    // onShowIncomingCallUi — audio routing decision
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onShowIncomingCallUi plays ringtone when no active call exists`() {
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onShowIncomingCallUi()
+
+        verify(mockAudio).startRingtone(null)
+        verify(mockAudio, never()).startCallWaitingTone()
+    }
+
+    @Test
+    fun `onShowIncomingCallUi plays call-waiting tone when a call is active`() {
+        PhoneConnectionService.connectionManager = managerWithActiveCall()
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onShowIncomingCallUi()
+
+        verify(mockAudio).startCallWaitingTone()
+        verify(mockAudio, never()).startRingtone(null)
+    }
+
+    @Test
+    fun `onShowIncomingCallUi plays call-waiting tone when a call is on hold`() {
+        PhoneConnectionService.connectionManager = managerWithHeldCall()
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onShowIncomingCallUi()
+
+        verify(mockAudio).startCallWaitingTone()
+        verify(mockAudio, never()).startRingtone(null)
+    }
+
+    @Test
+    fun `onShowIncomingCallUi plays ringtone after active call disconnects`() {
+        val manager = managerWithActiveCall()
+        manager.getActiveConnection()?.setDisconnected(DisconnectCause(DisconnectCause.REMOTE))
+        PhoneConnectionService.connectionManager = manager
+
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onShowIncomingCallUi()
+
+        verify(mockAudio).startRingtone(null)
+        verify(mockAudio, never()).startCallWaitingTone()
+    }
+
+    // -------------------------------------------------------------------------
+    // stopCallWaitingTone — cleanup paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onSilence stops the call-waiting tone`() {
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onSilence()
+
+        verify(mockAudio).stopCallWaitingTone()
+    }
+
+    @Test
+    fun `onDisconnect stops the call-waiting tone`() {
+        val mockAudio = mock(AudioManager::class.java)
+        val connection = createConnectionWithAudio(mockAudio)
+
+        connection.onDisconnect()
+
+        verify(mockAudio).stopCallWaitingTone()
+    }
+}


### PR DESCRIPTION
## Problem

When a second incoming call arrives while one call is already `STATE_ACTIVE`,
`isExistsIncomingConnection()` returns `false` (it only checks `STATE_NEW`/`STATE_RINGING`),
allowing the full ringtone to play via `TYPE_RINGTONE`. That stream routes through the
earpiece at full ringtone volume during a call and can hurt the user's ear.

## Changes

- **`ConnectionManager`** — add `hasActiveOrHoldingConnection()` to detect active/held calls
- **`AudioManager`** — add `startCallWaitingTone()` / `stopCallWaitingTone()` using
  `ToneGenerator(STREAM_VOICE_CALL)` — plays at in-call volume via earpiece/headset,
  not at ringtone volume; repeats every 3s via Handler until stopped
- **`PhoneConnection.onShowIncomingCallUi()`** — play call-waiting tone when an active/held
  call exists, ringtone otherwise; stop tone on `onActiveConnection`, `onDisconnect`, `onSilence`
- **`StandaloneCallService`** (non-Telecom path) — same branching via `answeredCallIds`;
  stop call-waiting tone on answer/decline/hangup/teardown
