### PR TITLE
fix: centralize pending-callId drain in InProcessCallkeepCore (WT-1538)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -215,6 +215,24 @@ interface CallkeepCore {
     @RequiresPermission(Manifest.permission.CALL_PHONE)
     fun startOutgoingCall(metadata: CallMetadata)
 
+    /**
+     * Reserves [metadata]'s callId in the pending tracker, then dispatches to the active
+     * call backend (Telecom or standalone).
+     *
+     * Failure modes:
+     * - **Logical errors** are delivered via [onError] with a [PIncomingCallError]. The
+     *   pending reservation is drained before [onError] is invoked.
+     * - **Synchronous exceptions** from the backend (e.g. uninitialized ContextHolder)
+     *   propagate to the caller after the pending reservation is drained. The original
+     *   throwable reaches the Pigeon channel as channel-error, so its message and stack
+     *   trace are preserved for Dart-side diagnostics.
+     *
+     * Callers that pre-register state (Pigeon callbacks, timeouts) before invoking this
+     * method must either: (a) wrap the call in their own try/catch and clean that state
+     * on throw, or (b) rely on a self-cleaning safety-net (e.g. a deferred timeout that
+     * removes the stale entries) — exception propagation will skip [onError] entirely
+     * in the synchronous-throw case.
+     */
     fun startIncomingCall(
         metadata: CallMetadata,
         onSuccess: () -> Unit,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -33,15 +33,16 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * All call sites are unaware of which backend is active — routing is entirely internal to [CallServiceRouter].
  */
-class InProcessCallkeepCore private constructor() : CallkeepCore {
-    private val tracker: ConnectionTracker = MainProcessConnectionTracker.instance
-
+class InProcessCallkeepCore internal constructor(
+    private val tracker: ConnectionTracker = MainProcessConnectionTracker.instance,
+    routerInit: () -> CallServiceRouter = { CallServiceRouter(ContextHolder.context) },
+) : CallkeepCore {
     // The context is read per call (not at construction time) so the singleton can be
     // created early without risking a NullPointerException. ContextHolder.init() must
     // have been called before any CS command method is invoked (guaranteed by Application.onCreate).
     private val context get() = ContextHolder.context
 
-    private val router: CallServiceRouter by lazy { CallServiceRouter(context) }
+    private val router: CallServiceRouter by lazy(routerInit)
 
     // -------------------------------------------------------------------------
     // Listener registry and lazy global BroadcastReceiver

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -20,6 +20,7 @@ import com.webtrit.callkeep.services.broadcaster.ConnectionServicePerformBroadca
 import com.webtrit.callkeep.services.services.connection.PhoneConnectionService
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * In-process implementation of [CallkeepCore].
@@ -238,13 +239,40 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
         onSuccess: () -> Unit,
         onError: (PIncomingCallError?) -> Unit,
     ) {
+        val callId = metadata.callId
         // Register as pending before handing off to the backend so that answerCall() can
         // find the call via core.isPending() during the broadcast-lag window, regardless
         // of which entry point initiated the incoming call (ForegroundService,
         // SignalingIsolateService, BackgroundPushNotificationIsolateBootstrapApi, etc.).
-        // addPending() is idempotent — safe to call even if the caller already did so.
-        tracker.addPending(metadata.callId)
-        router.startIncomingCall(metadata, onSuccess, onError)
+        //
+        // addPending() returns true only when this invocation actually inserted the entry.
+        // If a concurrent caller already owns the entry, we must not drain it on failure here —
+        // ownsPending guards that.
+        val ownsPending = tracker.addPending(callId)
+        val drained = AtomicBoolean(false)
+
+        fun drainOnce() {
+            if (ownsPending && drained.compareAndSet(false, true)) {
+                tracker.removePending(callId)
+            }
+        }
+
+        try {
+            router.startIncomingCall(
+                metadata,
+                onSuccess = onSuccess,
+                onError = { err ->
+                    drainOnce()
+                    onError(err)
+                },
+            )
+        } catch (t: Throwable) {
+            // Synchronous failure (e.g. IllegalStateException from ContextHolder, SecurityException,
+            // any unexpected throw inside the router). Drain so the next reportNewIncomingCall for
+            // this callId is not rejected as "already pending, rejecting concurrent duplicate".
+            drainOnce()
+            throw t
+        }
     }
 
     override fun startAnswerCall(metadata: CallMetadata) = router.startAnswerCall(metadata)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -12,6 +12,7 @@ import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.PIncomingCallErrorEnum
 import com.webtrit.callkeep.common.ContextHolder
+import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
@@ -240,19 +241,30 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
         onError: (PIncomingCallError?) -> Unit,
     ) {
         val callId = metadata.callId
-        // Register as pending before handing off to the backend so that answerCall() can
-        // find the call via core.isPending() during the broadcast-lag window, regardless
-        // of which entry point initiated the incoming call (ForegroundService,
-        // SignalingIsolateService, BackgroundPushNotificationIsolateBootstrapApi, etc.).
+        // Reserve the pendingCallIds entry before handing off to the backend so that
+        // answerCall() / endCall() issued before DidPushIncomingCall fires can locate
+        // the call via core.isPending() during the broadcast-lag window.
         //
         // addPending() returns true only when this invocation actually inserted the entry.
-        // If a concurrent caller already owns the entry, we must not drain it on failure here —
-        // ownsPending guards that.
-        val ownsPending = tracker.addPending(callId)
+        // If it returns false, a concurrent first invocation (e.g. push-isolate vs
+        // foreground signaling for the same callId) already owns the entry — reject this
+        // duplicate via onError(CALL_ID_ALREADY_EXISTS) rather than letting both proceed
+        // to Telecom, which would cause the second to be silently adopted via the
+        // :callkeep_core CALL_ID_ALREADY_EXISTS path and return null, masking the
+        // duplicate from the caller.
+        val addedPending = tracker.addPending(callId)
+        if (!addedPending) {
+            Log.w(TAG, "startIncomingCall: callId=$callId already pending, rejecting concurrent duplicate")
+            onError(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS))
+            return
+        }
+
+        // From here on we own the pendingCallIds entry. Any failure must drain it so the
+        // next reportNewIncomingCall for the same callId is not rejected as a stale duplicate.
         val drained = AtomicBoolean(false)
 
         fun drainOnce() {
-            if (ownsPending && drained.compareAndSet(false, true)) {
+            if (drained.compareAndSet(false, true)) {
                 tracker.removePending(callId)
             }
         }
@@ -311,6 +323,8 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
     override fun sendSyncConnectionState() = router.sendSyncConnectionState()
 
     companion object {
+        private const val TAG = "InProcessCallkeepCore"
+
         val instance: CallkeepCore = InProcessCallkeepCore()
 
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -282,6 +282,13 @@ class InProcessCallkeepCore private constructor() : CallkeepCore {
             // Synchronous failure (e.g. IllegalStateException from ContextHolder, SecurityException,
             // any unexpected throw inside the router). Drain so the next reportNewIncomingCall for
             // this callId is not rejected as "already pending, rejecting concurrent duplicate".
+            //
+            // The throwable is re-thrown rather than converted to onError so the original
+            // exception message + stack trace reach Dart via Pigeon's channel-error envelope
+            // (better diagnostics than a structured PIncomingCallError(INTERNAL) that would
+            // lose t.message). This skips the onError callback path — callers that pre-register
+            // state before invoking this method must handle that themselves; see KDoc on
+            // CallkeepCore.startIncomingCall.
             drainOnce()
             throw t
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -522,6 +522,13 @@ class ForegroundService :
         // duplicate push-path didPushIncomingCall must not reach it.
         core.markSignalingRegistered(callId)
 
+        // Note: core.startIncomingCall can throw synchronously (e.g. uninitialized
+        // ContextHolder). The exception bypasses our onError handler and propagates to
+        // Pigeon as channel-error. The 5 s timeoutRunnable above is our safety-net for
+        // that case — it fires, drains pending, and resolves pendingIncomingCallbacks
+        // with CALL_REJECTED_BY_SYSTEM. (Dart will have already received the original
+        // throwable via channel-error by then; the second reply is matched by reply-ID
+        // and silently dropped by Flutter.)
         core.startIncomingCall(
             metadata = metadata,
             onSuccess = {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -488,20 +488,6 @@ class ForegroundService :
             return
         }
 
-        // Register as pending before sending to Telecom so that answerCall() / endCall()
-        // issued before DidPushIncomingCall fires can locate the call via core.isPending().
-        // addPending returns true only if this invocation actually inserted the entry.
-        // If it returns false the callId is already pending from a concurrent first invocation —
-        // reject the duplicate immediately rather than letting both proceed to Telecom (which
-        // would cause the second to be silently adopted via the CALL_ID_ALREADY_EXISTS onError
-        // path and return null, masking the duplicate from Flutter).
-        val addedPending = core.addPending(callId)
-        if (!addedPending) {
-            logger.w("reportNewIncomingCall: callId=$callId already pending, rejecting concurrent duplicate")
-            callback(Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS)))
-            return
-        }
-
         // Pre-register the Pigeon callback and safety timeout BEFORE calling startIncomingCall.
         // DidPushIncomingCall can arrive synchronously — during the addNewIncomingCall Telecom
         // call inside startIncomingCall — before the IPC onSuccess callback returns to this
@@ -512,7 +498,11 @@ class ForegroundService :
             Runnable {
                 logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
                 pendingIncomingTimeouts.remove(callId)
-                if (addedPending) core.removePending(callId)
+                // pendingCallIds is owned by InProcessCallkeepCore.startIncomingCall now.
+                // If we got here, neither onSuccess nor onError fired within 5 s — the
+                // internal drain did not run, so we must drain explicitly. removePending
+                // is idempotent.
+                core.removePending(callId)
                 // Mark terminated and endCallDispatched so that a late-arriving HungUp
                 // broadcast (after the timeout) does not cause handleCSReportDeclineCall
                 // to fire performEndCall for a call Flutter already got callRejectedBySystem for.
@@ -600,10 +590,10 @@ class ForegroundService :
 
                     else -> {
                         logger.e("reportNewIncomingCall: startIncomingCall failed callId=$callId, error=$error")
-                        // Roll back the signaling-registered guard and the pending entry so that
-                        // a retry or concurrent push-path registration is not incorrectly suppressed.
+                        // Roll back the signaling-registered guard. The pending entry has already
+                        // been drained by InProcessCallkeepCore.startIncomingCall before invoking
+                        // this onError callback, so no core.removePending(callId) is needed here.
                         core.consumeSignalingRegistered(callId)
-                        if (addedPending) core.removePending(callId)
                         callback(Result.success(error))
                     }
                 }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCoreTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCoreTest.kt
@@ -1,0 +1,219 @@
+package com.webtrit.callkeep.services.core
+
+import android.os.Build
+import com.webtrit.callkeep.PIncomingCallError
+import com.webtrit.callkeep.PIncomingCallErrorEnum
+import com.webtrit.callkeep.models.CallMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [InProcessCallkeepCore.startIncomingCall].
+ *
+ * Covers the centralized pending-callId lifecycle:
+ *   1. Concurrent duplicate (addPending returns false) -> onError(CALL_ID_ALREADY_EXISTS),
+ *      router never invoked, the other caller's pending entry is preserved.
+ *   2. onSuccess -> pending kept (the connection lifecycle owns it from here).
+ *   3. onError callback -> pending drained before the caller's onError lambda runs.
+ *   4. Synchronous throw -> pending drained, original throwable re-raised verbatim,
+ *      onSuccess/onError NOT invoked (the documented contract — see KDoc on
+ *      [CallkeepCore.startIncomingCall]).
+ *   5. Drain-once guard under double resolution from a misbehaving backend.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class InProcessCallkeepCoreTest {
+    private lateinit var tracker: MainProcessConnectionTracker
+    private lateinit var router: CallServiceRouter
+    private lateinit var core: InProcessCallkeepCore
+
+    private fun metadata(callId: String = "call-1") = CallMetadata(callId = callId)
+
+    @Before
+    fun setUp() {
+        tracker = MainProcessConnectionTracker()
+        router = mock(CallServiceRouter::class.java)
+        core = InProcessCallkeepCore(tracker = tracker, routerInit = { router })
+    }
+
+    // ----------------------------------------------------------------------
+    // Concurrent duplicate (addPending returns false)
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `startIncomingCall — concurrent duplicate routes to onError and skips router`() {
+        // A concurrent first invocation already owns the pending entry.
+        tracker.addPending("call-1")
+
+        var receivedError: PIncomingCallError? = null
+        var successCalled = false
+        core.startIncomingCall(
+            metadata(),
+            onSuccess = { successCalled = true },
+            onError = { receivedError = it },
+        )
+
+        verifyNoInteractions(router)
+        assertFalse(successCalled)
+        assertEquals(PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS, receivedError?.value)
+        // The first caller's pending entry must remain — we do not strip it.
+        assertTrue(tracker.isPending("call-1"))
+    }
+
+    // ----------------------------------------------------------------------
+    // onSuccess keeps pending
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `startIncomingCall — onSuccess keeps pending`() {
+        stubRouter { _, onSuccess, _ -> onSuccess() }
+
+        var succeeded = false
+        core.startIncomingCall(metadata(), onSuccess = { succeeded = true }, onError = {})
+
+        assertTrue(succeeded)
+        // Connection lifecycle (promote / markTerminated) drains pending later — not us.
+        assertTrue(tracker.isPending("call-1"))
+    }
+
+    // ----------------------------------------------------------------------
+    // onError drains pending before caller's lambda
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `startIncomingCall — onError drains pending before invoking caller's onError`() {
+        val expectedError = PIncomingCallError(PIncomingCallErrorEnum.INTERNAL)
+        stubRouter { _, _, onError -> onError(expectedError) }
+
+        var receivedError: PIncomingCallError? = null
+        var pendingAtCallback = true
+        core.startIncomingCall(
+            metadata(),
+            onSuccess = {},
+            onError = {
+                receivedError = it
+                pendingAtCallback = tracker.isPending("call-1")
+            },
+        )
+
+        assertEquals(expectedError, receivedError)
+        // Drain must run BEFORE the caller's onError lambda is invoked.
+        assertFalse(pendingAtCallback)
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    // ----------------------------------------------------------------------
+    // Synchronous throw drains + re-raises verbatim
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `startIncomingCall — synchronous throw drains pending and re-raises verbatim`() {
+        val expectedThrow = IllegalStateException("ContextHolder is not initialized. Call init() first.")
+        doThrow(expectedThrow)
+            .`when`(router)
+            .startIncomingCall(anyMetadata(), anyOnSuccess(), anyOnError())
+
+        var receivedError: PIncomingCallError? = null
+        var succeeded = false
+
+        try {
+            core.startIncomingCall(
+                metadata(),
+                onSuccess = { succeeded = true },
+                onError = { receivedError = it },
+            )
+            fail("expected IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals(expectedThrow, e)
+        }
+
+        // Callbacks bypassed — documented contract: caller must rely on its own safety-net
+        // (e.g. ForegroundService's 5 s INCOMING_CALL_CONFIRMATION_TIMEOUT_MS).
+        assertFalse(succeeded)
+        assertNull(receivedError)
+        // Pending drained — a subsequent reportNewIncomingCall for this callId can succeed.
+        assertFalse(tracker.isPending("call-1"))
+    }
+
+    // ----------------------------------------------------------------------
+    // Drain-once guarantee
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `startIncomingCall — drain runs at most once on double resolution`() {
+        val spyTracker = spy(MainProcessConnectionTracker())
+        core = InProcessCallkeepCore(tracker = spyTracker, routerInit = { router })
+
+        stubRouter { _, _, onError ->
+            // Misbehaving backend fires onError twice — drain-once guard must hold.
+            onError(PIncomingCallError(PIncomingCallErrorEnum.INTERNAL))
+            onError(PIncomingCallError(PIncomingCallErrorEnum.INTERNAL))
+        }
+
+        core.startIncomingCall(metadata(), onSuccess = {}, onError = {})
+
+        verify(spyTracker, times(1)).removePending("call-1")
+    }
+
+    // ----------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------
+
+    /**
+     * Configures [router].startIncomingCall to dispatch via [handler], which receives the
+     * metadata and the two callbacks and can invoke whichever it wants.
+     */
+    private fun stubRouter(
+        handler: (CallMetadata, () -> Unit, (PIncomingCallError?) -> Unit) -> Unit,
+    ) {
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            handler(
+                invocation.arguments[0] as CallMetadata,
+                invocation.arguments[1] as () -> Unit,
+                invocation.arguments[2] as (PIncomingCallError?) -> Unit,
+            )
+            null
+        }.`when`(router).startIncomingCall(anyMetadata(), anyOnSuccess(), anyOnError())
+    }
+
+    // Mockito ArgumentMatchers wrappers. Mockito.any() returns null after registering a
+    // matcher in the thread-local stack — but `null as CallMetadata` (concrete non-null Kotlin
+    // type) compiles to Intrinsics.checkNotNull and throws at runtime. The trick: route through
+    // a type-parameter helper so the compiler emits no concrete null check; the typed null is
+    // then handed to the Mockito-inline mock, which intercepts before the receiver method body
+    // runs (so Kotlin's checkNotNullParameter never fires either).
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> uninitialized(): T = null as T
+
+    private fun anyMetadata(): CallMetadata {
+        ArgumentMatchers.any<CallMetadata>()
+        return uninitialized()
+    }
+
+    private fun anyOnSuccess(): () -> Unit {
+        ArgumentMatchers.any<() -> Unit>()
+        return uninitialized()
+    }
+
+    private fun anyOnError(): (PIncomingCallError?) -> Unit {
+        ArgumentMatchers.any<(PIncomingCallError?) -> Unit>()
+        return uninitialized()
+    }
+}


### PR DESCRIPTION
## Why

`InProcessCallkeepCore.startIncomingCall` adds an entry to `pendingCallIds` but the cleanup contract used to be implicit and applied inconsistently across the three entry points (`ForegroundService.reportNewIncomingCall`, `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall`, `IncomingCallSmsTriggerReceiver.tryStartCall`). Two of the three had no cleanup at all.

In the WT-1538 OPPO scenario the bg-isolate path's first `reportNewIncomingCall` threw `IllegalStateException: ContextHolder is not initialized` synchronously inside the router. The pending entry leaked permanently, every subsequent attempt for the same `callId` was rejected as `already pending, rejecting concurrent duplicate`, the call was never registered with Telecom, and the user's answer eventually ended with SIP 487.

## What this PR does

The whole pending-callId lifecycle (reservation + duplicate detection + drain on failure) is now owned by `InProcessCallkeepCore.startIncomingCall`. All current and future entry points inherit the same guarantees automatically, with no per-caller bookkeeping.

- A synchronous throw inside the router drains the pending entry and re-raises the original exception verbatim so its message + stack trace reach Dart through Pigeon's `channel-error` envelope (better diagnostics than a structured `INTERNAL` error). Callers that pre-register state must rely on their own safety-net for that case.
- An `onError` callback drains before the caller's lambda runs. The drain is guarded by an `AtomicBoolean` so a misbehaving router that fires `onError` twice cannot strip the entry twice.
- A successful call leaves the entry in place — the connection lifecycle (`promote` / `markTerminated`) owns it from there.
- A concurrent duplicate (a parallel caller already inserted the same `callId`) routes through `onError(CALL_ID_ALREADY_EXISTS)` instead of touching the router. The first caller's entry is preserved.

Bookkeeping in `ForegroundService.reportNewIncomingCall` is dropped accordingly: the local `addedPending` flag, the early bail, and the two `removePending` calls inside its `onError`/timeout paths. The 5 s `INCOMING_CALL_CONFIRMATION_TIMEOUT_MS` stays — it covers a different concern (Pigeon-callback / Telecom-confirmation timeout) and continues to serve as the safety-net for the documented synchronous-throw case.

## Behaviour-change note

Concurrent main-process duplicate (e.g. push-isolate and foreground signaling racing for the same `callId`) used to short-circuit with `CALL_ID_ALREADY_EXISTS` and no side effects. After this PR it routes through `ForegroundService`'s existing `onError CALL_ID_ALREADY_EXISTS` handler, which calls `core.promote(callId, metadata, RINGING)` and returns the same error to Flutter.

This is safe in practice: the `STATE_ACTIVE` branch of that handler (which would fire `performAnswerCall`) is unreachable here because `core.checkIncomingDuplicate` filters `STATE_ACTIVE` earlier; and both callers compute `CallMetadata` from the same signaling event, so `promote` is an idempotent overwrite with identical fields.

## Documentation

The synchronous-throw contract is captured in three places so future readers don't trip over it:

- KDoc on the `CallkeepCore.startIncomingCall` interface — covers both failure modes and the caller contract for pre-registered state.
- A comment on the `catch` block in `InProcessCallkeepCore` — rationale for re-throw rather than `onError(INTERNAL)` conversion.
- An inline note at the call site in `ForegroundService.reportNewIncomingCall` — explains that the existing 5 s timeout doubles as the sync-throw safety-net.

## Verified on device

Reproduction logged in `bugs/open/WT-1538/logs/fix:wt-1538-…_114654.logcat` (Samsung SM-M325FV, Android 13, headless FGS post-reboot):

- The first bg-isolate `reportNewIncomingCall` still throws `ContextHolder is not initialized` synchronously. The stack confirms the throw is intercepted in the new centralized path (`InProcessCallkeepCore.kt:274` → lazy `routerInit` at `:38`), `pendingCallIds` is drained, and the original throwable is re-raised verbatim — Dart receives `PlatformException(channel-error, …)` with the original message and stack.
- A subsequent `reportNewIncomingCall` for the same `callId` is **not** rejected as `already pending` (the WT-1538 hard-failure mode prior to this PR). Telecom proceeds to `addNewIncomingCall` → `onCreateIncomingConnection` → `performAnswerCall`, the call connects and audio works.

The ContextHolder race itself is addressed by PR #297 plus the corresponding phone-side integration; this PR is the defensive layer that turns the previously permanent pending leak into a recoverable race in any build where the race still triggers.