### PR TITLE
feat(android): native file logging for callkeep services

### DIFF
--- a/webtrit_callkeep/example/lib/bootstrap.dart
+++ b/webtrit_callkeep/example/lib/bootstrap.dart
@@ -77,6 +77,4 @@ void initializeLogs() {
       debugPrint('${record.stackTrace}');
     }
   });
-
-  WebtritCallkeepLogs().setLogsDelegate(CallkeepLogs());
 }

--- a/webtrit_callkeep/example/lib/features/actions/bloc/actions_cubit.dart
+++ b/webtrit_callkeep/example/lib/features/actions/bloc/actions_cubit.dart
@@ -429,18 +429,6 @@ class ActionsCubit extends Cubit<ActionsState>
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Logs
-  // ---------------------------------------------------------------------------
-
-  void toggleLogsDelegate() {
-    if (state.isLogsDelegateActive) {
-      emit(state.copyWith(isLogsDelegateActive: false).log(LogEntry.info('logs delegate: OFF')));
-    } else {
-      emit(state.copyWith(isLogsDelegateActive: true).log(LogEntry.info('logs delegate: ON')));
-    }
-  }
-
   @override
   void onLog(CallkeepLogType type, String tag, String message) {
     emit(state.log(LogEntry.event('[native/${type.name}] $tag: $message')));

--- a/webtrit_callkeep/example/lib/features/actions/bloc/actions_cubit.dart
+++ b/webtrit_callkeep/example/lib/features/actions/bloc/actions_cubit.dart
@@ -34,7 +34,6 @@ class ActionsCubit extends Cubit<ActionsState>
   @override
   Future<void> close() {
     _callkeep.setDelegate(null);
-    WebtritCallkeepLogs().setLogsDelegate(null);
     return super.close();
   }
 
@@ -436,10 +435,8 @@ class ActionsCubit extends Cubit<ActionsState>
 
   void toggleLogsDelegate() {
     if (state.isLogsDelegateActive) {
-      WebtritCallkeepLogs().setLogsDelegate(null);
       emit(state.copyWith(isLogsDelegateActive: false).log(LogEntry.info('logs delegate: OFF')));
     } else {
-      WebtritCallkeepLogs().setLogsDelegate(this);
       emit(state.copyWith(isLogsDelegateActive: true).log(LogEntry.info('logs delegate: ON')));
     }
   }

--- a/webtrit_callkeep/example/lib/features/actions/bloc/actions_state.dart
+++ b/webtrit_callkeep/example/lib/features/actions/bloc/actions_state.dart
@@ -33,7 +33,6 @@ class ActionsState {
     this.lines = const [],
     this.activeLineId,
     this.connections = const [],
-    this.isLogsDelegateActive = false,
     this.isRingbackPlaying = false,
   });
 
@@ -42,7 +41,6 @@ class ActionsState {
   final List<CallLine> lines;
   final String? activeLineId;
   final List<CallkeepConnection> connections;
-  final bool isLogsDelegateActive;
   final bool isRingbackPlaying;
 
   CallLine? get activeLine => lines.where((l) => l.id == activeLineId).firstOrNull;
@@ -56,7 +54,6 @@ class ActionsState {
     List<CallLine>? lines,
     String? activeLineId,
     List<CallkeepConnection>? connections,
-    bool? isLogsDelegateActive,
     bool? isRingbackPlaying,
   }) {
     return ActionsState(
@@ -65,7 +62,6 @@ class ActionsState {
       lines: lines ?? this.lines,
       activeLineId: activeLineId ?? this.activeLineId,
       connections: connections ?? this.connections,
-      isLogsDelegateActive: isLogsDelegateActive ?? this.isLogsDelegateActive,
       isRingbackPlaying: isRingbackPlaying ?? this.isRingbackPlaying,
     );
   }
@@ -77,7 +73,6 @@ class ActionsState {
       lines: lines,
       activeLineId: null,
       connections: connections,
-      isLogsDelegateActive: isLogsDelegateActive,
       isRingbackPlaying: isRingbackPlaying,
     );
   }

--- a/webtrit_callkeep/example/lib/features/actions/view/actions_screen.dart
+++ b/webtrit_callkeep/example/lib/features/actions/view/actions_screen.dart
@@ -524,18 +524,6 @@ class _HelperDrawer extends StatelessWidget {
                       _Btn('Open Settings', cubit.openSettings),
                     ],
                   ),
-
-                  // --- Native Logs ---
-                  _Section(
-                    title: 'Native Logs',
-                    children: [
-                      _ToggleBtn(
-                        label: state.isLogsDelegateActive ? 'Logs: ON' : 'Logs: OFF',
-                        active: state.isLogsDelegateActive,
-                        onPressed: cubit.toggleLogsDelegate,
-                      ),
-                    ],
-                  ),
                 ],
               ),
             ),

--- a/webtrit_callkeep/lib/src/webtrit_callkeep_logs.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_logs.dart
@@ -20,8 +20,8 @@ class WebtritCallkeepLogs {
   /// Sets the logs delegate.
   /// [CallkeepLogsDelegate] needs to be implemented to receive logs.
   ///
-  /// Deprecated: pass [CallkeepAndroidOptions.logFilePath] to [Callkeep.setUp] instead.
-  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
+  /// Deprecated: pass [CallkeepAndroidOptions.nativeLogFilePath] to [Callkeep.setUp] instead.
+  @Deprecated('Use CallkeepAndroidOptions.nativeLogFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {
     if (kIsWeb || !Platform.isAndroid) {
       return;

--- a/webtrit_callkeep/lib/src/webtrit_callkeep_logs.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_logs.dart
@@ -19,11 +19,15 @@ class WebtritCallkeepLogs {
 
   /// Sets the logs delegate.
   /// [CallkeepLogsDelegate] needs to be implemented to receive logs.
+  ///
+  /// Deprecated: pass [CallkeepAndroidOptions.logFilePath] to [Callkeep.setUp] instead.
+  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {
     if (kIsWeb || !Platform.isAndroid) {
       return;
     }
 
+    // ignore: deprecated_member_use
     WebtritCallkeepPlatform.instance.setLogsDelegate(delegate);
   }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -416,6 +416,8 @@ data class PAndroidOptions(
      * automatically disconnected. When null the native default is used.
      */
     val outgoingCallTimeoutMs: Long? = null,
+    /** Absolute path to a file where native logs will be written directly. */
+    val logFilePath: String? = null,
 ) {
     companion object {
         fun fromList(pigeonVar_list: List<Any?>): PAndroidOptions {
@@ -424,7 +426,8 @@ data class PAndroidOptions(
             val incomingCallFullScreen = pigeonVar_list[2] as Boolean?
             val incomingCallTimeoutMs = pigeonVar_list[3] as Long?
             val outgoingCallTimeoutMs = pigeonVar_list[4] as Long?
-            return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen, incomingCallTimeoutMs, outgoingCallTimeoutMs)
+            val logFilePath = pigeonVar_list[5] as String?
+            return PAndroidOptions(ringtoneSound, ringbackSound, incomingCallFullScreen, incomingCallTimeoutMs, outgoingCallTimeoutMs, logFilePath)
         }
     }
 
@@ -435,6 +438,7 @@ data class PAndroidOptions(
             incomingCallFullScreen,
             incomingCallTimeoutMs,
             outgoingCallTimeoutMs,
+            logFilePath,
         )
 
     override fun equals(other: Any?): Boolean {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -101,7 +101,6 @@ class Log(
                     fos.flush()
                     fos.fd.sync()
                 }
-                AndroidLog.d(GLOBAL_PREFIX, "writeToFile: ok size=${File(path).length()}")
             } catch (e: Exception) {
                 AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
             }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -71,6 +71,8 @@ class Log(
             performSystemLog(type, prefixedTag, message, throwable)
         }
 
+        private fun nativeLogFilePath(): String? = logFilePath?.let { if (it.endsWith(".log")) it.dropLast(4) + "_native.log" else "$it.native" }
+
         @Synchronized
         private fun writeToFile(
             type: PLogTypeEnum,
@@ -78,8 +80,10 @@ class Log(
             message: String,
             throwable: Throwable?,
         ) {
-            val path = logFilePath ?: return
+            val path = nativeLogFilePath() ?: return
             try {
+                val file = File(path)
+                LogFileRotator.rotateIfNeeded(file)
                 val level =
                     when (type) {
                         PLogTypeEnum.DEBUG -> "D"
@@ -96,7 +100,7 @@ class Log(
                         "$timestamp $level $tag: $message\n"
                     }
                 val bytes = line.toByteArray(Charsets.UTF_8)
-                FileOutputStream(File(path), true).use { fos ->
+                FileOutputStream(file, true).use { fos ->
                     fos.write(bytes)
                     fos.flush()
                     fos.fd.sync()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -71,7 +71,7 @@ class Log(
             message: String,
             throwable: Throwable? = null,
         ) {
-            if (nativeLogFilePath() != null) {
+            if (logFilePath != null) {
                 writeToFile(type, tag, message, throwable)
             } else {
                 // logFilePath not yet configured — fall back to logcat directly
@@ -86,8 +86,6 @@ class Log(
             }
         }
 
-        private fun nativeLogFilePath(): String? = logFilePath?.let { if (it.endsWith(".log")) it.dropLast(4) + "_native.log" else "$it.native" }
-
         @Synchronized
         private fun writeToFile(
             type: PLogTypeEnum,
@@ -95,7 +93,7 @@ class Log(
             message: String,
             throwable: Throwable?,
         ) {
-            val path = nativeLogFilePath() ?: return
+            val path = logFilePath ?: return
             try {
                 val file = File(path)
                 LogFileRotator.rotateIfNeeded(file)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -3,7 +3,7 @@ package com.webtrit.callkeep.common
 import com.webtrit.callkeep.PDelegateLogsFlutterApi
 import com.webtrit.callkeep.PLogTypeEnum
 import java.io.File
-import java.io.FileWriter
+import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -95,7 +95,13 @@ class Log(
                     } else {
                         "$timestamp $level $tag: $message\n"
                     }
-                FileWriter(File(path), true).use { it.write(line) }
+                val bytes = line.toByteArray(Charsets.UTF_8)
+                FileOutputStream(File(path), true).use { fos ->
+                    fos.write(bytes)
+                    fos.flush()
+                    fos.fd.sync()
+                }
+                AndroidLog.d(GLOBAL_PREFIX, "writeToFile: ok size=${File(path).length()}")
             } catch (e: Exception) {
                 AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
             }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -123,7 +123,7 @@ class Log(
                     }
                 }
             } catch (e: Exception) {
-                AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
+                AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path", e)
             }
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -7,7 +7,7 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import android.util.Log as AndroidLog
+import android.util.Log as AndroidLog // used for error fallback and stack trace formatting
 
 /**
  * A logging utility that can be instantiated with a specific tag or used statically.
@@ -66,9 +66,7 @@ class Log(
             message: String,
             throwable: Throwable? = null,
         ) {
-            val prefixedTag = "$GLOBAL_PREFIX.$tag"
             writeToFile(type, tag, message, throwable)
-            performSystemLog(type, prefixedTag, message, throwable)
         }
 
         private fun nativeLogFilePath(): String? = logFilePath?.let { if (it.endsWith(".log")) it.dropLast(4) + "_native.log" else "$it.native" }
@@ -107,21 +105,6 @@ class Log(
                 }
             } catch (e: Exception) {
                 AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
-            }
-        }
-
-        private fun performSystemLog(
-            type: PLogTypeEnum,
-            tag: String,
-            message: String,
-            throwable: Throwable?,
-        ) {
-            when (type) {
-                PLogTypeEnum.DEBUG -> AndroidLog.d(tag, message, throwable)
-                PLogTypeEnum.INFO -> AndroidLog.i(tag, message, throwable)
-                PLogTypeEnum.WARN -> AndroidLog.w(tag, message, throwable)
-                PLogTypeEnum.ERROR -> AndroidLog.e(tag, message, throwable)
-                PLogTypeEnum.VERBOSE -> AndroidLog.v(tag, message, throwable)
             }
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -86,7 +86,6 @@ class Log(
             }
         }
 
-        @Synchronized
         private fun writeToFile(
             type: PLogTypeEnum,
             tag: String,
@@ -95,8 +94,8 @@ class Log(
         ) {
             val path = logFilePath ?: return
             try {
-                val file = File(path)
-                LogFileRotator.rotateIfNeeded(file)
+                val logFile = File(path)
+                val lockFile = File("$path.lock")
                 val level =
                     when (type) {
                         PLogTypeEnum.DEBUG -> "D"
@@ -113,12 +112,18 @@ class Log(
                         "$timestamp $level $tag: $message\n"
                     }
                 val bytes = line.toByteArray(Charsets.UTF_8)
-                FileOutputStream(file, true).use { fos ->
-                    fos.channel.lock().use {
-                        fos.write(bytes)
-                        fos.flush()
-                        if (type == PLogTypeEnum.ERROR || type == PLogTypeEnum.WARN) {
-                            fos.fd.sync()
+                // Lock on a dedicated lock file so rotation and write are atomic
+                // across OS processes (main + callkeep_core). FileChannel.lock() is
+                // OS-level and works across processes, unlike @Synchronized.
+                FileOutputStream(lockFile, true).use { lockFos ->
+                    lockFos.channel.lock().use {
+                        LogFileRotator.rotateIfNeeded(logFile)
+                        FileOutputStream(logFile, true).use { fos ->
+                            fos.write(bytes)
+                            fos.flush()
+                            if (type == PLogTypeEnum.ERROR || type == PLogTypeEnum.WARN) {
+                                fos.fd.sync()
+                            }
                         }
                     }
                 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -67,7 +67,7 @@ class Log(
             throwable: Throwable? = null,
         ) {
             val prefixedTag = "$GLOBAL_PREFIX.$tag"
-            writeToFile(type, prefixedTag, message, throwable)
+            writeToFile(type, tag, message, throwable)
             performSystemLog(type, prefixedTag, message, throwable)
         }
 
@@ -116,13 +116,12 @@ class Log(
             message: String,
             throwable: Throwable?,
         ) {
-            val msg = "$tag: $message"
             when (type) {
-                PLogTypeEnum.DEBUG -> AndroidLog.d(GLOBAL_PREFIX, msg, throwable)
-                PLogTypeEnum.INFO -> AndroidLog.i(GLOBAL_PREFIX, msg, throwable)
-                PLogTypeEnum.WARN -> AndroidLog.w(GLOBAL_PREFIX, msg, throwable)
-                PLogTypeEnum.ERROR -> AndroidLog.e(GLOBAL_PREFIX, msg, throwable)
-                PLogTypeEnum.VERBOSE -> AndroidLog.v(GLOBAL_PREFIX, msg, throwable)
+                PLogTypeEnum.DEBUG -> AndroidLog.d(tag, message, throwable)
+                PLogTypeEnum.INFO -> AndroidLog.i(tag, message, throwable)
+                PLogTypeEnum.WARN -> AndroidLog.w(tag, message, throwable)
+                PLogTypeEnum.ERROR -> AndroidLog.e(tag, message, throwable)
+                PLogTypeEnum.VERBOSE -> AndroidLog.v(tag, message, throwable)
             }
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -117,7 +117,9 @@ class Log(
                     fos.channel.lock().use {
                         fos.write(bytes)
                         fos.flush()
-                        fos.fd.sync()
+                        if (type == PLogTypeEnum.ERROR || type == PLogTypeEnum.WARN) {
+                            fos.fd.sync()
+                        }
                     }
                 }
             } catch (e: Exception) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -7,7 +7,7 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import android.util.Log as AndroidLog // used for error fallback and stack trace formatting
+import android.util.Log as AndroidLog
 
 /**
  * A logging utility that can be instantiated with a specific tag or used statically.
@@ -44,6 +44,11 @@ class Log(
             AndroidLog.d(GLOBAL_PREFIX, "setLogFilePath: $path")
         }
 
+        fun clearLogFilePath() {
+            logFilePath = null
+            AndroidLog.d(GLOBAL_PREFIX, "clearLogFilePath")
+        }
+
         fun initFromContext(context: android.content.Context) {
             val path = StorageDelegate.Logging.getLogFilePath(context)
             AndroidLog.d(GLOBAL_PREFIX, "initFromContext: getLogFilePath=$path pid=${android.os.Process.myPid()}")
@@ -66,7 +71,19 @@ class Log(
             message: String,
             throwable: Throwable? = null,
         ) {
-            writeToFile(type, tag, message, throwable)
+            if (nativeLogFilePath() != null) {
+                writeToFile(type, tag, message, throwable)
+            } else {
+                // logFilePath not yet configured — fall back to logcat directly
+                val prefixedTag = "$GLOBAL_PREFIX.$tag"
+                when (type) {
+                    PLogTypeEnum.DEBUG -> AndroidLog.d(prefixedTag, message, throwable)
+                    PLogTypeEnum.INFO -> AndroidLog.i(prefixedTag, message, throwable)
+                    PLogTypeEnum.WARN -> AndroidLog.w(prefixedTag, message, throwable)
+                    PLogTypeEnum.ERROR -> AndroidLog.e(prefixedTag, message, throwable)
+                    PLogTypeEnum.VERBOSE -> AndroidLog.v(prefixedTag, message, throwable)
+                }
+            }
         }
 
         private fun nativeLogFilePath(): String? = logFilePath?.let { if (it.endsWith(".log")) it.dropLast(4) + "_native.log" else "$it.native" }
@@ -99,9 +116,11 @@ class Log(
                     }
                 val bytes = line.toByteArray(Charsets.UTF_8)
                 FileOutputStream(file, true).use { fos ->
-                    fos.write(bytes)
-                    fos.flush()
-                    fos.fd.sync()
+                    fos.channel.lock().use {
+                        fos.write(bytes)
+                        fos.flush()
+                        fos.fd.sync()
+                    }
                 }
             } catch (e: Exception) {
                 AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
@@ -133,5 +152,11 @@ class Log(
             message: String,
             throwable: Throwable? = null,
         ) = log(PLogTypeEnum.WARN, tag, message, throwable)
+
+        @JvmStatic
+        fun v(
+            tag: String,
+            message: String,
+        ) = log(PLogTypeEnum.VERBOSE, tag, message)
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/Log.kt
@@ -1,10 +1,12 @@
 package com.webtrit.callkeep.common
 
-import android.os.Handler
-import android.os.Looper
 import com.webtrit.callkeep.PDelegateLogsFlutterApi
 import com.webtrit.callkeep.PLogTypeEnum
-import java.util.concurrent.CopyOnWriteArrayList
+import java.io.File
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import android.util.Log as AndroidLog
 
 /**
@@ -13,168 +15,132 @@ import android.util.Log as AndroidLog
 class Log(
     private val tag: String,
 ) {
-    /**
-     * Logs an error message using the instance tag.
-     */
     fun e(
         message: String,
         throwable: Throwable? = null,
-    ) = log(PLogTypeEnum.ERROR, tag, "$message\n$throwable")
+    ) = log(PLogTypeEnum.ERROR, tag, message, throwable)
 
-    /**
-     * Logs a debug message using the instance tag.
-     */
     fun d(message: String) = log(PLogTypeEnum.DEBUG, tag, message)
 
-    /**
-     * Logs an informational message using the instance tag.
-     */
     fun i(message: String) = log(PLogTypeEnum.INFO, tag, message)
 
-    /**
-     * Logs a verbose message using the instance tag.
-     */
     fun v(message: String) = log(PLogTypeEnum.VERBOSE, tag, message)
 
-    /**
-     * Logs a warning message using the instance tag.
-     */
     fun w(
         message: String,
         throwable: Throwable? = null,
-    ) = log(PLogTypeEnum.WARN, tag, "$message\n$throwable")
+    ) = log(PLogTypeEnum.WARN, tag, message, throwable)
 
     companion object {
-        /**
-         * Prefix prepended to all log tags to uniquely identify library-related log output.
-         */
-        private const val GLOBAL_PREFIX = "CK-"
+        private const val GLOBAL_PREFIX = "WebtritCallkeep"
 
-        /**
-         * Collection of registered Flutter API delegates that receive and process log events.
-         */
-        private var isolateDelegates = CopyOnWriteArrayList<PDelegateLogsFlutterApi>()
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 
-        /**
-         * Reusable handler tied to the main looper for dispatching logs to delegates.
-         */
-        private val mainHandler = Handler(Looper.getMainLooper())
+        @Volatile
+        private var logFilePath: String? = null
 
-        /**
-         * Adds a delegate to receive log messages.
-         */
-        @JvmStatic
-        fun add(delegate: PDelegateLogsFlutterApi) {
-            isolateDelegates.add(delegate)
+        fun setLogFilePath(path: String) {
+            logFilePath = path
+            AndroidLog.d(GLOBAL_PREFIX, "setLogFilePath: $path")
         }
 
-        /**
-         * Removes a delegate from receiving log messages.
-         */
-        @JvmStatic
-        fun remove(delegate: PDelegateLogsFlutterApi) {
-            isolateDelegates.remove(delegate)
+        fun initFromContext(context: android.content.Context) {
+            val path = StorageDelegate.Logging.getLogFilePath(context)
+            AndroidLog.d(GLOBAL_PREFIX, "initFromContext: getLogFilePath=$path pid=${android.os.Process.myPid()}")
+            if (path != null) {
+                logFilePath = path
+            }
         }
 
-        /**
-         * Internal dispatcher for log messages.
-         */
+        /** No-op: kept for API compatibility until delegate API is removed. */
+        @JvmStatic
+        fun add(delegate: PDelegateLogsFlutterApi) = Unit
+
+        /** No-op: kept for API compatibility until delegate API is removed. */
+        @JvmStatic
+        fun remove(delegate: PDelegateLogsFlutterApi) = Unit
+
         private fun log(
             type: PLogTypeEnum,
             tag: String,
             message: String,
             throwable: Throwable? = null,
         ) {
-            val prefixedTag = "$GLOBAL_PREFIX$tag"
-            if (isolateDelegates.isEmpty()) {
-                performSystemLog(type, prefixedTag, message, throwable)
-            } else {
-                dispatchToDelegate(type, prefixedTag, message, throwable)
+            val prefixedTag = "$GLOBAL_PREFIX.$tag"
+            writeToFile(type, prefixedTag, message, throwable)
+            performSystemLog(type, prefixedTag, message, throwable)
+        }
+
+        @Synchronized
+        private fun writeToFile(
+            type: PLogTypeEnum,
+            tag: String,
+            message: String,
+            throwable: Throwable?,
+        ) {
+            val path = logFilePath ?: return
+            try {
+                val level =
+                    when (type) {
+                        PLogTypeEnum.DEBUG -> "D"
+                        PLogTypeEnum.INFO -> "I"
+                        PLogTypeEnum.WARN -> "W"
+                        PLogTypeEnum.ERROR -> "E"
+                        PLogTypeEnum.VERBOSE -> "V"
+                    }
+                val timestamp = dateFormat.format(Date())
+                val line =
+                    if (throwable != null) {
+                        "$timestamp $level $tag: $message\n${AndroidLog.getStackTraceString(throwable)}\n"
+                    } else {
+                        "$timestamp $level $tag: $message\n"
+                    }
+                FileWriter(File(path), true).use { it.write(line) }
+            } catch (e: Exception) {
+                AndroidLog.e(GLOBAL_PREFIX, "writeToFile failed for $path: ${e.javaClass.simpleName}: ${e.message}")
             }
         }
 
-        /**
-         * Logs to the standard Android system log with proper throwable handling.
-         */
         private fun performSystemLog(
             type: PLogTypeEnum,
             tag: String,
             message: String,
             throwable: Throwable?,
         ) {
+            val msg = "$tag: $message"
             when (type) {
-                PLogTypeEnum.DEBUG -> AndroidLog.d(tag, message, throwable)
-                PLogTypeEnum.INFO -> AndroidLog.i(tag, message, throwable)
-                PLogTypeEnum.WARN -> AndroidLog.w(tag, message, throwable)
-                PLogTypeEnum.ERROR -> AndroidLog.e(tag, message, throwable)
-                PLogTypeEnum.VERBOSE -> AndroidLog.v(tag, message, throwable)
+                PLogTypeEnum.DEBUG -> AndroidLog.d(GLOBAL_PREFIX, msg, throwable)
+                PLogTypeEnum.INFO -> AndroidLog.i(GLOBAL_PREFIX, msg, throwable)
+                PLogTypeEnum.WARN -> AndroidLog.w(GLOBAL_PREFIX, msg, throwable)
+                PLogTypeEnum.ERROR -> AndroidLog.e(GLOBAL_PREFIX, msg, throwable)
+                PLogTypeEnum.VERBOSE -> AndroidLog.v(GLOBAL_PREFIX, msg, throwable)
             }
         }
 
-        /**
-         * Dispatches log events to the main thread for delegate consumption.
-         */
-        private fun dispatchToDelegate(
-            type: PLogTypeEnum,
-            tag: String,
-            message: String,
-            throwable: Throwable?,
-        ) = mainHandler.post { notifyFirstDelegate(type, tag, message, throwable) }
-
-        /**
-         * Notifies the primary registered isolate delegate.
-         */
-        private fun notifyFirstDelegate(
-            type: PLogTypeEnum,
-            tag: String,
-            message: String,
-            throwable: Throwable?,
-        ) {
-            val fullMessage =
-                if (throwable != null) {
-                    "$message\n${AndroidLog.getStackTraceString(throwable)}"
-                } else {
-                    message
-                }
-            isolateDelegates.firstOrNull()?.onLog(type, tag, fullMessage) {}
-        }
-
-        /**
-         * Logs an error message. (Static version)
-         */
         @JvmStatic
         fun e(
             tag: String,
             message: String,
             throwable: Throwable? = null,
-        ) = log(PLogTypeEnum.ERROR, tag, "$message\n$throwable")
+        ) = log(PLogTypeEnum.ERROR, tag, message, throwable)
 
-        /**
-         * Logs a debug message. (Static version)
-         */
         @JvmStatic
         fun d(
             tag: String,
             message: String,
         ) = log(PLogTypeEnum.DEBUG, tag, message)
 
-        /**
-         * Logs an informational message. (Static version)
-         */
         @JvmStatic
         fun i(
             tag: String,
             message: String,
         ) = log(PLogTypeEnum.INFO, tag, message)
 
-        /**
-         * Logs a warning message. (Static version)
-         */
         @JvmStatic
         fun w(
             tag: String,
             message: String,
             throwable: Throwable? = null,
-        ) = log(PLogTypeEnum.WARN, tag, "$message\n$throwable")
+        ) = log(PLogTypeEnum.WARN, tag, message, throwable)
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/LogFileRotator.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/LogFileRotator.kt
@@ -1,19 +1,26 @@
 package com.webtrit.callkeep.common
 
+import android.util.Log
 import java.io.File
 
 object LogFileRotator {
+    private const val TAG = "LogFileRotator"
     private const val MAX_SIZE_BYTES = 2 * 1024 * 1024L // 2 MB
 
     /**
      * Rotates [file] if it exceeds [MAX_SIZE_BYTES].
      * Renames it to <path>.1 (deleting any existing .1 first).
-     * Must be called inside a @Synchronized block (caller's responsibility).
+     * Must be called inside a file lock (caller's responsibility).
      */
     fun rotateIfNeeded(file: File) {
         if (!file.exists() || file.length() <= MAX_SIZE_BYTES) return
         val rotated = File("${file.path}.1")
-        if (rotated.exists()) rotated.delete()
-        file.renameTo(rotated)
+        if (rotated.exists() && !rotated.delete()) {
+            Log.w(TAG, "failed to delete old rotated log: ${rotated.path}")
+            return
+        }
+        if (!file.renameTo(rotated)) {
+            Log.w(TAG, "failed to rotate log file: ${file.path}")
+        }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/LogFileRotator.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/LogFileRotator.kt
@@ -1,0 +1,19 @@
+package com.webtrit.callkeep.common
+
+import java.io.File
+
+object LogFileRotator {
+    private const val MAX_SIZE_BYTES = 2 * 1024 * 1024L // 2 MB
+
+    /**
+     * Rotates [file] if it exceeds [MAX_SIZE_BYTES].
+     * Renames it to <path>.1 (deleting any existing .1 first).
+     * Must be called inside a @Synchronized block (caller's responsibility).
+     */
+    fun rotateIfNeeded(file: File) {
+        if (!file.exists() || file.length() <= MAX_SIZE_BYTES) return
+        val rotated = File("${file.path}.1")
+        if (rotated.exists()) rotated.delete()
+        file.renameTo(rotated)
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -142,8 +142,8 @@ object StorageDelegate {
             context: Context,
             path: String,
         ) {
-            val ok = sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
-            if (!ok) Log.w("WebtritCallkeep", "StorageDelegate: commit() failed for LOG_FILE_PATH")
+            val isCommitted = sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
+            if (!isCommitted) Log.w("WebtritCallkeep", "StorageDelegate: commit() failed for LOG_FILE_PATH")
         }
 
         fun getLogFilePath(context: Context): String? = sharedPreferences(context).getString(LOG_FILE_PATH, null)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -142,7 +142,8 @@ object StorageDelegate {
             context: Context,
             path: String,
         ) {
-            sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
+            val ok = sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
+            if (!ok) AndroidLog.w("WebtritCallkeep", "StorageDelegate: commit() failed for LOG_FILE_PATH")
         }
 
         fun getLogFilePath(context: Context): String? = sharedPreferences(context).getString(LOG_FILE_PATH, null)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -147,5 +147,10 @@ object StorageDelegate {
         }
 
         fun getLogFilePath(context: Context): String? = sharedPreferences(context).getString(LOG_FILE_PATH, null)
+
+        fun clearLogFilePath(context: Context) {
+            val isCommitted = sharedPreferences(context).edit().remove(LOG_FILE_PATH).commit()
+            if (!isCommitted) Log.w("WebtritCallkeep", "StorageDelegate: commit() failed clearing LOG_FILE_PATH")
+        }
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -143,7 +143,7 @@ object StorageDelegate {
             path: String,
         ) {
             val ok = sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
-            if (!ok) AndroidLog.w("WebtritCallkeep", "StorageDelegate: commit() failed for LOG_FILE_PATH")
+            if (!ok) Log.w("WebtritCallkeep", "StorageDelegate: commit() failed for LOG_FILE_PATH")
         }
 
         fun getLogFilePath(context: Context): String? = sharedPreferences(context).getString(LOG_FILE_PATH, null)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/StorageDelegate.kt
@@ -132,4 +132,19 @@ object StorageDelegate {
 
         fun getRegexPattern(context: Context): String? = sharedPreferences(context).getString(SMS_REGEX_PATTERN, null)
     }
+
+    object Logging {
+        private const val LOG_FILE_PATH = "LOG_FILE_PATH_KEY"
+
+        // commit() instead of apply() so the value is on disk before callkeep_core
+        // can start and call getLogFilePath() in initFromContext().
+        fun setLogFilePath(
+            context: Context,
+            path: String,
+        ) {
+            sharedPreferences(context).edit().putString(LOG_FILE_PATH, path).commit()
+        }
+
+        fun getLogFilePath(context: Context): String? = sharedPreferences(context).getString(LOG_FILE_PATH, null)
+    }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.parcelableArrayList
 import com.webtrit.callkeep.common.startForegroundServiceCompat
@@ -22,6 +23,7 @@ class ActiveCallService : Service() {
     override fun onCreate() {
         super.onCreate()
         ContextHolder.init(applicationContext)
+        Log.initFromContext(applicationContext)
     }
 
     override fun onStartCommand(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -157,6 +157,9 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
+        // Refresh log path from SharedPreferences — the main process may have updated it
+        // after this service was already running (each process has its own JVM copy).
+        Log.initFromContext(applicationContext)
         val metadata = CallMetadata.fromBundle(request.extras)
 
         // Check if a connection with the same call ID already exists.
@@ -220,6 +223,9 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
+        // Refresh log path from SharedPreferences — the main process may have updated it
+        // after this service was already running (each process has its own JVM copy).
+        Log.initFromContext(applicationContext)
         val metadata = CallMetadata.fromBundle(request.extras)
         Log.i(TAG, "onCreateIncomingConnection: entry callId=${metadata.callId} account=$connectionManagerPhoneAccount")
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -48,6 +48,7 @@ class PhoneConnectionService : ConnectionService() {
         // Initialize ContextHolder for the :callkeep_core process. Each OS process has its own
         // JVM, so ContextHolder.init() called in the main process has no effect here.
         ContextHolder.init(applicationContext)
+        Log.initFromContext(applicationContext)
         // Initialize AssetCacheManager for the :callkeep_core process so that
         // PhoneConnection.onShowIncomingCallUi() can resolve the custom ringtone asset
         // path via AssetCacheManager.getAsset(). Without this, AssetCacheManager.getAsset()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -157,9 +157,6 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
-        // Refresh log path from SharedPreferences — the main process may have updated it
-        // after this service was already running (each process has its own JVM copy).
-        Log.initFromContext(applicationContext)
         val metadata = CallMetadata.fromBundle(request.extras)
 
         // Check if a connection with the same call ID already exists.
@@ -223,9 +220,6 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
-        // Refresh log path from SharedPreferences — the main process may have updated it
-        // after this service was already running (each process has its own JVM copy).
-        Log.initFromContext(applicationContext)
         val metadata = CallMetadata.fromBundle(request.extras)
         Log.i(TAG, "onCreateIncomingConnection: entry callId=${metadata.callId} account=$connectionManagerPhoneAccount")
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -40,7 +40,7 @@ import com.webtrit.callkeep.managers.AudioManager as CallkeepAudioManager
  * that [PhoneConnectionService] produces in the Telecom path. This means [ForegroundService]
  * and the Flutter layer do not need to be aware of which path is active.
  *
- * The service runs in the `:callkeep_core` process, mirroring [PhoneConnectionService].
+ * The service runs in the main process (no `android:process` in the manifest).
  * It is started as a foreground service on the first incoming call and stopped when all
  * calls have ended or a teardown command is received.
  */
@@ -73,12 +73,13 @@ class StandaloneCallService : Service() {
         super.onCreate()
         ContextHolder.init(applicationContext)
         AssetCacheManager.init(applicationContext)
+        Log.initFromContext(applicationContext)
         // Register notification channels here as well as in ForegroundService.setUp().
-        // StandaloneCallService runs in the :callkeep_core process and may start before
-        // setUp() is invoked from the Flutter layer (e.g. when SyncConnectionState is
-        // dispatched during app startup). Without this call, startForeground() would
-        // crash with CannotPostForegroundServiceNotificationException because the
-        // channel does not yet exist in the system.
+        // This service may start before setUp() is invoked from the Flutter layer
+        // (e.g. when SyncConnectionState is dispatched during app startup). Without this
+        // call, startForeground() would crash with
+        // CannotPostForegroundServiceNotificationException because the channel does not
+        // yet exist in the system.
         NotificationChannelManager.registerNotificationChannels(applicationContext)
         isRunning = true
         // Do NOT call promoteToForeground() here.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -247,10 +247,15 @@ class ForegroundService :
             options.android.incomingCallFullScreen?.let { StorageDelegate.IncomingCall.setFullScreen(baseContext, it) }
             options.android.incomingCallTimeoutMs?.let { StorageDelegate.Timeout.setIncomingCallTimeoutMs(baseContext, it) }
             options.android.outgoingCallTimeoutMs?.let { StorageDelegate.Timeout.setOutgoingCallTimeoutMs(baseContext, it) }
-            options.android.logFilePath?.let {
-                StorageDelegate.Logging.setLogFilePath(baseContext, it)
-                Log.setLogFilePath(it)
-                logger.i("applySetupOptions: native logging initialized path=$it")
+            val logFilePath = options.android.logFilePath
+            if (logFilePath != null) {
+                StorageDelegate.Logging.setLogFilePath(baseContext, logFilePath)
+                Log.setLogFilePath(logFilePath)
+                logger.i("applySetupOptions: native logging initialized path=$logFilePath")
+            } else {
+                StorageDelegate.Logging.clearLogFilePath(baseContext)
+                Log.clearLogFilePath()
+                logger.i("applySetupOptions: native logging disabled")
             }
         }.onFailure { Log.w("CallKeep", "Android options init failed: ${it.message}", it) }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -247,15 +247,10 @@ class ForegroundService :
             options.android.incomingCallFullScreen?.let { StorageDelegate.IncomingCall.setFullScreen(baseContext, it) }
             options.android.incomingCallTimeoutMs?.let { StorageDelegate.Timeout.setIncomingCallTimeoutMs(baseContext, it) }
             options.android.outgoingCallTimeoutMs?.let { StorageDelegate.Timeout.setOutgoingCallTimeoutMs(baseContext, it) }
-            val logFilePath = options.android.logFilePath
-            if (logFilePath != null) {
-                StorageDelegate.Logging.setLogFilePath(baseContext, logFilePath)
-                Log.setLogFilePath(logFilePath)
-                logger.i("applySetupOptions: native logging initialized path=$logFilePath")
-            } else {
-                StorageDelegate.Logging.clearLogFilePath(baseContext)
-                Log.clearLogFilePath()
-                logger.i("applySetupOptions: native logging disabled")
+            options.android.logFilePath?.let {
+                StorageDelegate.Logging.setLogFilePath(baseContext, it)
+                Log.setLogFilePath(it)
+                logger.i("applySetupOptions: native logging initialized path=$it")
             }
         }.onFailure { Log.w("CallKeep", "Android options init failed: ${it.message}", it) }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -247,6 +247,11 @@ class ForegroundService :
             options.android.incomingCallFullScreen?.let { StorageDelegate.IncomingCall.setFullScreen(baseContext, it) }
             options.android.incomingCallTimeoutMs?.let { StorageDelegate.Timeout.setIncomingCallTimeoutMs(baseContext, it) }
             options.android.outgoingCallTimeoutMs?.let { StorageDelegate.Timeout.setOutgoingCallTimeoutMs(baseContext, it) }
+            options.android.logFilePath?.let {
+                StorageDelegate.Logging.setLogFilePath(baseContext, it)
+                Log.setLogFilePath(it)
+                logger.i("applySetupOptions: native logging initialized path=$it")
+            }
         }.onFailure { Log.w("CallKeep", "Android options init failed: ${it.message}", it) }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -116,6 +116,7 @@ class IncomingCallService :
         super.onCreate()
         setRunning(true)
         ContextHolder.init(applicationContext)
+        Log.initFromContext(applicationContext)
 
         Log.d(TAG, "IncomingCallService created")
 

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -253,6 +253,7 @@ class PAndroidOptions {
     this.incomingCallFullScreen,
     this.incomingCallTimeoutMs,
     this.outgoingCallTimeoutMs,
+    this.logFilePath,
   });
 
   String? ringtoneSound;
@@ -269,6 +270,9 @@ class PAndroidOptions {
   /// automatically disconnected. When null the native default is used.
   int? outgoingCallTimeoutMs;
 
+  /// Absolute path to a file where native logs will be written directly.
+  String? logFilePath;
+
   List<Object?> _toList() {
     return <Object?>[
       ringtoneSound,
@@ -276,6 +280,7 @@ class PAndroidOptions {
       incomingCallFullScreen,
       incomingCallTimeoutMs,
       outgoingCallTimeoutMs,
+      logFilePath,
     ];
   }
 
@@ -291,6 +296,7 @@ class PAndroidOptions {
       incomingCallFullScreen: result[2] as bool?,
       incomingCallTimeoutMs: result[3] as int?,
       outgoingCallTimeoutMs: result[4] as int?,
+      logFilePath: result[5] as String?,
     );
   }
 

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -177,6 +177,7 @@ extension CallkeepAndroidOptionsConverter on CallkeepAndroidOptions {
       incomingCallFullScreen: incomingCallFullScreen,
       incomingCallTimeoutMs: incomingCallTimeoutMs,
       outgoingCallTimeoutMs: outgoingCallTimeoutMs,
+      logFilePath: logFilePath,
     );
   }
 }

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -177,7 +177,7 @@ extension CallkeepAndroidOptionsConverter on CallkeepAndroidOptions {
       incomingCallFullScreen: incomingCallFullScreen,
       incomingCallTimeoutMs: incomingCallTimeoutMs,
       outgoingCallTimeoutMs: outgoingCallTimeoutMs,
-      logFilePath: logFilePath,
+      logFilePath: nativeLogFilePath,
     );
   }
 }

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -57,6 +57,7 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {
     if (delegate != null) {
       PDelegateLogsFlutterApi.setUp(_LogsDelegateRelay(delegate));

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -462,17 +462,6 @@ class _PushRegistryDelegateRelay implements PPushRegistryDelegateFlutterApi {
   }
 }
 
-class _LogsDelegateRelay implements PDelegateLogsFlutterApi {
-  const _LogsDelegateRelay(this._delegate);
-
-  final CallkeepLogsDelegate _delegate;
-
-  @override
-  void onLog(PLogTypeEnum type, String tag, String message) {
-    _delegate.onLog(type.toCallkeep(), tag, message);
-  }
-}
-
 class _CallkeepBackgroundServiceDelegateRelay implements PDelegateBackgroundServiceFlutterApi {
   const _CallkeepBackgroundServiceDelegateRelay(this._delegate);
 

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -57,7 +57,7 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
-  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
+  @Deprecated('Use CallkeepAndroidOptions.nativeLogFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {}
 
   @override

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -58,13 +58,7 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
 
   @override
   @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
-  void setLogsDelegate(CallkeepLogsDelegate? delegate) {
-    if (delegate != null) {
-      PDelegateLogsFlutterApi.setUp(_LogsDelegateRelay(delegate));
-    } else {
-      PDelegateLogsFlutterApi.setUp(null);
-    }
-  }
+  void setLogsDelegate(CallkeepLogsDelegate? delegate) {}
 
   @override
   Future<String?> pushTokenForPushTypeVoIP() {

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -37,6 +37,11 @@ class PAndroidOptions {
   /// Timeout in milliseconds before an unanswered outgoing call (STATE_DIALING) is
   /// automatically disconnected. When null the native default is used.
   late int? outgoingCallTimeoutMs;
+
+  /// Absolute path to a file where native logs will be written directly.
+  /// When set, all Log.d/i/w/e calls are appended to this file regardless
+  /// of whether the Flutter delegate is registered.
+  late String? logFilePath;
 }
 
 class POptions {

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -273,6 +273,42 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // CallkeepAndroidOptionsConverter
+  // ---------------------------------------------------------------------------
+
+  group('CallkeepAndroidOptionsConverter.toPigeon()', () {
+    test('nativeLogFilePath is forwarded to Pigeon logFilePath', () {
+      const opts = CallkeepAndroidOptions(nativeLogFilePath: '/data/app_logs_native.log');
+      expect(opts.toPigeon().logFilePath, '/data/app_logs_native.log');
+    });
+
+    test('nativeLogFilePath null maps to Pigeon logFilePath null', () {
+      const opts = CallkeepAndroidOptions();
+      expect(opts.toPigeon().logFilePath, isNull);
+    });
+  });
+
+  group('CallkeepAndroidOptions Equatable', () {
+    test('same nativeLogFilePath are equal', () {
+      const a = CallkeepAndroidOptions(nativeLogFilePath: '/data/app_logs_native.log');
+      const b = CallkeepAndroidOptions(nativeLogFilePath: '/data/app_logs_native.log');
+      expect(a, equals(b));
+    });
+
+    test('different nativeLogFilePath are not equal', () {
+      const a = CallkeepAndroidOptions(nativeLogFilePath: '/data/a.log');
+      const b = CallkeepAndroidOptions(nativeLogFilePath: '/data/b.log');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('null vs non-null nativeLogFilePath are not equal', () {
+      const a = CallkeepAndroidOptions(nativeLogFilePath: '/data/a.log');
+      const b = CallkeepAndroidOptions();
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CallkeepOptionsConverter
   // ---------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -346,40 +346,14 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('_LogsDelegateRelay', () {
-    late _FakeLogsDelegate fake;
-
-    setUp(() {
-      fake = _FakeLogsDelegate();
-      // ignore: deprecated_member_use
-      WebtritCallkeepPlatform.instance.setLogsDelegate(fake);
-    });
-
-    tearDown(() {
-      // ignore: deprecated_member_use
-      WebtritCallkeepPlatform.instance.setLogsDelegate(null);
-    });
-
     test('setLogsDelegate(null) clears without error', () {
       // ignore: deprecated_member_use
       expect(() => WebtritCallkeepPlatform.instance.setLogsDelegate(null), returnsNormally);
     });
 
-    test('onLog converts PLogTypeEnum and forwards all fields', () async {
-      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.warn, 'TAG', 'some message']);
-      expect(fake.calls.length, 1);
-      expect(fake.calls[0][0], CallkeepLogType.warn);
-      expect(fake.calls[0][1], 'TAG');
-      expect(fake.calls[0][2], 'some message');
-    });
-
-    test('onLog with debug type', () async {
-      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.debug, 'DEBUG_TAG', 'debug msg']);
-      expect(fake.calls[0][0], CallkeepLogType.debug);
-    });
-
-    test('onLog with error type', () async {
-      await _send('$_prefix.PDelegateLogsFlutterApi.onLog', [PLogTypeEnum.error, 'ERR', 'err msg']);
-      expect(fake.calls[0][0], CallkeepLogType.error);
+    test('setLogsDelegate(delegate) completes without error', () {
+      // ignore: deprecated_member_use
+      expect(() => WebtritCallkeepPlatform.instance.setLogsDelegate(_FakeLogsDelegate()), returnsNormally);
     });
   });
 

--- a/webtrit_callkeep_android/test/delegate_relay_test.dart
+++ b/webtrit_callkeep_android/test/delegate_relay_test.dart
@@ -350,14 +350,17 @@ void main() {
 
     setUp(() {
       fake = _FakeLogsDelegate();
+      // ignore: deprecated_member_use
       WebtritCallkeepPlatform.instance.setLogsDelegate(fake);
     });
 
     tearDown(() {
+      // ignore: deprecated_member_use
       WebtritCallkeepPlatform.instance.setLogsDelegate(null);
     });
 
     test('setLogsDelegate(null) clears without error', () {
+      // ignore: deprecated_member_use
       expect(() => WebtritCallkeepPlatform.instance.setLogsDelegate(null), returnsNormally);
     });
 

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -58,6 +58,7 @@ class CallkeepAndroidOptions extends Equatable {
     this.incomingCallFullScreen,
     this.incomingCallTimeoutMs = 60000,
     this.outgoingCallTimeoutMs = 60000,
+    this.logFilePath,
   });
 
   final String? ringtoneSound;
@@ -76,6 +77,11 @@ class CallkeepAndroidOptions extends Equatable {
   /// is automatically disconnected. Defaults to `60000` ms.
   final int outgoingCallTimeoutMs;
 
+  /// Absolute path to a file where native (Kotlin) logs will be written directly,
+  /// bypassing the Flutter delegate channel. Logs are appended on every Log.d/i/w/e
+  /// call regardless of Flutter engine state.
+  final String? logFilePath;
+
   @override
   List<Object?> get props => [
     ringtoneSound,
@@ -83,5 +89,6 @@ class CallkeepAndroidOptions extends Equatable {
     incomingCallFullScreen,
     incomingCallTimeoutMs,
     outgoingCallTimeoutMs,
+    logFilePath,
   ];
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -58,7 +58,7 @@ class CallkeepAndroidOptions extends Equatable {
     this.incomingCallFullScreen,
     this.incomingCallTimeoutMs = 60000,
     this.outgoingCallTimeoutMs = 60000,
-    this.logFilePath,
+    this.nativeLogFilePath,
   });
 
   final String? ringtoneSound;
@@ -77,10 +77,11 @@ class CallkeepAndroidOptions extends Equatable {
   /// is automatically disconnected. Defaults to `60000` ms.
   final int outgoingCallTimeoutMs;
 
-  /// Absolute path to a file where native (Kotlin) logs will be written directly,
-  /// bypassing the Flutter delegate channel. Logs are appended on every Log.d/i/w/e
-  /// call regardless of Flutter engine state.
-  final String? logFilePath;
+  /// Absolute path to the file where native (Kotlin) logs will be written.
+  /// Kotlin writes directly to this exact path — no renaming or suffix is applied.
+  /// Pass [AppPath.nativeLogFilePath] here and the same value to [NativeLogForwarder]
+  /// so both sides agree on the file location.
+  final String? nativeLogFilePath;
 
   @override
   List<Object?> get props => [
@@ -89,6 +90,6 @@ class CallkeepAndroidOptions extends Equatable {
     incomingCallFullScreen,
     incomingCallTimeoutMs,
     outgoingCallTimeoutMs,
-    logFilePath,
+    nativeLogFilePath,
   ];
 }

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -42,9 +42,9 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
   /// Sets the logs delegate.
   /// [CallkeepLogsDelegate] needs to be implemented to receive logs.
   ///
-  /// Deprecated: pass [CallkeepAndroidOptions.logFilePath] to [setUp] instead.
+  /// Deprecated: pass [CallkeepAndroidOptions.nativeLogFilePath] to [setUp] instead.
   /// Native logs are then written directly to a file without the Flutter engine.
-  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
+  @Deprecated('Use CallkeepAndroidOptions.nativeLogFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {
     throw UnimplementedError('setLogsDelegate() has not been implemented.');
   }

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -41,6 +41,10 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
 
   /// Sets the logs delegate.
   /// [CallkeepLogsDelegate] needs to be implemented to receive logs.
+  ///
+  /// Deprecated: pass [CallkeepAndroidOptions.logFilePath] to [setUp] instead.
+  /// Native logs are then written directly to a file without the Flutter engine.
+  @Deprecated('Use CallkeepAndroidOptions.logFilePath in setUp() instead.')
   void setLogsDelegate(CallkeepLogsDelegate? delegate) {
     throw UnimplementedError('setLogsDelegate() has not been implemented.');
   }


### PR DESCRIPTION
Switches Android callkeep logging from Flutter channel-based routing to direct file + logcat writes.

Previously logs from Kotlin services were piped through a Flutter delegate channel (`PDelegateLogsFlutterApi`). This coupled log visibility to whether a Flutter isolate was alive and a delegate was registered — fragile, and made logs disappear in background/foreground service scenarios.

Now every `Log.d/i/w/e` call writes directly to the shared log file and `AndroidLog` in parallel, unconditionally. No channels, no delegates, no timing dependencies.