### PR TITLE
feat(android): add CallkeepFgsIntegration for FGS engine channel registration

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
@@ -1,0 +1,175 @@
+package com.webtrit.callkeep
+
+import android.content.Context
+import com.webtrit.callkeep.common.StorageDelegate
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.models.toCallHandle
+import com.webtrit.callkeep.services.core.CallkeepCore
+import io.flutter.plugin.common.BinaryMessenger
+
+/**
+ * Registers webtrit_callkeep Pigeon channels on a secondary Flutter engine that was created
+ * with automaticallyRegisterPlugins=false (e.g. the SignalingForegroundService FGS engine).
+ *
+ * Usage in Application.onCreate:
+ * ```kotlin
+ * SignalingForegroundService.onFgsEngineReady = { context, messenger ->
+ *     CallkeepFgsIntegration.register(context, messenger)
+ * }
+ * ```
+ */
+object CallkeepFgsIntegration {
+    fun register(
+        context: Context,
+        messenger: BinaryMessenger,
+    ) {
+        PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
+            messenger,
+            BackgroundPushNotificationIsolateBootstrapApi(context),
+        )
+        PHostApi.setUp(messenger, FgsHostApiHandler(context))
+    }
+
+    private class FgsHostApiHandler(
+        private val context: Context,
+    ) : PHostApi {
+        override fun isSetUp(): Boolean = true
+
+        override fun setUp(
+            options: POptions,
+            callback: (Result<Unit>) -> Unit,
+        ) {
+            callback(Result.success(Unit))
+        }
+
+        override fun tearDown(callback: (Result<Unit>) -> Unit) {
+            callback(Result.success(Unit))
+        }
+
+        override fun reportNewIncomingCall(
+            callId: String,
+            handle: PHandle,
+            displayName: String?,
+            hasVideo: Boolean,
+            callback: (Result<PIncomingCallError?>) -> Unit,
+        ) {
+            val ringtonePath = StorageDelegate.Sound.getRingtonePath(context)
+            val metadata =
+                CallMetadata(
+                    callId = callId,
+                    handle = handle.toCallHandle(),
+                    displayName = displayName,
+                    hasVideo = hasVideo,
+                    ringtonePath = ringtonePath,
+                )
+            CallkeepCore.instance.startIncomingCall(
+                metadata = metadata,
+                onSuccess = { callback(Result.success(null)) },
+                onError = { error -> callback(Result.success(error)) },
+            )
+        }
+
+        override fun reportEndCall(
+            callId: String,
+            displayName: String,
+            reason: PEndCallReason,
+            callback: (Result<Unit>) -> Unit,
+        ) {
+            val metadata = CallMetadata(callId = callId, displayName = displayName)
+            CallkeepCore.instance.startDeclineCall(metadata)
+            callback(Result.success(Unit))
+        }
+
+        override fun reportConnectingOutgoingCall(
+            callId: String,
+            callback: (Result<Unit>) -> Unit,
+        ) {
+            callback(Result.success(Unit))
+        }
+
+        override fun reportConnectedOutgoingCall(
+            callId: String,
+            callback: (Result<Unit>) -> Unit,
+        ) {
+            callback(Result.success(Unit))
+        }
+
+        override fun reportUpdateCall(
+            callId: String,
+            handle: PHandle?,
+            displayName: String?,
+            hasVideo: Boolean?,
+            proximityEnabled: Boolean?,
+            callback: (Result<Unit>) -> Unit,
+        ) {
+            callback(Result.success(Unit))
+        }
+
+        override fun startCall(
+            callId: String,
+            handle: PHandle,
+            displayNameOrContactIdentifier: String?,
+            video: Boolean,
+            proximityEnabled: Boolean,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun answerCall(
+            callId: String,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun endCall(
+            callId: String,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun setHeld(
+            callId: String,
+            onHold: Boolean,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun setMuted(
+            callId: String,
+            muted: Boolean,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun setSpeaker(
+            callId: String,
+            enabled: Boolean,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun setAudioDevice(
+            callId: String,
+            device: PAudioDevice,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun sendDTMF(
+            callId: String,
+            key: String,
+            callback: (Result<PCallRequestError?>) -> Unit,
+        ) {
+            callback(Result.success(null))
+        }
+
+        override fun onDelegateSet() {}
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
@@ -1,8 +1,11 @@
 package com.webtrit.callkeep
 
+import android.Manifest
 import android.content.Context
+import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.models.toAudioDevice
 import com.webtrit.callkeep.models.toCallHandle
 import com.webtrit.callkeep.services.core.CallkeepCore
 import io.flutter.plugin.common.BinaryMessenger
@@ -59,18 +62,18 @@ object CallkeepFgsIntegration {
     private class FgsHostApiHandler(
         private val context: Context,
     ) : PHostApi {
+        private val core get() = CallkeepCore.instance
+
+        // setUp/tearDown manage the callkeep lifecycle and are owned by the Activity.
+        // Calling them from the FGS engine would conflict with Activity-side state.
         override fun isSetUp(): Boolean = true
 
         override fun setUp(
             options: POptions,
             callback: (Result<Unit>) -> Unit,
-        ) {
-            callback(Result.success(Unit))
-        }
+        ) = callback(Result.success(Unit))
 
-        override fun tearDown(callback: (Result<Unit>) -> Unit) {
-            callback(Result.success(Unit))
-        }
+        override fun tearDown(callback: (Result<Unit>) -> Unit) = callback(Result.success(Unit))
 
         override fun reportNewIncomingCall(
             callId: String,
@@ -79,16 +82,15 @@ object CallkeepFgsIntegration {
             hasVideo: Boolean,
             callback: (Result<PIncomingCallError?>) -> Unit,
         ) {
-            val ringtonePath = StorageDelegate.Sound.getRingtonePath(context)
             val metadata =
                 CallMetadata(
                     callId = callId,
                     handle = handle.toCallHandle(),
                     displayName = displayName,
                     hasVideo = hasVideo,
-                    ringtonePath = ringtonePath,
+                    ringtonePath = StorageDelegate.Sound.getRingtonePath(context),
                 )
-            CallkeepCore.instance.startIncomingCall(
+            core.startIncomingCall(
                 metadata = metadata,
                 onSuccess = { callback(Result.success(null)) },
                 onError = { error -> callback(Result.success(error)) },
@@ -101,22 +103,21 @@ object CallkeepFgsIntegration {
             reason: PEndCallReason,
             callback: (Result<Unit>) -> Unit,
         ) {
-            val metadata = CallMetadata(callId = callId, displayName = displayName)
-            CallkeepCore.instance.startDeclineCall(metadata)
+            core.startDeclineCall(CallMetadata(callId = callId, displayName = displayName))
             callback(Result.success(Unit))
         }
 
+        // No CallkeepCore command exists for the DIALING state transition.
         override fun reportConnectingOutgoingCall(
             callId: String,
             callback: (Result<Unit>) -> Unit,
-        ) {
-            callback(Result.success(Unit))
-        }
+        ) = callback(Result.success(Unit))
 
         override fun reportConnectedOutgoingCall(
             callId: String,
             callback: (Result<Unit>) -> Unit,
         ) {
+            core.startEstablishCall(CallMetadata(callId = callId))
             callback(Result.success(Unit))
         }
 
@@ -128,9 +129,19 @@ object CallkeepFgsIntegration {
             proximityEnabled: Boolean?,
             callback: (Result<Unit>) -> Unit,
         ) {
+            core.startUpdateCall(
+                CallMetadata(
+                    callId = callId,
+                    handle = handle?.toCallHandle(),
+                    displayName = displayName,
+                    hasVideo = hasVideo,
+                    proximityEnabled = proximityEnabled,
+                ),
+            )
             callback(Result.success(Unit))
         }
 
+        @RequiresPermission(Manifest.permission.CALL_PHONE)
         override fun startCall(
             callId: String,
             handle: PHandle,
@@ -139,6 +150,15 @@ object CallkeepFgsIntegration {
             proximityEnabled: Boolean,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startOutgoingCall(
+                CallMetadata(
+                    callId = callId,
+                    handle = handle.toCallHandle(),
+                    displayName = displayNameOrContactIdentifier,
+                    hasVideo = video,
+                    proximityEnabled = proximityEnabled,
+                ),
+            )
             callback(Result.success(null))
         }
 
@@ -146,6 +166,7 @@ object CallkeepFgsIntegration {
             callId: String,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startAnswerCall(CallMetadata(callId = callId))
             callback(Result.success(null))
         }
 
@@ -153,6 +174,7 @@ object CallkeepFgsIntegration {
             callId: String,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startHungUpCall(CallMetadata(callId = callId))
             callback(Result.success(null))
         }
 
@@ -161,6 +183,7 @@ object CallkeepFgsIntegration {
             onHold: Boolean,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startHoldingCall(CallMetadata(callId = callId, hasHold = onHold))
             callback(Result.success(null))
         }
 
@@ -169,6 +192,7 @@ object CallkeepFgsIntegration {
             muted: Boolean,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startMutingCall(CallMetadata(callId = callId, hasMute = muted))
             callback(Result.success(null))
         }
 
@@ -177,6 +201,7 @@ object CallkeepFgsIntegration {
             enabled: Boolean,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startSpeaker(CallMetadata(callId = callId, hasSpeaker = enabled))
             callback(Result.success(null))
         }
 
@@ -185,6 +210,7 @@ object CallkeepFgsIntegration {
             device: PAudioDevice,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.setAudioDevice(CallMetadata(callId = callId, audioDevice = device.toAudioDevice()))
             callback(Result.success(null))
         }
 
@@ -193,6 +219,7 @@ object CallkeepFgsIntegration {
             key: String,
             callback: (Result<PCallRequestError?>) -> Unit,
         ) {
+            core.startSendDtmfCall(CallMetadata(callId = callId, dualToneMultiFrequency = key.firstOrNull()))
             callback(Result.success(null))
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/CallkeepFgsIntegration.kt
@@ -8,12 +8,38 @@ import com.webtrit.callkeep.services.core.CallkeepCore
 import io.flutter.plugin.common.BinaryMessenger
 
 /**
- * Registers webtrit_callkeep Pigeon channels on a secondary Flutter engine that was created
- * with automaticallyRegisterPlugins=false (e.g. the SignalingForegroundService FGS engine).
+ * Registers webtrit_callkeep Pigeon channels on a secondary Flutter engine whose
+ * BinaryMessenger is provided by the caller.
  *
- * Usage in Application.onCreate:
+ * ## Background
+ *
+ * Flutter plugins are normally registered automatically on the main engine via
+ * GeneratedPluginRegistrant. Secondary engines created for background work (foreground
+ * services, push-notification isolates, etc.) are typically started with
+ * `automaticallyRegisterPlugins = false` to avoid initialising audio, camera, and WebRTC
+ * hardware in a context where those resources must not be touched.
+ *
+ * Because [WebtritCallkeepPlugin.onAttachedToEngine] never fires on such engines,
+ * the two Pigeon HOST APIs that callkeep's background Dart code depends on are absent:
+ *
+ * - [PHostBackgroundPushNotificationIsolateBootstrapApi] — used by the push-notification
+ *   isolate to trigger ringing via [IncomingCallService].
+ * - [PHostApi] — used by any background Dart isolate that calls [Callkeep] directly
+ *   (e.g. to report an incoming call or end a call without going through the push path).
+ *
+ * [register] sets up both APIs on the given [messenger] so background Dart code works
+ * correctly without requiring the caller to know about callkeep internals.
+ *
+ * ## When to call
+ *
+ * Call [register] once, before the background Dart isolate starts executing. A safe place
+ * is inside a callback that the background engine host provides for exactly this purpose —
+ * for example `SignalingForegroundService.onFgsEngineReady` from the
+ * `webtrit_signaling_service` plugin, or an equivalent hook in your own foreground service.
+ *
  * ```kotlin
- * SignalingForegroundService.onFgsEngineReady = { context, messenger ->
+ * // Application.onCreate — wires callkeep into the FGS engine before any Dart code runs
+ * yourBackgroundEngineHost.onEngineReady = { context, messenger ->
  *     CallkeepFgsIntegration.register(context, messenger)
  * }
  * ```


### PR DESCRIPTION
## Summary

- Adds `CallkeepFgsIntegration` object with a single `register(context, messenger)` method
- Encapsulates `PHostBackgroundPushNotificationIsolateBootstrapApi` + `PHostApi` (via internal `FgsHostApiHandler`) registration on the FGS engine
- Removes the need for app-layer code to know about callkeep internals when integrating with `webtrit_signaling_service`

## Motivation

Previously, apps using `webtrit_signaling_service` with `automaticallyRegisterPlugins=false` on the FGS engine had to manually register callkeep's Pigeon channels in `WebtritApplication`, requiring knowledge of `PHostApi`, `BackgroundPushNotificationIsolateBootstrapApi`, `CallkeepCore`, and `StorageDelegate` internals.

With this change, the integration is reduced to a single call:
```kotlin
SignalingForegroundService.onFgsEngineReady = { context, messenger ->
    CallkeepFgsIntegration.register(context, messenger)
}
```

The two plugins remain fully decoupled — `CallkeepFgsIntegration` only takes a `Context` and `BinaryMessenger`, with no dependency on `webtrit_signaling_service`.

## Related

Companion change in `webtrit_phone`: `fix/fgs-hangup-callkeep-dispatch`