### PR TITLE
fix(android): augment audio device list with wired headset during ringing (WT-1426)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -137,6 +137,10 @@ class PhoneConnection internal constructor(
             audioManager.startRingtone(metadata.ringtonePath)
         }
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            forceUpdateAudioState()
+        }
     }
 
     /**
@@ -279,7 +283,10 @@ class PhoneConnection internal constructor(
         logger.d("Legacy audio state changed: $state")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
 
-        val audioDevices = state?.supportedRouteMask?.let(::mapSupportedRoutes) ?: emptyList()
+        var audioDevices = state?.supportedRouteMask?.let(::mapSupportedRoutes) ?: emptyList()
+        if (audioDevices.none { it.type == AudioDeviceType.WIRED_HEADSET } && audioManager.isWiredHeadsetConnected()) {
+            audioDevices = audioDevices + AudioDevice(AudioDeviceType.WIRED_HEADSET)
+        }
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = audioDevices))
 
         val currentDevice = state?.route?.let(::mapRouteToAudioDevice) ?: AudioDevice(AudioDeviceType.UNKNOWN)
@@ -357,7 +364,10 @@ class PhoneConnection internal constructor(
         logger.d("Available call endpoints changed: $callEndpoints")
         availableCallEndpoints = callEndpoints
 
-        val devices = callEndpoints.map(::mapEndpointToAudioDevice)
+        var devices = callEndpoints.map(::mapEndpointToAudioDevice)
+        if (devices.none { it.type == AudioDeviceType.WIRED_HEADSET } && audioManager.isWiredHeadsetConnected()) {
+            devices = devices + AudioDevice(AudioDeviceType.WIRED_HEADSET)
+        }
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = devices))
 
         enforceVideoSpeakerLogic()


### PR DESCRIPTION
## Summary

- Android Telecom does not include wired headset in the available device list during the RINGING state for self-managed connections — only earpiece and speaker are reported
- As a result, Flutter receives `[earpiece, speaker]` while ringing; CallKeep routes audio to earpiece while WebRTC independently claims the wired headset, causing split audio
- Augment the Telecom-reported list in both legacy (`onCallAudioStateChanged`) and modern (`onAvailableCallEndpointsChanged`) paths by checking `AudioManager` directly when wired headset is missing
- Also call `forceUpdateAudioState()` in `onShowIncomingCallUi()` for the legacy path to handle cases where Telecom has not fired `onCallAudioStateChanged` yet during ringing

## Test plan

- [ ] Connect wired headset, receive incoming call — verify wired headset appears in audio device list during ringing
- [ ] Answer call — verify audio routes to wired headset
- [ ] Repeat without headset — verify normal earpiece/speaker behavior unchanged
- [ ] Verify on Android < 14 (legacy path) and Android 14+ (modern path)

