### PR TITLE
fix(android): replace Call Declined notification with silent on missed/declined call (WT-1430)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -163,26 +163,6 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
             }
     }
 
-    fun buildReleaseNotification(): Notification {
-        val builder =
-            baseNotificationBuilder(
-                title = context.getString(R.string.incoming_call_declined_title),
-                text = context.getString(R.string.incoming_call_declined_text, callMetaData?.name),
-            ).apply {
-                setFullScreenIntent(null, false)
-                setTimeoutAfter(5_000)
-            }
-        return builder.build().apply {
-            flags = flags or NotificationCompat.FLAG_INSISTENT
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    fun updateToReleaseIncomingCallNotification() {
-        val meta = requireNotNull(callMetaData) { "Call metadata must be set before updating the notification." }
-        NotificationManagerCompat.from(context).notify(notificationId(meta.callId), buildReleaseNotification())
-    }
-
     companion object {
         const val TAG = "INCOMING_CALL_NOTIFICATION"
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -472,8 +472,6 @@ class IncomingCallService :
         // Stopping the service immediately would destroy the isolate, which can be critical if the signaling layer
         // still needs to be notified about the disconnection.
         // Instead, we initiate communication with the Flutter side and delay stopping the service to ensure a graceful shutdown.
-        // During this time, the notification is replaced with a special "release" notification
-        // using IncomingCallNotificationBuilder.buildReleaseNotification to inform the user that the call is being finalized.
         fun release(
             context: Context,
             type: IncomingCallRelease,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -56,9 +56,9 @@ class IncomingCallHandler(
     }
 
     /**
-     * Updates the notification based on call answer state:
-     *  - answered=true  -> release incoming-call notification (builder-specific behavior)
-     *  - answered=false -> mute: replace with a silent ongoing notification
+     * Replaces the ringing notification with a silent one regardless of answer state.
+     * The silent notification keeps the FGS alive while the signaling layer sends SIP BYE
+     * (answered=false) or while the active-call session takes over (answered=true).
      */
     @SuppressLint("MissingPermission")
     fun releaseIncomingCallNotification(answered: Boolean) {
@@ -66,11 +66,7 @@ class IncomingCallHandler(
             Log.w(TAG, "releaseIncomingCallNotification: no metadata (service not initialized), skipping")
             return
         }
-        if (answered) {
-            muteIncomingCallNotification()
-        } else {
-            notificationBuilder.updateToReleaseIncomingCallNotification()
-        }
+        muteIncomingCallNotification()
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/res/values/strings.xml
+++ b/webtrit_callkeep_android/android/src/main/res/values/strings.xml
@@ -14,7 +14,5 @@
     <string name="push_notification_missed_call_channel_description">Notification of missed calls</string>
     <string name="push_notification_foreground_call_service_title">Ongoing call</string>
     <string name="push_notification_foreground_call_service_description">This service keeps the call active in the background</string>
-    <string name="incoming_call_declined_title">Call Declined</string>
-    <string name="incoming_call_declined_text">Declined an incoming call from %1$s</string>
     <string name="incoming_call_connecting">Connecting…</string>
 </resources>


### PR DESCRIPTION
## Summary

- Removes the visible **Call Declined** notification that appeared for 5 seconds after a missed or declined call
- Replaces it with the existing `muteIncomingCallNotification()` path (silent FGS keepalive), which is already used for the answered case
- The server-side **Missed call** push (introduced in WT-1423) is now the sole user-visible notification

## Root cause

`IncomingCallHandler.releaseIncomingCallNotification(answered=false)` was calling `updateToReleaseIncomingCallNotification()`, which posted a "Call Declined" banner with `setTimeoutAfter(5_000)`. After WT-1423, this caused users to see two sequential notifications: **Call Declined** → **Missed call**.

## Change

`IncomingCallHandler.kt` — removed the `else` branch, both `answered=true` and `answered=false` now call `muteIncomingCallNotification()`.

The silent notification keeps the FGS alive while the signaling layer sends SIP BYE, then `stopTimeoutRunnable` stops the service and `onDestroy()` cleans up.
