### PR TITLE
fix(android): add CATEGORY_CALL to silent FGS notification to prevent startForeground crash on Android 12 (WT-1511)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -139,10 +139,7 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
         return NotificationCompat
             .Builder(context, INCOMING_CALL_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
-            // Intentionally no CATEGORY_CALL here: Samsung/MIUI force all CATEGORY_CALL
-            // notifications to show as heads-up regardless of priority or silent flag.
-            // This notification is a transitional FGS keepalive during teardown and must
-            // not be visible to the user.
+            .setCategory(NotificationCompat.CATEGORY_CALL)
             .setContentTitle(title)
             .setContentText(description)
             .setOnlyAlertOnce(true)


### PR DESCRIPTION
## Summary

Restores CATEGORY_CALL on the “silent” incoming-call foreground-service notification so startForeground(..., FOREGROUND_SERVICE_TYPE_PHONE_CALL) isn’t rejected on Android 12 OEM builds (e.g., ColorOS 12), preventing RemoteServiceException: Bad notification for startForeground during the teardown/mute path.

## Why the CATEGORY_CALL removal was wrong

`44b8f99` (WT-1312) fixed blank Samsung/MIUI heads-up notifications via two correct changes:
1. Removed the placeholder notification from `IncomingCallService.onCreate()`
2. Switched IC_RELEASE delivery from `startService()` to `BroadcastReceiver` (prevents zombie restart)

`buildSilent()` was not involved in the WT-1312 blank notification issue — it is only called *after* the ringing phase ends (answer or decline), not during the initial heads-up. The `CATEGORY_CALL` removal from `buildSilent()` was a speculative side-action without a corresponding reported problem.

Subsequent PRs confirmed this: WT-1393 (#275, zombie call race fix) and WT-1430 (#282, unified answer/decline notification path) addressed real service lifecycle issues without touching `buildSilent()` or needing the `CATEGORY_CALL` absence.