### PR TITLE
fix(android): improve vibration reliability in vibrate mode (WT-1460)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -121,7 +121,7 @@ class AudioManager(
 
     private fun startVibration() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator?.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, 0))
+            vibrator?.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0))
         } else {
             @Suppress("DEPRECATION")
             vibrator?.vibrate(VIBRATION_PATTERN, 0)
@@ -225,7 +225,7 @@ class AudioManager(
     companion object {
         private const val TAG = "AudioManager"
 
-        // delay 0ms, vibrate 1s, pause 1s, repeat
         private val VIBRATION_PATTERN = longArrayOf(0, 1000, 1000)
+        private val VIBRATION_AMPLITUDES = intArrayOf(0, 255, 0)
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -98,9 +98,16 @@ class AudioManager(
      * The Ringtone API plays through the ringtone audio stream, which is muted in
      * RINGER_MODE_VIBRATE. In that case we skip the ringtone and start a repeating
      * vibration pattern directly so the user is notified of the incoming call.
+     *
+     * Some OEM ROMs (e.g. MIUI/HyperOS on Xiaomi) report vibrate mode as
+     * RINGER_MODE_NORMAL with STREAM_RING volume = 0 instead of RINGER_MODE_VIBRATE.
+     * In that case Ringtone.play() runs silently and no vibration is triggered.
+     * We detect this by checking stream volume and treat it as vibrate mode.
      */
     fun startRingtone(ringtoneSound: String?) {
         ringtone?.stop()
+        val ringVolume = audioManager.getStreamVolume(android.media.AudioManager.STREAM_RING)
+        Log.i(TAG, "startRingtone: ringerMode=${audioManager.ringerMode}, ringVolume=$ringVolume, vibratorAvailable=${vibrator != null}")
         when (audioManager.ringerMode) {
             android.media.AudioManager.RINGER_MODE_VIBRATE -> {
                 ringtone = null
@@ -108,9 +115,15 @@ class AudioManager(
             }
 
             android.media.AudioManager.RINGER_MODE_NORMAL -> {
-                ringtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
-                ringtone?.setLoopingCompat(true)
-                ringtone?.play()
+                if (ringVolume == 0) {
+                    // OEM quirk: vibrate mode reported as NORMAL with zero ring volume
+                    ringtone = null
+                    startVibration()
+                } else {
+                    ringtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
+                    ringtone?.setLoopingCompat(true)
+                    ringtone?.play()
+                }
             }
 
             else -> {
@@ -120,11 +133,15 @@ class AudioManager(
     }
 
     private fun startVibration() {
+        if (vibrator == null) {
+            Log.w(TAG, "startVibration: vibrator is null, skipping")
+            return
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator?.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0))
+            vibrator.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0))
         } else {
             @Suppress("DEPRECATION")
-            vibrator?.vibrate(VIBRATION_PATTERN, 0)
+            vibrator.vibrate(VIBRATION_PATTERN, 0)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -137,8 +137,21 @@ class AudioManager(
             Log.w(TAG, "startVibration: vibrator is null, skipping")
             return
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val attrs =
+                android.os.VibrationAttributes
+                    .Builder()
+                    .setUsage(android.os.VibrationAttributes.USAGE_RINGTONE)
+                    .build()
+            vibrator.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0), attrs)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val attrs =
+                AudioAttributes
+                    .Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                    .build()
+            vibrator.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, VIBRATION_AMPLITUDES, 0), attrs)
         } else {
             @Suppress("DEPRECATION")
             vibrator.vibrate(VIBRATION_PATTERN, 0)


### PR DESCRIPTION
## Summary

- Use explicit max amplitude (`intArrayOf(0, 255, 0)`) in `VibrationEffect.createWaveform` so the vibration motor actually fires on devices that ignore DEFAULT_AMPLITUDE
- Pass `VibrationAttributes(USAGE_RINGTONE)` / `AudioAttributes(USAGE_NOTIFICATION_RINGTONE)` to `vibrator.vibrate()` so the OS background-vibration policy allows the call on Android 8+
- Detect the Xiaomi/MIUI quirk where `RINGER_MODE_NORMAL` + `STREAM_RING` volume = 0 actually means vibrate mode and start vibration instead of playing a silent ringtone

## Investigation notes

Tested on Xiaomi 25028RN03Y (Android 15, HyperOS). The device silently blocks `vibrator.vibrate()` from both the `:callkeep_core` process and the main process regardless of attributes. This is a system-level restriction in HyperOS that affects all third-party VoIP apps (confirmed with Telegram as well). The three commits in this PR fix real issues on other devices and OEMs; the HyperOS case requires the user to set Battery saver = No restrictions + Autostart = ON in system settings.

## Test plan

- [ ] Android device in vibrate mode (`RINGER_MODE_VIBRATE`) — incoming call should vibrate
- [ ] Android device in normal mode with ring volume > 0 — incoming call should play ringtone
- [ ] Xiaomi/MIUI device with ring volume = 0 reported as NORMAL mode — incoming call should vibrate
- [ ] Verify no regression on answer / decline / hangup flows