### PR TITLE
refactor(android): remove dead answered param from releaseIncomingCallNotification

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -337,7 +337,7 @@ class IncomingCallService :
         // is not held on for the full WAKELOCK_TIMEOUT_MS during post-call teardown.
         // onDestroy() keeps the lock as a final safety net in case this path is skipped.
         releaseScreenWakeLock()
-        incomingCallHandler.releaseIncomingCallNotification(answered)
+        incomingCallHandler.releaseIncomingCallNotification()
         timeoutHandler.removeCallbacks(independentTimeoutRunnable)
         timeoutHandler.removeCallbacks(stopTimeoutRunnable)
         timeoutHandler.postDelayed(stopTimeoutRunnable, SERVICE_TIMEOUT_MS)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -56,12 +56,11 @@ class IncomingCallHandler(
     }
 
     /**
-     * Replaces the ringing notification with a silent one regardless of answer state.
-     * The silent notification keeps the FGS alive while the signaling layer sends SIP BYE
-     * (answered=false) or while the active-call session takes over (answered=true).
+     * Replaces the ringing notification with a silent one to transition out of the ringing phase.
+     * The silent notification keeps the FGS alive while the signaling layer completes teardown.
      */
     @SuppressLint("MissingPermission")
-    fun releaseIncomingCallNotification(answered: Boolean) {
+    fun releaseIncomingCallNotification() {
         if (lastMetadata == null) {
             Log.w(TAG, "releaseIncomingCallNotification: no metadata (service not initialized), skipping")
             return

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -57,7 +57,8 @@ class IncomingCallHandler(
 
     /**
      * Replaces the ringing notification with a silent one to transition out of the ringing phase.
-     * The silent notification keeps the FGS alive while the signaling layer completes teardown.
+     * The silent notification keeps the FGS alive while the signaling layer completes teardown
+     * (decline path) or while the active-call session takes over (answer path).
      */
     @SuppressLint("MissingPermission")
     fun releaseIncomingCallNotification() {


### PR DESCRIPTION
## Summary

- `releaseIncomingCallNotification(answered: Boolean)` — the `answered` parameter has been ignored since commit `99698dc` (WT-1430, 2026-04-30), when both the answer and decline paths were unified to call `muteIncomingCallNotification()`
- Remove the dead parameter and update the single call site in `IncomingCallService.handleRelease()`