### PR TITLE
fix(android): guard VibrationAttributes vibrate call behind API 33 (WT-1460)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/AudioManager.kt
@@ -137,7 +137,7 @@ class AudioManager(
             Log.w(TAG, "startVibration: vibrator is null, skipping")
             return
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val attrs =
                 android.os.VibrationAttributes
                     .Builder()


### PR DESCRIPTION
## Problem

Crash on incoming call on devices running **Android 12 (API 32)** — e.g. Huawei:

```
java.lang.NoSuchMethodError: No virtual method
  vibrate(Landroid/os/VibrationEffect;Landroid/os/VibrationAttributes;)V
  in class Landroid/os/Vibrator;
    at AudioManager.startVibration(AudioManager.kt:146)
```

## Root Cause

PR #280 introduced `VibrationAttributes` but guarded the call with `Build.VERSION_CODES.S` (API 31).  
The `Vibrator.vibrate(VibrationEffect, VibrationAttributes)` overload is only available from **API 33 (TIRAMISU)**, not API 31.  
Devices on Android 11–12 (API 30–32) have the `VibrationAttributes` class but not this method → `NoSuchMethodError` crash.

## Fix

Changed the API level check from `Build.VERSION_CODES.S` (31) to `Build.VERSION_CODES.TIRAMISU` (33).  
The existing `AudioAttributes` fallback branch now covers API 26–32.