### PR TITLE
chore: bump SDK constraint to ^3.12.0 across modules

### DIFF
--- a/webtrit_callkeep/pubspec.yaml
+++ b/webtrit_callkeep/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.0+0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_android/pubspec.yaml
+++ b/webtrit_callkeep_android/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.0+0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_ios/pubspec.yaml
+++ b/webtrit_callkeep_ios/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.0+0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_linux/pubspec.yaml
+++ b/webtrit_callkeep_linux/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_macos/pubspec.yaml
+++ b/webtrit_callkeep_macos/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_platform_interface/pubspec.yaml
+++ b/webtrit_callkeep_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.0+0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 dependencies:
   flutter:

--- a/webtrit_callkeep_web/pubspec.yaml
+++ b/webtrit_callkeep_web/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.0+0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 flutter:
   plugin:

--- a/webtrit_callkeep_windows/pubspec.yaml
+++ b/webtrit_callkeep_windows/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.12.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Summary

- Bumps the Dart SDK constraint from `^3.8.0` (or `>=3.0.0 <4.0.0`) to `^3.12.0` in all 8 module `pubspec.yaml` files
- Aligns webtrit_callkeep packages with the Dart 3.12.0 minimum that ships with Flutter 3.44.0, mirroring the bump on the webtrit_phone consumer side

CI workflows (Flutter version pin) are intentionally **not** touched in this PR.

## Touched modules

- `webtrit_callkeep`
- `webtrit_callkeep_android`
- `webtrit_callkeep_ios`
- `webtrit_callkeep_linux`
- `webtrit_callkeep_macos`
- `webtrit_callkeep_platform_interface`
- `webtrit_callkeep_web`
- `webtrit_callkeep_windows`

## Test plan

- [ ] `flutter analyze` clean on each package under Dart 3.12 / Flutter 3.44
- [ ] Per-package CI workflows pass once Flutter pin is bumped (separate PR)