### PR TITLE
chore(android): add startForeground marker logs to IncomingCallHandler (WT-1511)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -87,6 +87,7 @@ class IncomingCallHandler(
      */
     @SuppressLint("MissingPermission")
     fun muteIncomingCallNotification() {
+        Log.d(TAG, "muteIncomingCallNotification: entry callId=${lastMetadata?.callId}")
         stopForegroundDetach()
         notifier.cancel(currentNotificationId)
         startForegroundCompat(notificationBuilder.buildSilent())
@@ -97,12 +98,14 @@ class IncomingCallHandler(
         // foregroundServiceType must be passed explicitly: on API 34+ startForeground() without
         // a type throws InvalidForegroundServiceTypeException when the manifest declares one.
         val notification = notificationBuilder.apply { setCallMetaData(metadata) }.build()
+        Log.d(TAG, "startForeground [ringing]: id=$currentNotificationId SDK=${Build.VERSION.SDK_INT}")
         service.startForegroundServiceCompat(
             service,
             currentNotificationId,
             notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
         )
+        Log.d(TAG, "startForeground [ringing]: completed")
     }
 
     private fun maybeInitBackgroundHandling() {
@@ -130,6 +133,7 @@ class IncomingCallHandler(
      * Starts foreground respecting SDK level to avoid deprecated API warnings.
      */
     private fun startForegroundCompat(notification: Notification) {
+        Log.d(TAG, "startForeground [silent]: id=$currentNotificationId SDK=${Build.VERSION.SDK_INT}")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             service.startForeground(
                 currentNotificationId,
@@ -139,6 +143,7 @@ class IncomingCallHandler(
         } else {
             service.startForeground(currentNotificationId, notification)
         }
+        Log.d(TAG, "startForeground [silent]: completed")
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds diagnostic log markers before and after each `startForeground()` call site in `IncomingCallHandler` to disambiguate which call triggers a `Bad notification for startForeground` crash on OEM Android 12 devices.

- `muteIncomingCallNotification()` — entry log with `callId`
- `showNotification()` — before/after `startForeground [ringing]`
- `startForegroundCompat()` — before/after `startForeground [silent]`

## How to read a future crash

| Last log before exception | Conclusion |
|--------------------------|-----------|
| `startForeground [ringing]: id=...` (no `completed`) | First call crashed — lock screen notification never appeared |
| `startForeground [ringing]: completed` + `muteIncomingCallNotification: entry` | Second call crashed — user tapped Answer/Decline, `buildSilent()` path failed |
| `startForeground [silent]: id=...` (no `completed`) | Second call crashed — confirmed |

## Context

- WT-1511: `RemoteServiceException: Bad notification for startForeground` on Oppo Android 12
- Crash evidence showed zero `[CK-IncomingCallService]` logs in Logz.io — process died before Flutter pipeline could flush
- Root cause confirmed: `buildSilent()` lacked `CATEGORY_CALL` (fixed in PR #292)
- These markers will be more effective once PR #286 (native file logging) is merged — logs will write directly to disk and survive process death

## Related

- PR #292 — fix: restore `CATEGORY_CALL` in `buildSilent()` (WT-1511)
- PR #286 — feat: native file logging for callkeep services