### PR TITLE
fix(android): route ringtone through headset when connected (WT-1426)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -81,6 +81,28 @@ class AudioManager(
     fun isBluetoothConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
 
     /**
+     * Returns true if any headset is reachable for communication audio — wired (with or without
+     * mic) or Bluetooth (A2DP or SCO). Used to decide whether the ringtone should follow the
+     * communication audio path instead of the default ring stream.
+     *
+     * BT SCO is often not yet connected at ringtone-start time; checking A2DP as well means we
+     * catch the headset before SCO is established and let Android re-route the track once SCO
+     * comes up.
+     */
+    private fun isHeadsetAvailable(): Boolean {
+        val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+        val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        return inputs.any {
+            it.type == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+                it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+        } ||
+            outputs.any {
+                it.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
+                    it.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+            }
+    }
+
+    /**
      * Check if the speakerphone is currently on.
      *
      * @return True if the speakerphone is on, false otherwise.
@@ -120,7 +142,24 @@ class AudioManager(
                     ringtone = null
                     startVibration()
                 } else {
-                    ringtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
+                    val r = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
+                    val headsetAvailable = isHeadsetAvailable()
+                    Log.i(TAG, "startRingtone: headsetAvailable=$headsetAvailable")
+                    if (headsetAvailable) {
+                        // STREAM_RING routes to speaker in MODE_RINGTONE even when a headset is
+                        // connected, while WebRTC audio independently uses the headset — causing
+                        // split audio. Using USAGE_VOICE_COMMUNICATION_SIGNALLING routes the
+                        // ringtone through the same communication path as WebRTC, so Android
+                        // re-routes it to the headset once BT SCO connects or immediately for
+                        // wired headsets.
+                        r.audioAttributes =
+                            AudioAttributes
+                                .Builder()
+                                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                                .build()
+                    }
+                    ringtone = r
                     ringtone?.setLoopingCompat(true)
                     ringtone?.play()
                 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -67,11 +67,18 @@ class AudioManager(
     fun isSupportSpeakerphone(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER)
 
     /**
-     * Check if a wired headset is connected.
+     * Check if a wired headset (with mic) is connected.
      *
      * @return True if a wired headset is connected, false otherwise.
      */
     fun isWiredHeadsetConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_WIRED_HEADSET)
+
+    /**
+     * Check if wired headphones (output-only, no mic) are connected.
+     *
+     * @return True if wired headphones are connected, false otherwise.
+     */
+    private fun isWiredHeadphonesConnected(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_WIRED_HEADPHONES)
 
     /**
      * Check if a Bluetooth headset is connected via SCO (active call audio profile).
@@ -115,7 +122,9 @@ class AudioManager(
     fun startRingtone(ringtoneSound: String?) {
         ringtone?.stop()
         val ringVolume = audioManager.getStreamVolume(android.media.AudioManager.STREAM_RING)
-        Log.i(TAG, "startRingtone: ringerMode=${audioManager.ringerMode}, ringVolume=$ringVolume, vibratorAvailable=${vibrator != null}")
+        val wiredConnected = isWiredHeadsetConnected() || isWiredHeadphonesConnected()
+        val btConnected = isBluetoothA2dpAvailable()
+        Log.i(TAG, "startRingtone: ringerMode=${audioManager.ringerMode}, ringVolume=$ringVolume, wired=$wiredConnected, btA2dp=$btConnected, vibratorAvailable=${vibrator != null}")
         when (audioManager.ringerMode) {
             android.media.AudioManager.RINGER_MODE_VIBRATE -> {
                 ringtone = null
@@ -129,6 +138,19 @@ class AudioManager(
                     startVibration()
                 } else {
                     val pendingRingtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
+                    if (wiredConnected || btConnected) {
+                        // Some OEMs (e.g. Samsung) route STREAM_RING to both speaker and
+                        // headset simultaneously in ringtone mode. Switching to USAGE_MEDIA
+                        // (STREAM_MUSIC) routes the ringtone exclusively to the connected
+                        // headset/BT device and avoids the dual-output behavior.
+                        Log.i(TAG, "startRingtone: headset detected, overriding to USAGE_MEDIA to prevent dual-output")
+                        pendingRingtone.audioAttributes =
+                            AudioAttributes
+                                .Builder()
+                                .setUsage(AudioAttributes.USAGE_MEDIA)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                                .build()
+                    }
                     ringtone = pendingRingtone
                     ringtone?.setLoopingCompat(true)
                     ringtone?.play()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -142,7 +142,7 @@ class AudioManager(
                     ringtone = null
                     startVibration()
                 } else {
-                    val r = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
+                    val pendingRingtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
                     val headsetAvailable = isHeadsetAvailable()
                     Log.i(TAG, "startRingtone: headsetAvailable=$headsetAvailable")
                     if (headsetAvailable) {
@@ -152,14 +152,14 @@ class AudioManager(
                         // ringtone through the same communication path as WebRTC, so Android
                         // re-routes it to the headset once BT SCO connects or immediately for
                         // wired headsets.
-                        r.audioAttributes =
+                        pendingRingtone.audioAttributes =
                             AudioAttributes
                                 .Builder()
                                 .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING)
                                 .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                                 .build()
                     }
-                    ringtone = r
+                    ringtone = pendingRingtone
                     ringtone?.setLoopingCompat(true)
                     ringtone?.play()
                 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -74,33 +74,19 @@ class AudioManager(
     fun isWiredHeadsetConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_WIRED_HEADSET)
 
     /**
-     * Check if a Bluetooth headset is connected.
+     * Check if a Bluetooth headset is connected via SCO (active call audio profile).
      *
-     * @return True if a Bluetooth headset is connected, false otherwise.
+     * @return True if a Bluetooth SCO headset is connected, false otherwise.
      */
     fun isBluetoothConnected(): Boolean = isInputDeviceConnected(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
 
     /**
-     * Returns true if any headset is reachable for communication audio — wired (with or without
-     * mic) or Bluetooth (A2DP or SCO). Used to decide whether the ringtone should follow the
-     * communication audio path instead of the default ring stream.
+     * Check if a Bluetooth device is available via A2DP (media profile).
      *
-     * BT SCO is often not yet connected at ringtone-start time; checking A2DP as well means we
-     * catch the headset before SCO is established and let Android re-route the track once SCO
-     * comes up.
+     * BT SCO is not established until the call becomes active; A2DP is connected earlier and
+     * indicates a BT headset is present before SCO comes up.
      */
-    private fun isHeadsetAvailable(): Boolean {
-        val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
-        val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
-        return inputs.any {
-            it.type == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
-                it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO
-        } ||
-            outputs.any {
-                it.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
-                    it.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
-            }
-    }
+    fun isBluetoothA2dpAvailable(): Boolean = isOutputDeviceConnected(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP)
 
     /**
      * Check if the speakerphone is currently on.
@@ -143,22 +129,6 @@ class AudioManager(
                     startVibration()
                 } else {
                     val pendingRingtone = ringtoneSound?.let { getRingtone(it) } ?: getDefaultRingtone()
-                    val headsetAvailable = isHeadsetAvailable()
-                    Log.i(TAG, "startRingtone: headsetAvailable=$headsetAvailable")
-                    if (headsetAvailable) {
-                        // STREAM_RING routes to speaker in MODE_RINGTONE even when a headset is
-                        // connected, while WebRTC audio independently uses the headset — causing
-                        // split audio. Using USAGE_VOICE_COMMUNICATION_SIGNALLING routes the
-                        // ringtone through the same communication path as WebRTC, so Android
-                        // re-routes it to the headset once BT SCO connects or immediately for
-                        // wired headsets.
-                        pendingRingtone.audioAttributes =
-                            AudioAttributes
-                                .Builder()
-                                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING)
-                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                                .build()
-                    }
                     ringtone = pendingRingtone
                     ringtone?.setLoopingCompat(true)
                     ringtone?.play()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -137,6 +137,35 @@ class PhoneConnection internal constructor(
             audioManager.startRingtone(metadata.ringtonePath)
         }
         dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            routeRingtoneToHeadsetLegacy()
+        }
+    }
+
+    /**
+     * Requests Telecom to route audio to a connected headset during the ringing phase.
+     *
+     * STREAM_RING defaults to speaker in MODE_RINGTONE even when a headset is connected,
+     * while WebRTC audio claims the headset independently — causing split audio. Calling
+     * setAudioRoute() routes the ring stream through Telecom's audio routing so both
+     * ringtone and WebRTC audio reach the same output device.
+     *
+     * BT A2DP is checked instead of BT SCO because SCO is not established until the call
+     * becomes active; A2DP indicates a BT headset is present during ringing.
+     */
+    private fun routeRingtoneToHeadsetLegacy() {
+        when {
+            audioManager.isBluetoothConnected() || audioManager.isBluetoothA2dpAvailable() -> {
+                logger.d("routeRingtoneToHeadsetLegacy: routing to BLUETOOTH for callId: $callId")
+                setAudioRoute(CallAudioState.ROUTE_BLUETOOTH)
+            }
+
+            audioManager.isWiredHeadsetConnected() -> {
+                logger.d("routeRingtoneToHeadsetLegacy: routing to WIRED_HEADSET for callId: $callId")
+                setAudioRoute(CallAudioState.ROUTE_WIRED_HEADSET)
+            }
+        }
     }
 
     /**
@@ -360,7 +389,27 @@ class PhoneConnection internal constructor(
         val devices = callEndpoints.map(::mapEndpointToAudioDevice)
         dispatcher(CallMediaEvent.AudioDevicesUpdate, metadata.copy(audioDevices = devices))
 
+        routeRingtoneToHeadsetModern(callEndpoints)
         enforceVideoSpeakerLogic()
+    }
+
+    /**
+     * Auto-selects a headset endpoint during the ringing phase on API 34+.
+     *
+     * Telecom may deliver the headset endpoint asynchronously after [onShowIncomingCallUi].
+     * Reacting here ensures the route is applied even when endpoints arrive after ringing starts.
+     * Only acts during STATE_RINGING to avoid disrupting an already active call.
+     */
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun routeRingtoneToHeadsetModern(callEndpoints: List<CallEndpoint>) {
+        if (state != STATE_RINGING) return
+        val headsetEndpoint =
+            callEndpoints.firstOrNull {
+                it.endpointType == CallEndpoint.TYPE_BLUETOOTH ||
+                    it.endpointType == CallEndpoint.TYPE_WIRED_HEADSET
+            } ?: return
+        logger.d("routeRingtoneToHeadsetModern: switching to ${headsetEndpoint.endpointName} for callId: $callId")
+        performEndpointChange(headsetEndpoint)
     }
 
     /**


### PR DESCRIPTION
## Summary

- `STREAM_RING` routes to speaker in `MODE_RINGTONE` even when a wired or Bluetooth headset is connected, while WebRTC audio independently uses the headset — causing split audio: ringtone on speaker, call progress tones on headset
- Root cause: the `Ringtone` API uses ring audio policy (speaker), WebRTC uses communication audio policy (headset) — different routing paths
- Fix: in `AudioManager.startRingtone()`, when any headset is detected (wired, BT A2DP, or BT SCO), switch the ringtone `AudioAttributes` to `USAGE_VOICE_COMMUNICATION_SIGNALLING` so both ringtone and WebRTC follow the same communication audio path
- BT A2DP is checked explicitly because BT SCO is often not yet established at ringtone-start time; Android re-routes the track automatically once SCO connects

## Test plan

- [ ] Connect wired headset, receive incoming call — ringtone plays through headset, not speaker
- [ ] Connect BT headset, receive incoming call — ringtone plays through BT headset
- [ ] No headset connected — ringtone plays through speaker as normal
- [ ] Verify on both Android < 14 and Android 14+

Fixes: https://youtrack.portaone.com/issue/WT-1426