### PR TITLE
fix(android): re-enable plugin auto-registration on background FGS engine

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/FlutterEngineHelper.kt
@@ -38,14 +38,10 @@ class FlutterEngineHelper(
             }
             flutterLoader.ensureInitializationComplete(context.applicationContext, null)
 
-            // automaticallyRegisterPlugins=false: prevents GeneratedPluginRegistrant from
-            // registering all app plugins on this background FGS engine. On Android 16
-            // REMOTE_MESSAGING services, audio/hardware init in onAttachedToEngine can
-            // block the Dart VM from running the background entry point.
             // FlutterJNI is obtained via FlutterInjector so DI overrides are respected,
             // matching the internal behaviour of the 1-arg FlutterEngine constructor.
             backgroundEngine =
-                FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, false).also { engine ->
+                FlutterEngine(context.applicationContext, null, FlutterInjector.instance().flutterJNIFactory.provideFlutterJNI(), null, true).also { engine ->
                     val callbackInformation =
                         FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 


### PR DESCRIPTION
## Problem

Commit c7bcf23 set `automaticallyRegisterPlugins=false` when creating the background `FlutterEngine` in `FlutterEngineHelper`, based on the hypothesis that auto-registering plugins caused a first-frame freeze on incoming calls on some devices.

This broke incoming call handling: with `false`, `GeneratedPluginRegistrant` is never called, `WebtritCallkeepPlugin` is never registered on the isolate engine, and `onAttachedToService()` is never triggered. As a result, `establishFlutterCommunication()` is never called, `flutterApi` stays `null`, and `syncPushIsolate` silently drops all incoming call data.

Symptom in logs:
```
[CK-IncomingCallService] onStart: invoking syncPushIsolate, flutterApi=false
[CK-IncomingCallService] syncPushIsolate: flutterApi is null, isolate will not receive call data
```

## Fix

Revert `automaticallyRegisterPlugins` back to `true`. The hypothesis about first-frame freeze was not confirmed — the change had no observable effect on frame timing.

## Test

- Incoming call on Android — push notification arrives and call data is delivered to the isolate
- `syncPushIsolate: success` appears in logs