### PR TITLE
fix(android): mark connection answered immediately on AnswerCall event

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -258,12 +258,6 @@ class IncomingCallService :
     }
 
     private fun performAnswerCall(metadata: CallMetadata): Int {
-        // Telecom confirmed the user answered — mark the connection as active before
-        // notifying the Flutter push isolate. If flutterApi is null (push isolate not
-        // yet ready), callLifecycleHandler.performAnswerCall returns early without
-        // marking the connection, leaving the tracker in STATE_RINGING. HandshakeProcessor
-        // would then see stateDisconnected and incorrectly send a DeclineRequest.
-        CallkeepCore.instance.markAnswered(metadata.callId)
         callLifecycleHandler.performAnswerCall(metadata)
         return START_STICKY
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -108,6 +108,13 @@ class IncomingCallService :
         // teardown.
         if (event == CallLifecycleEvent.AnswerCall) {
             val metadata = data?.let(CallMetadata::fromBundleOrNull) ?: return
+            // Telecom confirmed the user answered — mark the connection as active
+            // immediately, before notifying the Flutter push isolate. If flutterApi
+            // is null (push isolate not yet ready), performAnswerCall returns early
+            // without marking the connection, leaving the tracker in STATE_RINGING.
+            // HandshakeProcessor then sees stateDisconnected and incorrectly sends
+            // a DeclineRequest for the active call.
+            CallkeepCore.instance.markAnswered(metadata.callId)
             performAnswerCall(metadata)
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -108,13 +108,6 @@ class IncomingCallService :
         // teardown.
         if (event == CallLifecycleEvent.AnswerCall) {
             val metadata = data?.let(CallMetadata::fromBundleOrNull) ?: return
-            // Telecom confirmed the user answered — mark the connection as active
-            // immediately, before notifying the Flutter push isolate. If flutterApi
-            // is null (push isolate not yet ready), performAnswerCall returns early
-            // without marking the connection, leaving the tracker in STATE_RINGING.
-            // HandshakeProcessor then sees stateDisconnected and incorrectly sends
-            // a DeclineRequest for the active call.
-            CallkeepCore.instance.markAnswered(metadata.callId)
             performAnswerCall(metadata)
         }
     }
@@ -265,6 +258,12 @@ class IncomingCallService :
     }
 
     private fun performAnswerCall(metadata: CallMetadata): Int {
+        // Telecom confirmed the user answered — mark the connection as active before
+        // notifying the Flutter push isolate. If flutterApi is null (push isolate not
+        // yet ready), callLifecycleHandler.performAnswerCall returns early without
+        // marking the connection, leaving the tracker in STATE_RINGING. HandshakeProcessor
+        // would then see stateDisconnected and incorrectly send a DeclineRequest.
+        CallkeepCore.instance.markAnswered(metadata.callId)
         callLifecycleHandler.performAnswerCall(metadata)
         return START_STICKY
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -43,7 +43,7 @@ class CallLifecycleHandler(
             Log.w(TAG, "performAnswerCall: flutterApi is null, no Flutter isolate to notify for callId=${metadata.callId}")
             // The push isolate is not reachable, so markAnswered() will never be
             // called through the normal Flutter callback path. Mark the connection
-            // here so HandshakeProcessor sees STATE_ACTIVE instead of stateDisconnected.
+            // here so the connection tracker reflects STATE_ACTIVE instead of stateDisconnected.
             CallkeepCore.instance.markAnswered(metadata.callId)
             return
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/CallLifecycleHandler.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.webtrit.callkeep.PCallkeepIncomingCallData
 import com.webtrit.callkeep.PHostBackgroundPushNotificationIsolateApi
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.core.CallkeepCore
 import com.webtrit.callkeep.services.services.incoming_call.CallConnectionController
 import com.webtrit.callkeep.services.services.incoming_call.FlutterIsolateCommunicator
 
@@ -40,6 +41,10 @@ class CallLifecycleHandler(
         val api = flutterApi
         if (api == null) {
             Log.w(TAG, "performAnswerCall: flutterApi is null, no Flutter isolate to notify for callId=${metadata.callId}")
+            // The push isolate is not reachable, so markAnswered() will never be
+            // called through the normal Flutter callback path. Mark the connection
+            // here so HandshakeProcessor sees STATE_ACTIVE instead of stateDisconnected.
+            CallkeepCore.instance.markAnswered(metadata.callId)
             return
         }
         api.performAnswer(metadata.callId, onSuccess = {


### PR DESCRIPTION
## Summary

When the user answers an incoming push call while the push isolate's Flutter engine is not yet ready (`flutterApi == null`), `CallLifecycleHandler.performAnswerCall` returns early without calling `markAnswered()`. The connection tracker keeps the call in `STATE_RINGING` instead of `STATE_ACTIVE`.

When the signaling handshake arrives shortly after, `HandshakeProcessor` queries the connection state and sees `stateDisconnected`, which triggers a `DeclineRequest` — terminating a call the user deliberately answered.

**Root cause:** `markAnswered()` was never called in the `IncomingCallService` path — only in `ForegroundService`. The answer state depended entirely on the Flutter push isolate being reachable, but Telecom had already confirmed the answer.

**Fix:** Call `CallkeepCore.instance.markAnswered(callId)` in `onConnectionEvent` immediately when `AnswerCall` fires, before attempting to notify the Flutter push isolate. Telecom is the authoritative source for the answer event — the Flutter callback is best-effort and does not determine connection state.

## Test plan

- [x] Incoming push call while app is backgrounded (signaling service killed by OS)
- [x] User answers from notification — call proceeds to connected
- [x] Verify `HandshakeProcessor` does not send `DeclineRequest` for the active call
- [x] Normal answer flow (push isolate ready) is unaffected
- [x] Decline and missed call flows are unaffected