### PR TITLE
fix(android): use fromBundleOrNull in PhoneConnectionService.onStartCommand

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -101,7 +101,12 @@ class PhoneConnectionService : ConnectionService() {
                 Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
                 return START_NOT_STICKY
             }
-        val metadata = intent.extras?.let { CallMetadata.fromBundle(it) }
+        // Use fromBundleOrNull (not fromBundle, which throws on missing
+        // callId): several actions below — TearDownConnections,
+        // CleanConnections, SyncAudioState, SyncConnectionState — don't
+        // carry a callId in their extras, and the rest already null-check
+        // metadata.callId before using it.
+        val metadata = intent.extras?.let { CallMetadata.fromBundleOrNull(it) }
 
         try {
             when (action) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -101,11 +101,6 @@ class PhoneConnectionService : ConnectionService() {
                 Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
                 return START_NOT_STICKY
             }
-        // Use fromBundleOrNull (not fromBundle, which throws on missing
-        // callId): several actions below — TearDownConnections,
-        // CleanConnections, SyncAudioState, SyncConnectionState — don't
-        // carry a callId in their extras, and the rest already null-check
-        // metadata.callId before using it.
         val metadata = intent.extras?.let { CallMetadata.fromBundleOrNull(it) }
 
         try {


### PR DESCRIPTION
## Summary

`PhoneConnectionService.onStartCommand` calls `CallMetadata.fromBundle(it)` on the intent extras. `fromBundle` throws `IllegalArgumentException("Missing required callId property in Bundle")` when `callId` is absent.

But several `ServiceAction` cases handled immediately below — `TearDownConnections`, `CleanConnections`, `SyncAudioState`, `SyncConnectionState` — don't carry a `callId` in their extras. And the actions that *do* (`ReserveAnswer`, `NotifyPending`) already null-check `metadata?.callId` before using it (lines 116-122).

The throw at the parse step makes those defensive null-checks unreachable: the foreground service crashes every time the host app dispatches one of the no-callId actions.

This shows up in our Play Vitals as `IllegalArgumentException` originating from `CallMetadata\$Companion.fromBundle` at `CallMetaData.kt:121`, triggered from `PhoneConnectionService.onStartCommand` at `PhoneConnectionService.kt:103`.

## Fix

Use `fromBundleOrNull` so missing-`callId` bundles produce `metadata == null`, which the existing handlers already expect.