### PR TITLE
fix(android): use applicationId for INTERNAL_BROADCAST permission

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -26,14 +26,14 @@
         Only components signed with the same key can send or receive these broadcasts.
     -->
     <permission
-        android:name="com.webtrit.callkeep.INTERNAL_BROADCAST"
+        android:name="${applicationId}.INTERNAL_BROADCAST"
         android:protectionLevel="signature" />
     <!--
         The app must also hold the permission it declares so that intra-app
         sendBroadcast(intent, permission) passes the receiver permission check,
         and registerReceiver(broadcastPermission) passes the sender permission check.
     -->
-    <uses-permission android:name="com.webtrit.callkeep.INTERNAL_BROADCAST" />
+    <uses-permission android:name="${applicationId}.INTERNAL_BROADCAST" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -126,7 +126,7 @@ class IncomingCallService :
                 addAction(IncomingCallRelease.IC_RELEASE_WITH_ANSWER.name)
             },
             exported = false,
-            permission = RELEASE_BROADCAST_PERMISSION,
+            permission = releaseBroadcastPermission(this),
         )
 
         CallkeepCore.instance.addConnectionEventListener(this)
@@ -444,7 +444,8 @@ class IncomingCallService :
         private const val INDEPENDENT_SERVICE_TIMEOUT_MS = 60_000L
         private const val WAKELOCK_TIMEOUT_MS = 30_000L
         private const val WAKELOCK_TAG = "com.webtrit.callkeep:IncomingCallWakeLock"
-        private const val RELEASE_BROADCAST_PERMISSION = "com.webtrit.callkeep.INTERNAL_BROADCAST"
+
+        private fun releaseBroadcastPermission(context: Context) = "${context.packageName}.INTERNAL_BROADCAST"
 
         @Volatile
         var isRunning = false
@@ -486,7 +487,7 @@ class IncomingCallService :
             // sendInternalBroadcast() uses setPackage(packageName) + FLAG_RECEIVER_FOREGROUND,
             // so it crosses the :callkeep_core → main-process boundary safely and is
             // delivered only to this app.
-            context.sendInternalBroadcast(type.name, permission = RELEASE_BROADCAST_PERMISSION)
+            context.sendInternalBroadcast(type.name, permission = releaseBroadcastPermission(context))
             Log.d(TAG, "Release action $type initiated via broadcast.")
         }
     }


### PR DESCRIPTION
## Summary

- Replaces hardcoded `com.webtrit.callkeep.INTERNAL_BROADCAST` with `${applicationId}.INTERNAL_BROADCAST` in `AndroidManifest.xml`
- Replaces `const val RELEASE_BROADCAST_PERMISSION` with `fun releaseBroadcastPermission(context: Context)` in `IncomingCallService.kt` to read `context.packageName` at runtime

## Problem

Any two white-label apps built from this plugin cannot coexist on the same Android device.
Android rejects the second install with `INSTALL_FAILED_DUPLICATE_PERMISSION` because both apps declare the same custom permission (`com.webtrit.callkeep.INTERNAL_BROADCAST`) — Android only allows one package to own a given custom permission.

## Solution

Use `${applicationId}` in the manifest (substituted by AGP at build time) and `context.packageName` in Kotlin so each app gets its own unique permission name (e.g. `com.webtrit.app.INTERNAL_BROADCAST`, `com.portaone.portaphonepbx2.INTERNAL_BROADCAST`).

## Test plan

- [ ] Build two white-label APKs with different `applicationId` values
- [ ] Install both on the same device — verify no `INSTALL_FAILED_DUPLICATE_PERMISSION`
- [ ] Verify incoming call flow works correctly (broadcast receiver still receives IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE)