### PR TITLE
fix(android): silence active call notification sound on answer (WT-1506)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationChannelManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationChannelManager.kt
@@ -14,7 +14,7 @@ object NotificationChannelManager {
     // Constants for notification channel IDs
     const val INCOMING_CALL_NOTIFICATION_CHANNEL_ID = "INCOMING_CALL_NOTIFICATION_CHANNEL_ID"
     const val FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID = "FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID"
-    const val NOTIFICATION_ACTIVE_CALL_CHANNEL_ID = "NOTIFICATION_ACTIVE_CALL_CHANNEL_ID"
+    const val NOTIFICATION_ACTIVE_CALL_CHANNEL_ID = "ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL"
 
     /**
      * Registers all necessary notification channels.
@@ -43,7 +43,7 @@ object NotificationChannelManager {
             channelId = NOTIFICATION_ACTIVE_CALL_CHANNEL_ID,
             title = context.getString(R.string.push_notification_active_call_channel_title),
             description = context.getString(R.string.push_notification_active_call_channel_description),
-            importance = NotificationManager.IMPORTANCE_DEFAULT,
+            importance = NotificationManager.IMPORTANCE_LOW,
         )
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationChannelManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationChannelManager.kt
@@ -14,7 +14,7 @@ object NotificationChannelManager {
     // Constants for notification channel IDs
     const val INCOMING_CALL_NOTIFICATION_CHANNEL_ID = "INCOMING_CALL_NOTIFICATION_CHANNEL_ID"
     const val FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID = "FOREGROUND_CALL_NOTIFICATION_CHANNEL_ID"
-    const val NOTIFICATION_ACTIVE_CALL_CHANNEL_ID = "ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL"
+    const val ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID = "ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL"
 
     /**
      * Registers all necessary notification channels.
@@ -25,6 +25,7 @@ object NotificationChannelManager {
      * @param context The context used to access system services and resources.
      */
     fun registerNotificationChannels(context: Context) {
+        NotificationManagerCompat.from(context).deleteNotificationChannel("NOTIFICATION_ACTIVE_CALL_CHANNEL_ID")
         registerActiveCallChannel(context)
         registerIncomingCallChannel(context)
         registerForegroundCallChannel(context)
@@ -40,7 +41,7 @@ object NotificationChannelManager {
     private fun registerActiveCallChannel(context: Context) {
         registerNotificationChannel(
             context,
-            channelId = NOTIFICATION_ACTIVE_CALL_CHANNEL_ID,
+            channelId = ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID,
             title = context.getString(R.string.push_notification_active_call_channel_title),
             description = context.getString(R.string.push_notification_active_call_channel_description),
             importance = NotificationManager.IMPORTANCE_LOW,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.graphics.drawable.Icon
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder.context
-import com.webtrit.callkeep.managers.NotificationChannelManager.NOTIFICATION_ACTIVE_CALL_CHANNEL_ID
+import com.webtrit.callkeep.managers.NotificationChannelManager.ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.NotificationAction
 import com.webtrit.callkeep.services.services.active_call.ActiveCallService
@@ -40,7 +40,7 @@ class ActiveCallNotificationBuilder : NotificationBuilder() {
             Notification
                 .Builder(
                     context,
-                    NOTIFICATION_ACTIVE_CALL_CHANNEL_ID,
+                    ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID,
                 ).apply {
                     setSmallIcon(R.drawable.ic_notification)
                     setOngoing(true)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
@@ -4,7 +4,6 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import android.graphics.drawable.Icon
-import androidx.core.app.NotificationCompat
 import com.webtrit.callkeep.R
 import com.webtrit.callkeep.common.ContextHolder.context
 import com.webtrit.callkeep.managers.NotificationChannelManager.NOTIFICATION_ACTIVE_CALL_CHANNEL_ID
@@ -45,17 +44,15 @@ class ActiveCallNotificationBuilder : NotificationBuilder() {
                 ).apply {
                     setSmallIcon(R.drawable.ic_notification)
                     setOngoing(true)
+                    setOnlyAlertOnce(true)
                     setContentTitle(title)
                     setContentText(text)
                     setAutoCancel(false)
                     setCategory(Notification.CATEGORY_SERVICE)
-                    setFullScreenIntent(buildOpenAppIntent(context), true)
                     addAction(hungUpAction)
                 }
 
-        val notification = notificationBuilder.build()
-        notification.flags = notification.flags or NotificationCompat.FLAG_INSISTENT
-        return notification
+        return notificationBuilder.build()
     }
 
     private fun getHungUpCallIntent(callMetaData: CallMetadata?): PendingIntent {


### PR DESCRIPTION
## Problem

When answering an incoming call, the device plays an audible notification sound at the moment of answer. Audio calls are not affected.

The active call notification channel was registered with `IMPORTANCE_DEFAULT`, and `ActiveCallNotificationBuilder` included `setFullScreenIntent(..., true)` and `FLAG_INSISTENT`. When `ActiveCallService` calls `startForeground()` at answer time, Android re-posts the notification — triggering an alert sound via the channel.
