### PR TITLE
fix(android): fix onReject teardown path and remove sticky-speaker workaround

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -186,35 +186,10 @@ class PhoneConnection internal constructor(
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
         audioManager.stopCallWaitingTone()
-        resetSystemAudioState()
 
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
-    }
-
-    // Resets system audio state after call ends to prevent speaker/mic state from
-    // bleeding into the next call session. Mirrors deactivateAudio() in StandaloneCallService.
-    //
-    // Order matters per Android docs:
-    //   1. clearCommunicationDevice() while still owning the audio mode priority
-    //   2. setMode(MODE_NORMAL) to release mode ownership
-    //   3. setSpeakerphoneOn(false) as MIUI fallback (MODE_IN_CALL ignores clearCommunicationDevice)
-    //   4. setMicrophoneMute(false) defensive reset
-    private fun resetSystemAudioState() {
-        try {
-            val sysAm = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                sysAm.clearCommunicationDevice()
-            }
-            sysAm.mode = android.media.AudioManager.MODE_NORMAL
-            @Suppress("DEPRECATION")
-            sysAm.isSpeakerphoneOn = false
-            sysAm.isMicrophoneMute = false
-            logger.d("System audio state reset on disconnect for callId: $callId")
-        } catch (e: Exception) {
-            logger.w("Failed to reset system audio state on disconnect: ${e.message}")
-        }
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -97,6 +97,7 @@ class PhoneConnection internal constructor(
         connectionProperties = PROPERTY_SELF_MANAGED
         connectionCapabilities = CAPABILITY_MUTE or CAPABILITY_SUPPORT_HOLD
 
+        clearStickyAudioState()
         setInitializing()
         updateData(metadata)
     }
@@ -191,6 +192,24 @@ class PhoneConnection internal constructor(
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
+    }
+
+    // Clears sticky speaker state inherited from a previous call session before EarHover
+    // activates for the new call. On Samsung One UI, EarHover reacts to the true→false
+    // transition that Telecom's SWITCH_FOCUS causes when isSpeakerphoneOn was left true
+    // by the previous session. Resetting here — before Telecom initialises call audio —
+    // prevents that reaction.
+    private fun clearStickyAudioState() {
+        try {
+            val sysAm = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
+            @Suppress("DEPRECATION")
+            if (sysAm.isSpeakerphoneOn) {
+                sysAm.isSpeakerphoneOn = false
+                logger.d("Cleared sticky speaker state at call start for callId: $callId")
+            }
+        } catch (e: Exception) {
+            logger.w("Failed to clear sticky audio state at call start: ${e.message}")
+        }
     }
 
     // Resets system audio state after call ends to prevent speaker/mic state from

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -97,7 +97,6 @@ class PhoneConnection internal constructor(
         connectionProperties = PROPERTY_SELF_MANAGED
         connectionCapabilities = CAPABILITY_MUTE or CAPABILITY_SUPPORT_HOLD
 
-        clearStickyAudioState()
         setInitializing()
         updateData(metadata)
     }
@@ -192,24 +191,6 @@ class PhoneConnection internal constructor(
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
-    }
-
-    // Clears sticky speaker state inherited from a previous call session before EarHover
-    // activates for the new call. On Samsung One UI, EarHover reacts to the true→false
-    // transition that Telecom's SWITCH_FOCUS causes when isSpeakerphoneOn was left true
-    // by the previous session. Resetting here — before Telecom initialises call audio —
-    // prevents that reaction.
-    private fun clearStickyAudioState() {
-        try {
-            val sysAm = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
-            @Suppress("DEPRECATION")
-            if (sysAm.isSpeakerphoneOn) {
-                sysAm.isSpeakerphoneOn = false
-                logger.d("Cleared sticky speaker state at call start for callId: $callId")
-            }
-        } catch (e: Exception) {
-            logger.w("Failed to clear sticky audio state at call start: ${e.message}")
-        }
     }
 
     // Resets system audio state after call ends to prevent speaker/mic state from

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -50,6 +50,19 @@ class PhoneConnection internal constructor(
     private var isSpeakerManuallyDisabled = false
 
     /**
+     * Set to true when the user explicitly activates the speaker via [setAudioDevice] or
+     * [toggleSpeaker]. Distinguishes user intent from system-triggered speaker switches
+     * (e.g. OEM proximity features that call setSpeakerphoneOn without user action).
+     */
+    private var isSpeakerUserActivated = false
+
+    /**
+     * Guards against countering a system-triggered speaker switch more than once per call.
+     * After the first counter-response the system is allowed to win to avoid a routing loop.
+     */
+    private var hasCounteredSystemSpeaker = false
+
+    /**
      * Prevents automatic speaker enforcement if the call originally started as audio-only.
      * This ensures mid-call video upgrades from the remote party do not force the speaker on.
      */
@@ -298,12 +311,25 @@ class PhoneConnection internal constructor(
 
     /**
      * Handles audio routing changes for Android versions below API 34.
+     *
+     * Includes a one-shot counter for OEM features (e.g. Samsung EarHover) that call
+     * setSpeakerphoneOn(true) without user intent. On an audio-only call, the first
+     * unexpected SPEAKER transition is silently redirected back to EARPIECE. A second
+     * system-triggered SPEAKER is allowed through to prevent an infinite routing loop.
      */
     @Deprecated("Deprecated in Java")
     override fun onCallAudioStateChanged(state: CallAudioState?) {
         super.onCallAudioStateChanged(state)
         logger.d("Legacy audio state changed: $state")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+
+        if (!hasVideo && !isSpeakerUserActivated && state?.route == CallAudioState.ROUTE_SPEAKER && !hasCounteredSystemSpeaker) {
+            hasCounteredSystemSpeaker = true
+            logger.w("Unexpected SPEAKER on audio-only call — countering with EARPIECE (system-triggered, e.g. OEM EarHover)")
+            setAudioRoute(CallAudioState.ROUTE_EARPIECE)
+            directRouteAudioDevice(AudioDeviceType.EARPIECE)
+            return
+        }
 
         val audioDevices = state?.supportedRouteMask?.let(::mapSupportedRoutes) ?: emptyList()
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = audioDevices))
@@ -423,6 +449,7 @@ class PhoneConnection internal constructor(
         logger.i("Setting audio device: $device for callId: $callId")
 
         isSpeakerManuallyDisabled = device.type != AudioDeviceType.SPEAKER
+        if (device.type == AudioDeviceType.SPEAKER) isSpeakerUserActivated = true
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val deviceId = device.id

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -267,8 +267,7 @@ class PhoneConnection internal constructor(
      */
     private fun onTimeoutTriggered() {
         logger.w("Timeout reached for callId: $callId")
-        setDisconnected(DisconnectCause(DisconnectCause.CANCELED, "Timeout reached"))
-        onDisconnect()
+        terminateWithCause(DisconnectCause(DisconnectCause.CANCELED, "Timeout reached"))
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -171,7 +171,7 @@ class PhoneConnection internal constructor(
     override fun onReject() {
         logger.i("Rejecting call: $callId")
         super.onReject()
-        setDisconnected(DisconnectCause(DisconnectCause.REJECTED))
+        terminateWithCause(DisconnectCause(DisconnectCause.REJECTED))
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -195,15 +195,21 @@ class PhoneConnection internal constructor(
 
     // Resets system audio state after call ends to prevent speaker/mic state from
     // bleeding into the next call session. Mirrors deactivateAudio() in StandaloneCallService.
+    //
+    // Order matters per Android docs:
+    //   1. clearCommunicationDevice() while still owning the audio mode priority
+    //   2. setMode(MODE_NORMAL) to release mode ownership
+    //   3. setSpeakerphoneOn(false) as MIUI fallback (MODE_IN_CALL ignores clearCommunicationDevice)
+    //   4. setMicrophoneMute(false) defensive reset
     private fun resetSystemAudioState() {
         try {
             val sysAm = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
-            @Suppress("DEPRECATION")
-            sysAm.isSpeakerphoneOn = false
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 sysAm.clearCommunicationDevice()
             }
             sysAm.mode = android.media.AudioManager.MODE_NORMAL
+            @Suppress("DEPRECATION")
+            sysAm.isSpeakerphoneOn = false
             sysAm.isMicrophoneMute = false
             logger.d("System audio state reset on disconnect for callId: $callId")
         } catch (e: Exception) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -50,19 +50,6 @@ class PhoneConnection internal constructor(
     private var isSpeakerManuallyDisabled = false
 
     /**
-     * Set to true when the user explicitly activates the speaker via [setAudioDevice] or
-     * [toggleSpeaker]. Distinguishes user intent from system-triggered speaker switches
-     * (e.g. OEM proximity features that call setSpeakerphoneOn without user action).
-     */
-    private var isSpeakerUserActivated = false
-
-    /**
-     * Guards against countering a system-triggered speaker switch more than once per call.
-     * After the first counter-response the system is allowed to win to avoid a routing loop.
-     */
-    private var hasCounteredSystemSpeaker = false
-
-    /**
      * Prevents automatic speaker enforcement if the call originally started as audio-only.
      * This ensures mid-call video upgrades from the remote party do not force the speaker on.
      */
@@ -311,25 +298,12 @@ class PhoneConnection internal constructor(
 
     /**
      * Handles audio routing changes for Android versions below API 34.
-     *
-     * Includes a one-shot counter for OEM features (e.g. Samsung EarHover) that call
-     * setSpeakerphoneOn(true) without user intent. On an audio-only call, the first
-     * unexpected SPEAKER transition is silently redirected back to EARPIECE. A second
-     * system-triggered SPEAKER is allowed through to prevent an infinite routing loop.
      */
     @Deprecated("Deprecated in Java")
     override fun onCallAudioStateChanged(state: CallAudioState?) {
         super.onCallAudioStateChanged(state)
         logger.d("Legacy audio state changed: $state")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
-
-        if (!hasVideo && !isSpeakerUserActivated && state?.route == CallAudioState.ROUTE_SPEAKER && !hasCounteredSystemSpeaker) {
-            hasCounteredSystemSpeaker = true
-            logger.w("Unexpected SPEAKER on audio-only call — countering with EARPIECE (system-triggered, e.g. OEM EarHover)")
-            setAudioRoute(CallAudioState.ROUTE_EARPIECE)
-            directRouteAudioDevice(AudioDeviceType.EARPIECE)
-            return
-        }
 
         val audioDevices = state?.supportedRouteMask?.let(::mapSupportedRoutes) ?: emptyList()
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = audioDevices))
@@ -449,7 +423,6 @@ class PhoneConnection internal constructor(
         logger.i("Setting audio device: $device for callId: $callId")
 
         isSpeakerManuallyDisabled = device.type != AudioDeviceType.SPEAKER
-        if (device.type == AudioDeviceType.SPEAKER) isSpeakerUserActivated = true
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val deviceId = device.id

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -186,10 +186,29 @@ class PhoneConnection internal constructor(
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
         audioManager.stopCallWaitingTone()
+        resetSystemAudioState()
 
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
         destroy()
+    }
+
+    // Resets system audio state after call ends to prevent speaker/mic state from
+    // bleeding into the next call session. Mirrors deactivateAudio() in StandaloneCallService.
+    private fun resetSystemAudioState() {
+        try {
+            val sysAm = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
+            @Suppress("DEPRECATION")
+            sysAm.isSpeakerphoneOn = false
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                sysAm.clearCommunicationDevice()
+            }
+            sysAm.mode = android.media.AudioManager.MODE_NORMAL
+            sysAm.isMicrophoneMute = false
+            logger.d("System audio state reset on disconnect for callId: $callId")
+        } catch (e: Exception) {
+            logger.w("Failed to reset system audio state on disconnect: ${e.message}")
+        }
     }
 
     /**
@@ -351,41 +370,15 @@ class PhoneConnection internal constructor(
 
     /**
      * Updates available audio destinations for API 34+.
-     *
-     * This method intercepts the initial hardware report to resolve the "Sticky Speaker State."
-     * On some devices, the Telecom Framework caches the last used route. By forcing the
-     * EARPIECE during the first load of an audio-only call, we override this behavior.
      */
     @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     override fun onAvailableCallEndpointsChanged(callEndpoints: List<CallEndpoint>) {
-        val isFirstLoad = availableCallEndpoints.isEmpty()
         super.onAvailableCallEndpointsChanged(callEndpoints)
         logger.d("Available call endpoints changed: $callEndpoints")
         availableCallEndpoints = callEndpoints
 
         val devices = callEndpoints.map(::mapEndpointToAudioDevice)
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = devices))
-
-        try {
-            /*
-             * Core Fix: Force EARPIECE on initialization for audio-only calls.
-             * By forcing the switch blindly on the first load, we preemptively correct
-             * any "sticky" speaker state without risking a crash.
-             */
-            if (isFirstLoad && !hasVideo) {
-                val earpiece = callEndpoints.firstOrNull { it.endpointType == CallEndpoint.TYPE_EARPIECE }
-                if (earpiece != null) {
-                    logger.i("Startup: Preemptively forcing EARPIECE to clear sticky state.")
-                    performEndpointChange(earpiece)
-                }
-            }
-        } catch (e: Exception) {
-            /*
-             * Defensive logging: Ensures the call remains active even if
-             * the platform-specific routing request fails.
-             */
-            logger.w("Failed to perform initial audio endpoint correction: ${e.message}", e)
-        }
 
         enforceVideoSpeakerLogic()
     }


### PR DESCRIPTION
## Problem

Two issues in `PhoneConnection.kt`:

1. `onReject()` called `setDisconnected()` directly, bypassing `terminateWithCause()`. This skipped the `onDisconnectCallback`/`destroy()` chain when Telecom initiated a system reject (DND, lock screen, notification action) — leaving the ringtone playing and connection in a broken state.

2. `onAvailableCallEndpointsChanged` contained a symptom-level workaround that force-switched to EARPIECE on the first endpoint report (API 34+) to patch a sticky speaker state at call start.

## Why the workaround is removed

The root cause is now fixed in `webtrit_phone` (WebTrit/webtrit_phone#1216): `CallMediaManager` calls `AndroidNativeAudioManagement.setAndroidAudioConfiguration()` with a preferred output order of `[bluetooth, wiredHeadset, earpiece, speakerphone]`. AudioSwitch uses this priority list when it activates during `getUserMedia` and selects earpiece automatically — making the Kotlin-side force-EARPIECE override redundant.

## Changes

### `PhoneConnection.kt`

**`onReject()`** — route through `terminateWithCause()` to match all other disconnect paths and run the full teardown chain.

**`onAvailableCallEndpointsChanged`** — remove the `isFirstLoad` + force-EARPIECE block.

## Test Plan

- [ ] Reject incoming call via system notification — verify ringtone stops and connection is cleaned up
- [ ] Reject incoming call via DND / lock screen — verify same behaviour
- [ ] Make an audio call, end it — verify next call starts on earpiece (no sticky state)
- [ ] Make a video call (auto-speaker), end it — verify next audio call starts on earpiece