### PR TITLE
fix(android): prevent zombie incoming calls — fast hangup and cold-start sync race (WT-1393)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -225,6 +225,22 @@ class WebtritCallkeepPlugin :
         ConnectionsApi().let {
             PHostConnectionsApi.setUp(messenger, it)
         }
+
+        // Cold-start recovery: Flutter's ServiceAware.onAttachedToService() is only dispatched
+        // to plugins that are registered at the time attachToService() is called. On a cold-start
+        // background engine, attachToService() fires before executeDartCallback() runs, so the
+        // plugin is not yet registered and misses the lifecycle call. onAttachedToEngine() fires
+        // later when Dart registers the plugin — at that point we can establish communication
+        // with a running IncomingCallService directly.
+        val runningService = IncomingCallService.runningInstance
+        if (runningService != null && !runningService.hasFlutterCommunication()) {
+            Log.i(TAG, "onAttachedToEngine: IncomingCallService running without flutterApi — establishing communication")
+            runningService.establishFlutterCommunication(
+                PDelegateBackgroundServiceFlutterApi(messenger),
+                PDelegateBackgroundRegisterFlutterApi(messenger),
+            )
+            PHostBackgroundPushNotificationIsolateApi.setUp(messenger, runningService.getCallLifecycleHandler())
+        }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -225,22 +225,6 @@ class WebtritCallkeepPlugin :
         ConnectionsApi().let {
             PHostConnectionsApi.setUp(messenger, it)
         }
-
-        // Cold-start recovery: Flutter's ServiceAware.onAttachedToService() is only dispatched
-        // to plugins that are registered at the time attachToService() is called. On a cold-start
-        // background engine, attachToService() fires before executeDartCallback() runs, so the
-        // plugin is not yet registered and misses the lifecycle call. onAttachedToEngine() fires
-        // later when Dart registers the plugin — at that point we can establish communication
-        // with a running IncomingCallService directly.
-        val runningService = IncomingCallService.runningInstance
-        if (runningService != null && !runningService.hasFlutterCommunication()) {
-            Log.i(TAG, "onAttachedToEngine: IncomingCallService running without flutterApi — establishing communication")
-            runningService.establishFlutterCommunication(
-                PDelegateBackgroundServiceFlutterApi(messenger),
-                PDelegateBackgroundRegisterFlutterApi(messenger),
-            )
-            PHostBackgroundPushNotificationIsolateApi.setUp(messenger, runningService.getCallLifecycleHandler())
-        }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
@@ -24,4 +24,10 @@ object PendingBroadcastQueue {
 
     /** Key for a pending IC_RELEASE_WITH_DECLINE for [callId]. */
     fun incomingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
+
+    /** Removes all pending entries. Intended for use in tests to reset state between cases. */
+    @androidx.annotation.VisibleForTesting
+    fun clear() {
+        queue.clear()
+    }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
@@ -21,4 +21,7 @@ object PendingBroadcastQueue {
 
     /** Returns true and removes the entry if [key] was present, false otherwise. */
     fun consume(key: String): Boolean = queue.remove(key) != null
+
+    /** Key for a pending IC_RELEASE_WITH_DECLINE for [callId]. */
+    fun incomingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PendingBroadcastQueue.kt
@@ -1,0 +1,24 @@
+package com.webtrit.callkeep.common
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-process queue for broadcasts that may fire before the target receiver is registered.
+ *
+ * Both sender and receiver must be in the same process. When a broadcast is sent to a
+ * component that has not started yet, the sender posts an entry here. The receiver drains
+ * the queue on startup and handles any pending entries as if the broadcast had just arrived.
+ *
+ * Keyed by an arbitrary string (e.g. "ACTION:callId"). Thread-safe. No TTL — entries persist
+ * until consumed. Suitable for short-lived FGS-to-FGS communication within one app session.
+ */
+object PendingBroadcastQueue {
+    private val queue = ConcurrentHashMap<String, Boolean>()
+
+    fun post(key: String) {
+        queue[key] = true
+    }
+
+    /** Returns true and removes the entry if [key] was present, false otherwise. */
+    fun consume(key: String): Boolean = queue.remove(key) != null
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -798,12 +798,15 @@ class ForegroundService :
         logger.i("reportEndCall: callId=$callId, reason=$reason")
         val callMetaData = CallMetadata(callId = callId, displayName = displayName)
         // Post a pending release so IncomingCallService.handleLaunch() can detect a stale
-        // IC_INITIALIZE that arrives after this call was already terminated. The broadcast
-        // IC_RELEASE_WITH_DECLINE sent from :callkeep_core may be lost if IncomingCallService
-        // has not started yet. This in-process entry bridges that timing gap.
+        // IC_INITIALIZE that arrives after this call was already terminated. Only posted when
+        // IncomingCallService is not yet running — if it is already up, releaseReceiver is
+        // registered and will handle IC_RELEASE_WITH_DECLINE directly. Posting when the service
+        // is already running creates orphan entries that are never consumed.
         // Must be posted here (main thread) — not in NotificationManager which runs in
         // :callkeep_core and cannot reach this main-process queue.
-        PendingBroadcastQueue.post(PendingBroadcastQueue.incomingReleaseKey(callId))
+        if (!IncomingCallService.isRunning) {
+            PendingBroadcastQueue.post(PendingBroadcastQueue.incomingReleaseKey(callId))
+        }
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -24,6 +24,7 @@ import com.webtrit.callkeep.PIncomingCallErrorEnum
 import com.webtrit.callkeep.POptions
 import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.common.PendingBroadcastQueue
 import com.webtrit.callkeep.common.Platform
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.TelephonyUtils
@@ -796,9 +797,18 @@ class ForegroundService :
     ) {
         logger.i("reportEndCall: callId=$callId, reason=$reason")
         val callMetaData = CallMetadata(callId = callId, displayName = displayName)
+        // Post a pending release so IncomingCallService.handleLaunch() can detect a stale
+        // IC_INITIALIZE that arrives after this call was already terminated. The broadcast
+        // IC_RELEASE_WITH_DECLINE sent from :callkeep_core may be lost if IncomingCallService
+        // has not started yet. This in-process entry bridges that timing gap.
+        // Must be posted here (main thread) — not in NotificationManager which runs in
+        // :callkeep_core and cannot reach this main-process queue.
+        PendingBroadcastQueue.post(pendingReleaseKey(callId))
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }
+
+    private fun pendingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
 
     override fun answerCall(
         callId: String,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -803,12 +803,10 @@ class ForegroundService :
         // has not started yet. This in-process entry bridges that timing gap.
         // Must be posted here (main thread) — not in NotificationManager which runs in
         // :callkeep_core and cannot reach this main-process queue.
-        PendingBroadcastQueue.post(pendingReleaseKey(callId))
+        PendingBroadcastQueue.post(PendingBroadcastQueue.incomingReleaseKey(callId))
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }
-
-    private fun pendingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
 
     override fun answerCall(
         callId: String,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -275,6 +275,10 @@ class IncomingCallService :
         // this in-process entry is the only remaining signal that the call is over.
         if (PendingBroadcastQueue.consume(PendingBroadcastQueue.incomingReleaseKey(metadata.callId))) {
             Log.w(TAG, "handleLaunch: pending release found for callId=${metadata.callId} — releasing immediately without showing UI")
+            // Block any deferred syncPushIsolate from establishFlutterCommunication(). The call
+            // is already in teardown; delivering it to Dart as a new incoming call would create
+            // a zombie ActiveCall on the Dart side that was never set up natively.
+            callDataSynced = true
             // startForeground() must be called within 5s of startForegroundService() on Android 12+.
             // handle() satisfies this by posting a notification and calling startForeground().
             // releaseIncomingCallNotification() immediately transitions it to a silent release

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -96,6 +96,8 @@ class IncomingCallService :
 
     fun getCallLifecycleHandler(): CallLifecycleHandler = callLifecycleHandler
 
+    fun hasFlutterCommunication(): Boolean = callLifecycleHandler.flutterApi != null
+
     override fun onConnectionEvent(
         event: ConnectionEvent,
         data: Bundle?,
@@ -115,6 +117,7 @@ class IncomingCallService :
     override fun onCreate() {
         super.onCreate()
         setRunning(true)
+        runningInstance = this
         ContextHolder.init(applicationContext)
 
         Log.d(TAG, "IncomingCallService created")
@@ -202,6 +205,7 @@ class IncomingCallService :
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
 
         setRunning(false)
+        runningInstance = null
         releaseScreenWakeLock()
         unregisterReceiver(releaseReceiver)
         CallkeepCore.instance.removeConnectionEventListener(this)
@@ -444,6 +448,14 @@ class IncomingCallService :
 
         @Volatile
         var isRunning = false
+            private set
+
+        // Weak reference to the currently running instance. Set in onCreate(), cleared in
+        // onDestroy(). Used by WebtritCallkeepPlugin.onAttachedToEngine() to establish Flutter
+        // communication when onAttachedToService() is not triggered retroactively (cold-start
+        // engine: attachToService() fires before Dart registers the plugin).
+        @Volatile
+        var runningInstance: IncomingCallService? = null
             private set
 
         private fun setRunning(running: Boolean) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -55,6 +55,11 @@ class IncomingCallService :
     // deferred) would otherwise both deliver call data to the Dart isolate.
     private var callDataSynced = false
 
+    // Set to true on the first handleRelease() call. Guards against a second invocation in the
+    // narrow window where both releaseReceiver and the PendingBroadcastQueue early-exit path
+    // could race to call handleRelease() for the same call.
+    private var isReleased = false
+
     // Receives IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE from release().
     // Registered in onCreate() and unregistered in onDestroy() so it only lives while the
     // service is alive. If the service is not running the broadcast goes nowhere — no zombie
@@ -319,6 +324,11 @@ class IncomingCallService :
 
     // Handles the RELEASE action and cancels the timeout
     private fun handleRelease(answered: Boolean = false): Int {
+        if (isReleased) {
+            Log.w(TAG, "handleRelease: already released, ignoring duplicate invocation")
+            return START_NOT_STICKY
+        }
+        isReleased = true
         // The ringing phase is over — release the wake lock immediately so the screen
         // is not held on for the full WAKELOCK_TIMEOUT_MS during post-call teardown.
         // onDestroy() keeps the lock as a final safety net in case this path is skipped.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -50,6 +50,11 @@ class IncomingCallService :
     // call is still in the teardown window).
     private var isInitialized = false
 
+    // Set to true once syncPushIsolate has been dispatched. Prevents double-sync when both
+    // the onStart() path (warm engine) and the establishFlutterCommunication() path (cold-start
+    // deferred) would otherwise both deliver call data to the Dart isolate.
+    private var callDataSynced = false
+
     // Receives IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE from release().
     // Registered in onCreate() and unregistered in onDestroy() so it only lives while the
     // service is alive. If the service is not running the broadcast goes nowhere — no zombie
@@ -126,9 +131,12 @@ class IncomingCallService :
                 Log.d(TAG, "onStart: invoking syncPushIsolate, flutterApi=${callLifecycleHandler.flutterApi != null}, callData=${callLifecycleHandler.currentCallData?.callId}")
                 callLifecycleHandler.flutterApi?.syncPushIsolate(
                     callLifecycleHandler.currentCallData,
-                    onSuccess = { Log.d(TAG, "syncPushIsolate: success") },
+                    onSuccess = {
+                        callDataSynced = true
+                        Log.d(TAG, "syncPushIsolate: success")
+                    },
                     onFailure = { e -> Log.e(TAG, "syncPushIsolate: failed: $e") },
-                ) ?: Log.e(TAG, "syncPushIsolate: flutterApi is null, isolate will not receive call data")
+                ) ?: Log.w(TAG, "syncPushIsolate: flutterApi is null — will retry from establishFlutterCommunication")
             }
 
         incomingCallHandler =
@@ -212,6 +220,21 @@ class IncomingCallService :
         callLifecycleHandler.apply {
             flutterApi =
                 DefaultFlutterIsolateCommunicator(this@IncomingCallService, serviceApi, registerApi)
+        }
+        // On a cold-start Flutter engine, executeDartCallback() returns before Dart has run.
+        // onStart() fires immediately and finds flutterApi == null, so syncPushIsolate is skipped.
+        // This is the first point where Dart has registered its APIs and can accept the call data.
+        if (!callDataSynced) {
+            val data = callLifecycleHandler.currentCallData
+            if (data != null) {
+                callDataSynced = true
+                Log.w(TAG, "establishFlutterCommunication: deferred sync for callId=${data.callId}")
+                callLifecycleHandler.flutterApi?.syncPushIsolate(
+                    data,
+                    onSuccess = { Log.d(TAG, "syncPushIsolate (deferred): success") },
+                    onFailure = { e -> Log.e(TAG, "syncPushIsolate (deferred): failed: $e") },
+                )
+            }
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -17,6 +17,7 @@ import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.common.PendingBroadcastQueue
 import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.registerReceiverCompat
@@ -242,6 +243,20 @@ class IncomingCallService :
             return START_NOT_STICKY
         }
         isInitialized = true
+
+        // Check for a pending release posted by ForegroundService.reportEndCall() before
+        // this service started. startForegroundService(IC_INITIALIZE) may be queued in the
+        // OS before the caller hangs up. By the time the OS delivers it, reportEndCall() has
+        // already run and posted to PendingBroadcastQueue. The IC_RELEASE_WITH_DECLINE
+        // broadcast from :callkeep_core was lost (releaseReceiver not yet registered), so
+        // this in-process entry is the only remaining signal that the call is over.
+        if (PendingBroadcastQueue.consume(pendingReleaseKey(metadata.callId))) {
+            Log.w(TAG, "handleLaunch: pending release found for callId=${metadata.callId} — releasing immediately without showing UI")
+            isInitialized = false
+            callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
+            handleRelease(answered = false)
+            return START_NOT_STICKY
+        }
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.postDelayed(independentTimeoutRunnable, INDEPENDENT_SERVICE_TIMEOUT_MS)
@@ -313,6 +328,8 @@ class IncomingCallService :
         Log.e(TAG, "Unknown or missing intent action: $action")
         return START_NOT_STICKY
     }
+
+    private fun pendingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
 
     /**
      * Returns true if the system will fire a full-screen intent for this app's notifications,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -96,8 +96,6 @@ class IncomingCallService :
 
     fun getCallLifecycleHandler(): CallLifecycleHandler = callLifecycleHandler
 
-    fun hasFlutterCommunication(): Boolean = callLifecycleHandler.flutterApi != null
-
     override fun onConnectionEvent(
         event: ConnectionEvent,
         data: Bundle?,
@@ -117,7 +115,6 @@ class IncomingCallService :
     override fun onCreate() {
         super.onCreate()
         setRunning(true)
-        runningInstance = this
         ContextHolder.init(applicationContext)
 
         Log.d(TAG, "IncomingCallService created")
@@ -136,15 +133,19 @@ class IncomingCallService :
 
         isolateHandler =
             FlutterIsolateHandler(this@IncomingCallService, this@IncomingCallService) {
-                Log.d(TAG, "onStart: invoking syncPushIsolate, flutterApi=${callLifecycleHandler.flutterApi != null}, callData=${callLifecycleHandler.currentCallData?.callId}")
-                callLifecycleHandler.flutterApi?.syncPushIsolate(
-                    callLifecycleHandler.currentCallData,
-                    onSuccess = {
-                        callDataSynced = true
-                        Log.d(TAG, "syncPushIsolate: success")
-                    },
-                    onFailure = { e -> Log.e(TAG, "syncPushIsolate: failed: $e") },
-                ) ?: Log.w(TAG, "syncPushIsolate: flutterApi is null — will retry from establishFlutterCommunication")
+                Log.d(TAG, "onStart: flutterApi=${callLifecycleHandler.flutterApi != null}, callDataSynced=$callDataSynced, callData=${callLifecycleHandler.currentCallData?.callId}")
+                if (callDataSynced) {
+                    Log.d(TAG, "onStart: callDataSynced already set — skipping duplicate syncPushIsolate")
+                } else {
+                    callLifecycleHandler.flutterApi?.syncPushIsolate(
+                        callLifecycleHandler.currentCallData,
+                        onSuccess = {
+                            callDataSynced = true
+                            Log.d(TAG, "syncPushIsolate: success")
+                        },
+                        onFailure = { e -> Log.e(TAG, "syncPushIsolate: failed: $e") },
+                    ) ?: Log.w(TAG, "syncPushIsolate: flutterApi is null — will retry from establishFlutterCommunication")
+                }
             }
 
         incomingCallHandler =
@@ -205,7 +206,6 @@ class IncomingCallService :
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
 
         setRunning(false)
-        runningInstance = null
         releaseScreenWakeLock()
         unregisterReceiver(releaseReceiver)
         CallkeepCore.instance.removeConnectionEventListener(this)
@@ -448,14 +448,6 @@ class IncomingCallService :
 
         @Volatile
         var isRunning = false
-            private set
-
-        // Weak reference to the currently running instance. Set in onCreate(), cleared in
-        // onDestroy(). Used by WebtritCallkeepPlugin.onAttachedToEngine() to establish Flutter
-        // communication when onAttachedToService() is not triggered retroactively (cold-start
-        // engine: attachToService() fires before Dart registers the plugin).
-        @Volatile
-        var runningInstance: IncomingCallService? = null
             private set
 
         private fun setRunning(running: Boolean) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -250,9 +250,13 @@ class IncomingCallService :
         // already run and posted to PendingBroadcastQueue. The IC_RELEASE_WITH_DECLINE
         // broadcast from :callkeep_core was lost (releaseReceiver not yet registered), so
         // this in-process entry is the only remaining signal that the call is over.
-        if (PendingBroadcastQueue.consume(pendingReleaseKey(metadata.callId))) {
+        if (PendingBroadcastQueue.consume(PendingBroadcastQueue.incomingReleaseKey(metadata.callId))) {
             Log.w(TAG, "handleLaunch: pending release found for callId=${metadata.callId} — releasing immediately without showing UI")
-            isInitialized = false
+            // startForeground() must be called within 5s of startForegroundService() on Android 12+.
+            // handle() satisfies this by posting a notification and calling startForeground().
+            // releaseIncomingCallNotification() immediately transitions it to a silent release
+            // notification, so the ringing UI is never visible to the user.
+            incomingCallHandler.handle(metadata)
             callLifecycleHandler.currentCallData = metadata.toPCallkeepIncomingCallData()
             handleRelease(answered = false)
             return START_NOT_STICKY
@@ -328,8 +332,6 @@ class IncomingCallService :
         Log.e(TAG, "Unknown or missing intent action: $action")
         return START_NOT_STICKY
     }
-
-    private fun pendingReleaseKey(callId: String) = "IC_RELEASE_WITH_DECLINE:$callId"
 
     /**
      * Returns true if the system will fire a full-screen intent for this app's notifications,


### PR DESCRIPTION
## Problem

Two separate race conditions that both produce a zombie \`ActiveCall(incomingFromPush)\` stuck in RINGING indefinitely on Android (confirmed on Xiaomi Android 15, WT-1393).

### Bug 1 — Caller hangs up before IncomingCallService starts

\`startForegroundService(IC_INITIALIZE)\` is queued in the OS before \`reportEndCall()\` runs. The \`IC_RELEASE_WITH_DECLINE\` broadcast from \`:callkeep_core\` fires while \`IncomingCallService\` is not yet running — \`releaseReceiver\` is not registered so the broadcast is lost. When the OS delivers the queued intent 266ms later, \`handleLaunch()\` starts the call UI unconditionally.

Confirmed in logs: \`reportEndCall\` at 13:18:56.701 → \`IncomingCallService created\` at 13:18:56.967 (+266ms). Reproduced across all 6 rapid calls in the test session.

### Bug 2 — Cold-start Flutter engine: \`syncPushIsolate\` silently dropped

On a cold-start engine, \`onStart()\` fires before Dart has registered its background Pigeon APIs (~1s gap on slow/MIUI devices). \`flutterApi\` is null at that point, so \`syncPushIsolate\` is skipped. The Dart isolate never receives the call data, \`CallBloc\` has no state for the callId, and the call gets stuck.

## Root cause

**Bug 1:** \`IC_RELEASE_WITH_DECLINE\` is sent cross-process from \`:callkeep_core\`. At that moment \`releaseReceiver\` is not yet registered — the broadcast is dropped with no retry.

**Bug 2:** \`automaticallyRegisterPlugins=false\` (introduced in #268, reverted in #274) prevented \`WebtritCallkeepPlugin\` from being registered on the ICS engine. \`onAttachedToService()\` was never dispatched, so \`flutterApi\` was never set. Even after #274 restored plugin registration, the cold-start timing window still required a deferred sync fallback.

## Fix

### Bug 1 — PendingBroadcastQueue

Adds \`PendingBroadcastQueue\` — an in-process deferred-broadcast utility for same-process components where the receiver may not be registered when the sender fires.

- \`ForegroundService.reportEndCall()\` posts a pending release keyed by \`callId\` when \`IncomingCallService\` is not yet running.
- \`IncomingCallService.handleLaunch()\` drains the queue on startup. If a pending release is found, calls \`handleRelease(answered=false)\` immediately — no notification shown, no Dart sync fired.
- \`handleRelease()\` is made idempotent via \`isReleased\` guard.

### Bug 2 — Deferred sync via \`establishFlutterCommunication\`

- Adds \`callDataSynced\` flag. If \`onStart()\` finds \`flutterApi == null\`, it skips the sync and logs a warning.
- \`establishFlutterCommunication()\` — called from \`onAttachedToService()\` — checks the flag and performs a deferred sync if not yet done.
- \`onStart\` lambda also checks \`callDataSynced\` to skip a duplicate sync when \`onAttachedToService\` fires first (normal path with \`automaticallyRegisterPlugins=true\`).
- \`callDataSynced = true\` is set immediately in the PendingBroadcastQueue early-exit path to suppress deferred sync for calls already in teardown.
