### PR TITLE
feat(android): WebtritCallkeep.attachToEngine — host callkeep on an external engine (WT-1538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ impractical. Signaling is also application-level responsibility: the plugin is c
 presenting calls to the OS, not maintaining a connection. FCM high-priority push is the
 recommended and sufficient mechanism to wake the device for an incoming call.
 
+### Hosting on your own Flutter engine
+
+If your app runs its own long-lived or headless Flutter engine (for example a foreground service
+that keeps a connection open and needs to present incoming calls), set callkeep up on that engine
+with `WebtritCallkeep.attachToEngine`. See
+[`docs/external-flutter-engines.md`](docs/external-flutter-engines.md).
+
 ---
 
 ## Android: SMS-triggered incoming call

--- a/docs/external-flutter-engines.md
+++ b/docs/external-flutter-engines.md
@@ -1,98 +1,59 @@
-# Hosting callkeep on your own Flutter engine (Android)
+# Hosting callkeep on an app-owned Flutter engine (Android)
 
-This guide explains how to use callkeep from a Flutter engine that **your app creates**, instead
-of the engine that callkeep manages on its own.
+## Purpose
 
-It is for integrators who run their own long-lived or headless engine on Android - for example a
-foreground service that keeps a connection open and needs to present incoming calls. If you only
-use the standard FCM push path described in the README, you do not need this.
+`WebtritCallkeep.attachToEngine` enables presenting and controlling callkeep calls from a Flutter
+engine that your application creates and owns - for example a foreground-service or other headless
+engine created with `automaticallyRegisterPlugins = false`.
 
-## When you need it
-
-callkeep's plugin (`WebtritCallkeepPlugin`) is registered automatically on engines created by the
-Flutter framework (a `FlutterActivity`, a `FlutterFragment`, or callkeep's own background engine).
-On those engines callkeep sets itself up transparently and you do nothing special.
-
-If you create your own `FlutterEngine` - typically with `automaticallyRegisterPlugins = false`, so
-that heavy plugins (WebRTC, audio, etc.) are not initialized on a background engine - the Flutter
-framework does **not** register callkeep's plugin there. As a result:
-
-- callkeep's application context is not initialized on that engine's process, and
-- callkeep's background host channels are not bound to that engine's messenger.
-
-Without setup, the first incoming call reported from that engine fails (the call UI is never
-shown). `WebtritCallkeep.attachToEngine` is the supported way to set callkeep up on such an engine.
+Use it when incoming calls must be reported from such an engine. Apps that only use the FCM push
+path described in the README do not need it.
 
 ## API
 
 `com.webtrit.callkeep.WebtritCallkeep`
 
-```kotlin
-object WebtritCallkeep {
-    // Set callkeep up on a host-provided engine. Call once when the engine is ready,
-    // on the main thread. Idempotent and safe to call again after a restart.
-    fun attachToEngine(context: Context, messenger: BinaryMessenger)
+`attachToEngine(context: Context, messenger: BinaryMessenger)`
 
-    // Reverse of attachToEngine. Call when the host engine is torn down.
-    fun detachFromEngine(messenger: BinaryMessenger)
-}
-```
+Sets callkeep up on the given engine: initializes callkeep's application context and registers its
+background host channels on the engine's messenger.
 
-You do not touch any internal Pigeon channels, core, or context classes - the whole setup is
-behind these two calls.
+`detachFromEngine(messenger: BinaryMessenger)`
 
-## What attachToEngine does
+Removes the setup performed by `attachToEngine` for that engine.
 
-`attachToEngine` is the manual counterpart of what the framework does automatically through
-`GeneratedPluginRegistrant`. For the given engine it:
+## Behavior
 
-1. Initializes callkeep's application context (process-wide, idempotent).
-2. Registers callkeep's background host channels on the engine's `BinaryMessenger`, so the Dart
-   code running in that engine can report and control calls.
-3. Marks callkeep as **hosted on an external engine** (see next section).
+- While at least one engine is attached, callkeep presents the incoming-call UI (notification,
+  ringtone, full-screen intent) and leaves background work to the host engine. It does not start
+  its own background isolate.
+- While no engine is attached, callkeep manages its own background isolate (the FCM push path).
 
-`detachFromEngine` unregisters those channels and clears the hosted mark.
+## Requirements
 
-## Behavior while hosted
+- Call `attachToEngine` on the main thread, after the engine and its `BinaryMessenger` exist, and
+  before the first incoming call is reported.
+- Call `detachFromEngine` when the engine is destroyed.
+- Both methods are idempotent and safe to call again after a restart.
+- Call both from the process that hosts the engine.
 
-While at least one host engine is attached, callkeep treats that engine as the owner of the
-background work. When a call is reported, callkeep shows the incoming-call UI (notification,
-ringtone, full-screen intent) but does **not** start its own background isolate for that call.
+## Integration
 
-This matters because your host engine already owns the background work (for example an open
-connection to your server). If callkeep also started its own isolate, you would get two parallel
-workers for the same call.
+Keep the engine-owning component decoupled from callkeep: expose generic seams from it and wire
+callkeep from the application layer.
 
-When no host engine is attached, callkeep manages its own background isolate as usual (the FCM
-push path). callkeep does not need to know which transport you use; the only thing it tracks is
-whether a host engine is currently attached.
-
-## Lifecycle
-
-- Call `attachToEngine` once the host engine and its `BinaryMessenger` exist, and before the first
-  incoming call is reported. The earliest safe place to wire this is `Application.onCreate`
-  (see the example below), because it runs before any engine or service starts.
-- Call `detachFromEngine` when the host engine is destroyed.
-- Both calls are idempotent. Calling `attachToEngine` again after a service restart is fine.
-- Call both on the main thread.
-- Call them from the same process that hosts the engine (your app's main process).
-
-## Integration example
-
-The recommended pattern keeps your engine-owning service decoupled from callkeep: the service
-exposes "engine ready" and "engine destroyed" seams, and the application wires callkeep into them.
-
-### 1. Your engine-owning service exposes seams
+### Engine-owning service
 
 ```kotlin
 class MyEngineService : Service() {
+    private var engine: FlutterEngine? = null
+
     override fun onCreate() {
         super.onCreate()
-        // Create your own engine (no auto plugin registration on a background engine).
-        val engine = FlutterEngine(applicationContext, null, /* ... */, /* automaticallyRegisterPlugins = */ false)
+        val engine = FlutterEngine(
+            applicationContext, null, /* ... */, /* automaticallyRegisterPlugins = */ false,
+        )
         engine.dartExecutor.executeDartCallback(/* your Dart entry point */)
-
-        // Hand the engine's messenger to whoever wants to wire onto it.
         onEngineReady?.invoke(applicationContext, engine.dartExecutor.binaryMessenger)
         this.engine = engine
     }
@@ -104,14 +65,16 @@ class MyEngineService : Service() {
     }
 
     companion object {
-        // Generic seams - this service knows nothing about callkeep.
-        @Volatile var onEngineReady: ((Context, BinaryMessenger) -> Unit)? = null
-        @Volatile var onEngineDestroyed: ((BinaryMessenger) -> Unit)? = null
+        @Volatile
+        var onEngineReady: ((Context, BinaryMessenger) -> Unit)? = null
+
+        @Volatile
+        var onEngineDestroyed: ((BinaryMessenger) -> Unit)? = null
     }
 }
 ```
 
-### 2. The application wires callkeep into those seams
+### Application wiring
 
 ```kotlin
 import com.webtrit.callkeep.WebtritCallkeep
@@ -125,48 +88,24 @@ class MyApplication : Application() {
 }
 ```
 
-With this in place, the host engine knows nothing about callkeep internals, and callkeep knows
-nothing about your service or transport. The application is the only seam between them.
+### Reporting calls from the engine (Dart)
 
-### 3. Report and control calls from the host engine (Dart)
-
-Inside the Dart entry point that runs on your host engine, use callkeep's existing background
-APIs. They reach the channels that `attachToEngine` registered:
+Inside the Dart entry point running on the engine, use callkeep's background APIs. They reach the
+channels registered by `attachToEngine`.
 
 ```dart
-// Report an incoming call so the OS shows the call UI:
+// Report an incoming call:
 await AndroidCallkeepServices.backgroundPushNotificationBootstrapService.reportNewIncomingCall(
   callId,
   CallkeepHandle.number(caller),
   displayName: displayName,
 );
 
-// Release a call (missed, declined, server hangup):
+// Release a call:
 await AndroidCallkeepServices.backgroundPushNotificationService.releaseCall(callId);
 ```
 
-## How it works (summary)
+## Constraints
 
-```text
-Normal engine (Activity / Fragment / callkeep's own):
-  Flutter framework -> GeneratedPluginRegistrant -> WebtritCallkeepPlugin.onAttachedToEngine
-    -> init context + register channels   (automatic)
-
-Host-owned engine (automaticallyRegisterPlugins = false):
-  callkeep plugin is NOT registered automatically
-  app calls WebtritCallkeep.attachToEngine(context, messenger)
-    -> init context + register channels + mark "hosted on external engine"   (manual)
-
-While hosted:
-  report incoming call -> callkeep shows call UI, does NOT start its own isolate
-  (the host engine owns the background work)
-```
-
-## Do and do not
-
-- Do call `attachToEngine` before the first incoming call, on the main thread.
-- Do pair `attachToEngine` with `detachFromEngine` on teardown.
-- Do keep your engine-owning component decoupled: expose generic seams and wire callkeep from the
-  application layer.
-- Do not register callkeep's internal Pigeon channels yourself.
-- Do not reference callkeep's internal classes (core, context, generated APIs) from your app.
+- Do not register callkeep's internal Pigeon channels directly.
+- Do not reference callkeep's internal classes from your application.

--- a/docs/external-flutter-engines.md
+++ b/docs/external-flutter-engines.md
@@ -1,0 +1,172 @@
+# Hosting callkeep on your own Flutter engine (Android)
+
+This guide explains how to use callkeep from a Flutter engine that **your app creates**, instead
+of the engine that callkeep manages on its own.
+
+It is for integrators who run their own long-lived or headless engine on Android - for example a
+foreground service that keeps a connection open and needs to present incoming calls. If you only
+use the standard FCM push path described in the README, you do not need this.
+
+## When you need it
+
+callkeep's plugin (`WebtritCallkeepPlugin`) is registered automatically on engines created by the
+Flutter framework (a `FlutterActivity`, a `FlutterFragment`, or callkeep's own background engine).
+On those engines callkeep sets itself up transparently and you do nothing special.
+
+If you create your own `FlutterEngine` - typically with `automaticallyRegisterPlugins = false`, so
+that heavy plugins (WebRTC, audio, etc.) are not initialized on a background engine - the Flutter
+framework does **not** register callkeep's plugin there. As a result:
+
+- callkeep's application context is not initialized on that engine's process, and
+- callkeep's background host channels are not bound to that engine's messenger.
+
+Without setup, the first incoming call reported from that engine fails (the call UI is never
+shown). `WebtritCallkeep.attachToEngine` is the supported way to set callkeep up on such an engine.
+
+## API
+
+`com.webtrit.callkeep.WebtritCallkeep`
+
+```kotlin
+object WebtritCallkeep {
+    // Set callkeep up on a host-provided engine. Call once when the engine is ready,
+    // on the main thread. Idempotent and safe to call again after a restart.
+    fun attachToEngine(context: Context, messenger: BinaryMessenger)
+
+    // Reverse of attachToEngine. Call when the host engine is torn down.
+    fun detachFromEngine(messenger: BinaryMessenger)
+}
+```
+
+You do not touch any internal Pigeon channels, core, or context classes - the whole setup is
+behind these two calls.
+
+## What attachToEngine does
+
+`attachToEngine` is the manual counterpart of what the framework does automatically through
+`GeneratedPluginRegistrant`. For the given engine it:
+
+1. Initializes callkeep's application context (process-wide, idempotent).
+2. Registers callkeep's background host channels on the engine's `BinaryMessenger`, so the Dart
+   code running in that engine can report and control calls.
+3. Marks callkeep as **hosted on an external engine** (see next section).
+
+`detachFromEngine` unregisters those channels and clears the hosted mark.
+
+## Behavior while hosted
+
+While at least one host engine is attached, callkeep treats that engine as the owner of the
+background work. When a call is reported, callkeep shows the incoming-call UI (notification,
+ringtone, full-screen intent) but does **not** start its own background isolate for that call.
+
+This matters because your host engine already owns the background work (for example an open
+connection to your server). If callkeep also started its own isolate, you would get two parallel
+workers for the same call.
+
+When no host engine is attached, callkeep manages its own background isolate as usual (the FCM
+push path). callkeep does not need to know which transport you use; the only thing it tracks is
+whether a host engine is currently attached.
+
+## Lifecycle
+
+- Call `attachToEngine` once the host engine and its `BinaryMessenger` exist, and before the first
+  incoming call is reported. The earliest safe place to wire this is `Application.onCreate`
+  (see the example below), because it runs before any engine or service starts.
+- Call `detachFromEngine` when the host engine is destroyed.
+- Both calls are idempotent. Calling `attachToEngine` again after a service restart is fine.
+- Call both on the main thread.
+- Call them from the same process that hosts the engine (your app's main process).
+
+## Integration example
+
+The recommended pattern keeps your engine-owning service decoupled from callkeep: the service
+exposes "engine ready" and "engine destroyed" seams, and the application wires callkeep into them.
+
+### 1. Your engine-owning service exposes seams
+
+```kotlin
+class MyEngineService : Service() {
+    override fun onCreate() {
+        super.onCreate()
+        // Create your own engine (no auto plugin registration on a background engine).
+        val engine = FlutterEngine(applicationContext, null, /* ... */, /* automaticallyRegisterPlugins = */ false)
+        engine.dartExecutor.executeDartCallback(/* your Dart entry point */)
+
+        // Hand the engine's messenger to whoever wants to wire onto it.
+        onEngineReady?.invoke(applicationContext, engine.dartExecutor.binaryMessenger)
+        this.engine = engine
+    }
+
+    override fun onDestroy() {
+        engine?.dartExecutor?.binaryMessenger?.let { onEngineDestroyed?.invoke(it) }
+        engine?.destroy()
+        super.onDestroy()
+    }
+
+    companion object {
+        // Generic seams - this service knows nothing about callkeep.
+        @Volatile var onEngineReady: ((Context, BinaryMessenger) -> Unit)? = null
+        @Volatile var onEngineDestroyed: ((BinaryMessenger) -> Unit)? = null
+    }
+}
+```
+
+### 2. The application wires callkeep into those seams
+
+```kotlin
+import com.webtrit.callkeep.WebtritCallkeep
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        MyEngineService.onEngineReady = WebtritCallkeep::attachToEngine
+        MyEngineService.onEngineDestroyed = WebtritCallkeep::detachFromEngine
+    }
+}
+```
+
+With this in place, the host engine knows nothing about callkeep internals, and callkeep knows
+nothing about your service or transport. The application is the only seam between them.
+
+### 3. Report and control calls from the host engine (Dart)
+
+Inside the Dart entry point that runs on your host engine, use callkeep's existing background
+APIs. They reach the channels that `attachToEngine` registered:
+
+```dart
+// Report an incoming call so the OS shows the call UI:
+await AndroidCallkeepServices.backgroundPushNotificationBootstrapService.reportNewIncomingCall(
+  callId,
+  CallkeepHandle.number(caller),
+  displayName: displayName,
+);
+
+// Release a call (missed, declined, server hangup):
+await AndroidCallkeepServices.backgroundPushNotificationService.releaseCall(callId);
+```
+
+## How it works (summary)
+
+```text
+Normal engine (Activity / Fragment / callkeep's own):
+  Flutter framework -> GeneratedPluginRegistrant -> WebtritCallkeepPlugin.onAttachedToEngine
+    -> init context + register channels   (automatic)
+
+Host-owned engine (automaticallyRegisterPlugins = false):
+  callkeep plugin is NOT registered automatically
+  app calls WebtritCallkeep.attachToEngine(context, messenger)
+    -> init context + register channels + mark "hosted on external engine"   (manual)
+
+While hosted:
+  report incoming call -> callkeep shows call UI, does NOT start its own isolate
+  (the host engine owns the background work)
+```
+
+## Do and do not
+
+- Do call `attachToEngine` before the first incoming call, on the main thread.
+- Do pair `attachToEngine` with `detachFromEngine` on teardown.
+- Do keep your engine-owning component decoupled: expose generic seams and wire callkeep from the
+  application layer.
+- Do not register callkeep's internal Pigeon channels yourself.
+- Do not reference callkeep's internal classes (core, context, generated APIs) from your app.

--- a/webtrit_callkeep_android/README.md
+++ b/webtrit_callkeep_android/README.md
@@ -31,6 +31,9 @@ Full architecture documentation lives in [`docs/`](docs/):
 | [docs/ipc-broadcasting.md](docs/ipc-broadcasting.md)                 | Cross-process event catalogue                         |
 | [docs/pigeon-apis.md](docs/pigeon-apis.md)                           | All Pigeon host and Flutter APIs                      |
 
+Diagrams: [docs/incoming-call-handling.md](docs/incoming-call-handling.md) — background-handling
+decision and terminal outcomes.
+
 ---
 
 ## Background modes

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/ExternalEngineCallApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/ExternalEngineCallApi.kt
@@ -1,0 +1,63 @@
+package com.webtrit.callkeep
+
+import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.core.CallkeepCore
+
+/**
+ * [PHostBackgroundPushNotificationIsolateApi] implementation used when callkeep is hosted on a
+ * Flutter engine it did not create itself, registered via [WebtritCallkeep.attachToEngine].
+ *
+ * It is decoupled from [com.webtrit.callkeep.services.services.incoming_call.IncomingCallService]
+ * and the push pathway: call-control requests are routed straight to [CallkeepCore], which owns
+ * the active Telecom/standalone connection.
+ */
+internal class ExternalEngineCallApi : PHostBackgroundPushNotificationIsolateApi {
+    override fun releaseCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        try {
+            CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
+            callback(Result.success(Unit))
+        } catch (e: Exception) {
+            Log.e(TAG, "releaseCall failed for callId=$callId", e)
+            callback(Result.failure(e))
+        }
+    }
+
+    override fun endCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        try {
+            CallkeepCore.instance.startDeclineCall(CallMetadata(callId = callId))
+            callback(Result.success(Unit))
+        } catch (e: Exception) {
+            Log.e(TAG, "endCall failed for callId=$callId", e)
+            callback(Result.failure(e))
+        }
+    }
+
+    override fun endAllCalls(callback: (Result<Unit>) -> Unit) {
+        try {
+            CallkeepCore.instance.sendTearDownConnections()
+            callback(Result.success(Unit))
+        } catch (e: Exception) {
+            Log.e(TAG, "endAllCalls failed", e)
+            callback(Result.failure(e))
+        }
+    }
+
+    override fun handoffCall(
+        callId: String,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        // The host engine owns the WebSocket in persistent/socket mode; handoff is not applicable.
+        callback(Result.success(Unit))
+    }
+
+    companion object {
+        private const val TAG = "ExternalEngineCallApi"
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
@@ -3,6 +3,7 @@ package com.webtrit.callkeep
 import android.content.Context
 import com.webtrit.callkeep.common.ContextHolder
 import io.flutter.plugin.common.BinaryMessenger
+import java.util.concurrent.CopyOnWriteArraySet
 
 /**
  * Public entry point for hosting callkeep on a Flutter engine that callkeep did not create.
@@ -17,12 +18,25 @@ import io.flutter.plugin.common.BinaryMessenger
  * host engine's [BinaryMessenger] is available. It performs the engine-scoped setup callkeep needs
  * in a background context and keeps callkeep's internal Pigeon channels hidden from the caller.
  *
- * The call is idempotent ([ContextHolder] init is a no-op once initialized; channel registration
- * replaces any previous handler), so it is safe across host-engine restarts. Pair it with
- * [detachFromEngine] to unregister explicitly; when the host engine is destroyed the channels are
- * torn down with it.
+ * While a host engine is attached, callkeep treats that engine as the owner of background work and
+ * does not start its own incoming-call isolate: it only shows the call UI. Pair every
+ * [attachToEngine] with a [detachFromEngine] when the host engine is torn down so callkeep can
+ * resume managing its own background work.
+ *
+ * The calls are idempotent and safe across host-engine restarts.
  */
 object WebtritCallkeep {
+    // Messengers of host-provided engines currently attached via [attachToEngine]. While this set
+    // is non-empty, a host engine owns the background work and callkeep skips its own isolate.
+    private val hostEngines = CopyOnWriteArraySet<BinaryMessenger>()
+
+    /**
+     * True while callkeep is hosted on at least one host-provided engine. Used internally to decide
+     * whether callkeep should start its own incoming-call background isolate.
+     */
+    internal val isHostedOnExternalEngine: Boolean
+        get() = hostEngines.isNotEmpty()
+
     fun attachToEngine(
         context: Context,
         messenger: BinaryMessenger,
@@ -36,9 +50,11 @@ object WebtritCallkeep {
             messenger,
             ExternalEngineCallApi(),
         )
+        hostEngines.add(messenger)
     }
 
     fun detachFromEngine(messenger: BinaryMessenger) {
+        hostEngines.remove(messenger)
         PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(messenger, null)
         PHostBackgroundPushNotificationIsolateApi.setUp(messenger, null)
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
@@ -1,0 +1,45 @@
+package com.webtrit.callkeep
+
+import android.content.Context
+import com.webtrit.callkeep.common.ContextHolder
+import io.flutter.plugin.common.BinaryMessenger
+
+/**
+ * Public entry point for hosting callkeep on a Flutter engine that callkeep did not create.
+ *
+ * A host-owned engine (for example a foreground service or another headless engine) is usually
+ * built with `automaticallyRegisterPlugins = false`, so that heavy plugins are not initialized on
+ * a background engine. As a side effect [WebtritCallkeepPlugin.onAttachedToEngine] never runs for
+ * such an engine, so callkeep's application context and its background host channels are not set
+ * up there.
+ *
+ * [attachToEngine] is the manual counterpart to that automatic registration: call it once when the
+ * host engine's [BinaryMessenger] is available. It performs the engine-scoped setup callkeep needs
+ * in a background context and keeps callkeep's internal Pigeon channels hidden from the caller.
+ *
+ * The call is idempotent ([ContextHolder] init is a no-op once initialized; channel registration
+ * replaces any previous handler), so it is safe across host-engine restarts. Pair it with
+ * [detachFromEngine] to unregister explicitly; when the host engine is destroyed the channels are
+ * torn down with it.
+ */
+object WebtritCallkeep {
+    fun attachToEngine(
+        context: Context,
+        messenger: BinaryMessenger,
+    ) {
+        ContextHolder.init(context)
+        PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
+            messenger,
+            BackgroundPushNotificationIsolateBootstrapApi(context),
+        )
+        PHostBackgroundPushNotificationIsolateApi.setUp(
+            messenger,
+            ExternalEngineCallApi(),
+        )
+    }
+
+    fun detachFromEngine(messenger: BinaryMessenger) {
+        PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(messenger, null)
+        PHostBackgroundPushNotificationIsolateApi.setUp(messenger, null)
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeep.kt
@@ -1,6 +1,7 @@
 package com.webtrit.callkeep
 
 import android.content.Context
+import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import io.flutter.plugin.common.BinaryMessenger
 import java.util.concurrent.CopyOnWriteArraySet
@@ -42,6 +43,7 @@ object WebtritCallkeep {
         messenger: BinaryMessenger,
     ) {
         ContextHolder.init(context)
+        AssetCacheManager.init(context)
         PHostBackgroundPushNotificationIsolateBootstrapApi.setUp(
             messenger,
             BackgroundPushNotificationIsolateBootstrapApi(context),

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/receivers/IncomingCallSmsTriggerReceiver.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/receivers/IncomingCallSmsTriggerReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.provider.Telephony
+import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.StorageDelegate
@@ -20,6 +21,7 @@ class IncomingCallSmsTriggerReceiver : BroadcastReceiver() {
         if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
 
         ContextHolder.init(context)
+        AssetCacheManager.init(context)
 
         val prefix = StorageDelegate.IncomingCallSmsConfig.getSmsPrefix(context) ?: return
         val pattern = StorageDelegate.IncomingCallSmsConfig.getRegexPattern(context) ?: return

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -6,6 +6,7 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.PermissionsHelper
@@ -23,6 +24,7 @@ class ActiveCallService : Service() {
     override fun onCreate() {
         super.onCreate()
         ContextHolder.init(applicationContext)
+        AssetCacheManager.init(applicationContext)
         Log.initFromContext(applicationContext)
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -15,6 +15,7 @@ import androidx.annotation.Keep
 import com.webtrit.callkeep.PDelegateBackgroundRegisterFlutterApi
 import com.webtrit.callkeep.PDelegateBackgroundServiceFlutterApi
 import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.PendingBroadcastQueue
@@ -116,6 +117,7 @@ class IncomingCallService :
         super.onCreate()
         setRunning(true)
         ContextHolder.init(applicationContext)
+        AssetCacheManager.init(applicationContext)
         Log.initFromContext(applicationContext)
 
         Log.d(TAG, "IncomingCallService created")

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/handlers/IncomingCallHandler.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.Lifecycle
+import com.webtrit.callkeep.WebtritCallkeep
 import com.webtrit.callkeep.common.startForegroundServiceCompat
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.notifications.IncomingCallNotificationBuilder
@@ -109,6 +110,14 @@ class IncomingCallHandler(
     }
 
     private fun maybeInitBackgroundHandling() {
+        // Skip isolate launch when callkeep is hosted on an external engine (attached via
+        // WebtritCallkeep.attachToEngine, e.g. a persistent signaling foreground service). That
+        // engine already owns the background work; callkeep only needs to show the call UI here.
+        // Starting its own isolate would open a duplicate signaling connection.
+        if (WebtritCallkeep.isHostedOnExternalEngine) {
+            Log.d(TAG, "maybeInitBackgroundHandling: hosted on external engine, skipping isolate launch")
+            return
+        }
         // Skip isolate launch when the main Flutter app is active (foreground or recently
         // backgrounded). In that state the main SignalingModule already has an open WebSocket
         // and handles the incoming call. Starting a second background isolate would open a

--- a/webtrit_callkeep_android/docs/incoming-call-handling.md
+++ b/webtrit_callkeep_android/docs/incoming-call-handling.md
@@ -1,0 +1,67 @@
+# Incoming call handling (decision + outcomes)
+
+How callkeep decides who runs the background work for an incoming call, and the terminal outcomes
+it drives. callkeep is transport-agnostic: it does not know whether a call arrives via push, a
+persistent socket, or in-app signaling. The integrator reports the call; callkeep presents it via
+Android Telecom and routes call control.
+
+Related: step-by-step flows in [call-flows.md](call-flows.md); services in
+[background-services.md](background-services.md) and [foreground-service.md](foreground-service.md);
+hosting callkeep on an app-owned engine in
+[../../docs/external-flutter-engines.md](../../docs/external-flutter-engines.md).
+
+Colour: blue = callkeep, orange = host app, grey = external (Telecom / system UI), yellow = decision.
+
+## Who owns the background work
+
+After a call is reported and `IncomingCallService` starts, `IncomingCallHandler.maybeInitBackgroundHandling`
+decides whether callkeep spawns its own background isolate:
+
+```mermaid
+flowchart TB
+  classDef ck fill:#dae8fc,stroke:#6c8ebf,color:#000
+  classDef app fill:#ffe6cc,stroke:#d79b00,color:#000
+  classDef ext fill:#f5f5f5,stroke:#999999,color:#000
+  classDef dec fill:#fff2cc,stroke:#d6b656,color:#000
+
+  IN["reportNewIncomingCall -> CallkeepCore.startIncomingCall<br/>-> PhoneConnectionService (Telecom) -> IncomingCallService.start (ringing UI)"]:::ck
+  GATE{"IncomingCallHandler.maybeInitBackgroundHandling"}:::dec
+  IN --> GATE
+  GATE -- "hosted on an external engine<br/>(WebtritCallkeep.attachToEngine)" --> HOST["the host engine owns the background work<br/>callkeep does NOT spawn an isolate"]:::app
+  GATE -- "app process active<br/>(ON_RESUME / ON_PAUSE / ON_STOP)" --> MAIN["the main app handles the call<br/>callkeep does NOT spawn an isolate"]:::app
+  GATE -- "else: app process dead<br/>(state null / ON_DESTROY)" --> OWN["callkeep spawns its OWN background isolate<br/>(IncomingCallService, automaticallyRegisterPlugins = true)"]:::ck
+```
+
+## Terminal outcomes
+
+The owner that reported the call drives the outcome; callkeep mediates through Telecom and
+`IncomingCallService`. The owner is the callkeep isolate, the host engine, or the main app
+(see the decision above).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant SYS as Android System UI
+    participant PCS as PhoneConnectionService (Telecom)
+    participant CORE as CallkeepCore
+    participant ICS as IncomingCallService
+    participant OWNER as Background owner (isolate / host engine / main app)
+    participant ACT as Activity + ForegroundService
+
+    SYS-->>User: ringing
+    alt User answers
+        User->>SYS: Answer
+        SYS->>PCS: onAnswer
+        PCS->>OWNER: performAnswerCall / markAnswered
+        Note over ACT: Activity adopts the connection; the app completes the answer (200 OK)
+    else User declines
+        User->>SYS: Decline
+        SYS->>PCS: onReject -> terminateWithCause(REJECTED)
+        PCS->>ICS: onDisconnect -> release(IC_RELEASE_WITH_DECLINE)
+        ICS->>OWNER: performEndCall (the owner sends the decline)
+    else Missed (caller cancels)
+        OWNER->>CORE: releaseCall -> terminate connection
+        PCS->>SYS: dismiss incoming UI
+    end
+```

--- a/webtrit_callkeep_android/docs/incoming-call-handling.md
+++ b/webtrit_callkeep_android/docs/incoming-call-handling.md
@@ -54,7 +54,7 @@ sequenceDiagram
         User->>SYS: Answer
         SYS->>PCS: onAnswer
         PCS->>OWNER: performAnswerCall / markAnswered
-        Note over ACT: Activity adopts the connection; the app completes the answer (200 OK)
+        Note over ACT: Activity adopts the connection, the app completes the answer (200 OK)
     else User declines
         User->>SYS: Decline
         SYS->>PCS: onReject -> terminateWithCause(REJECTED)

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -211,6 +211,11 @@ class PCallkeepConnection {
   late PCallkeepDisconnectCause disconnectCause;
 }
 
+// TODO: drop the transport-bound "PushNotification" from these two host API names — callkeep
+// should not encode whether a call arrives via push or signaling. Rename here, regenerate pigeon
+// (flutter pub run pigeon --input pigeons/callkeep.messages.dart) and update references:
+//   PHostBackgroundPushNotificationIsolateBootstrapApi -> PHostBackgroundIsolateBootstrapApi
+//   PHostBackgroundPushNotificationIsolateApi          -> PHostBackgroundIsolateApi
 @HostApi()
 abstract class PHostBackgroundPushNotificationIsolateBootstrapApi {
   @async


### PR DESCRIPTION
This PR introduces a new public Android entry point (`WebtritCallkeep.attachToEngine/detachFromEngine`) to host callkeep on a Flutter engine owned by the app (e.g., a long-lived foreground-service engine created with `automaticallyRegisterPlugins = false`). While such an external engine is attached, callkeep skips starting its own incoming-call isolate to avoid duplicate background signaling work.

**Changes:**
- Added `WebtritCallkeep` public API to manually attach/detach callkeep background host channels to an app-owned Flutter engine.
- Added an `ExternalEngineCallApi` host API implementation for call-control requests when running on an external engine.
- Updated incoming call handling to skip isolate startup while an external engine is attached; added docs describing how to wire this up.


## Why (WT-1538)

In persistent/socket mode the signaling foreground service owns the Flutter engine; callkeep's
plugin never attaches there, so `ContextHolder` was uninitialized and the first incoming call threw
`IllegalStateException` (no ring/notification). `attachToEngine` is the supported way to set callkeep
up on such an engine, so the app no longer hand-wires callkeep's internal Pigeon channels.

## Notes

- Paired with WebTrit/webtrit_phone#1293 (the consumer of this API).
- Runtime verification on a device (persistent cold-start + push regression) is still pending.
