### PR TITLE
feat: unified call-waiting tone sound API, driven from Dart (WT-1415)

### DIFF
--- a/webtrit_callkeep/lib/src/webtrit_callkeep_sound.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_sound.dart
@@ -28,4 +28,22 @@ class WebtritCallkeepSound {
   Future<void> stopRingbackSound() {
     return platform.stopRingbackSound();
   }
+
+  /// Play call-waiting tone
+  /// Use this method to play a soft, recurrent beep over the active call audio
+  /// when a second call arrives while another call is already active.
+  ///
+  /// Returns [Future] that resolves on sound was successfully played.
+  Future<void> playCallWaitingTone() {
+    return platform.playCallWaitingTone();
+  }
+
+  /// Stop call-waiting tone
+  /// Use this method to stop the call-waiting beep once the second call is
+  /// answered, declined or ended.
+  ///
+  /// Returns [Future] that resolves on sound was successfully stopped.
+  Future<void> stopCallWaitingTone() {
+    return platform.stopCallWaitingTone();
+  }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -1509,6 +1509,10 @@ interface PHostSoundApi {
 
     fun stopRingbackSound(callback: (Result<Unit>) -> Unit)
 
+    fun playCallWaitingTone(callback: (Result<Unit>) -> Unit)
+
+    fun stopCallWaitingTone(callback: (Result<Unit>) -> Unit)
+
     companion object {
         /** The codec used by PHostSoundApi. */
         val codec: MessageCodec<Any?> by lazy {
@@ -1545,6 +1549,40 @@ interface PHostSoundApi {
                 if (api != null) {
                     channel.setMessageHandler { _, reply ->
                         api.stopRingbackSound { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playCallWaitingTone$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.playCallWaitingTone { result: Result<Unit> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopCallWaitingTone$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.stopCallWaitingTone { result: Result<Unit> ->
                             val error = result.exceptionOrNull()
                             if (error != null) {
                                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/SoundApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/SoundApi.kt
@@ -19,4 +19,14 @@ class SoundApi(
         audioManager.stopRingback()
         callback(Result.success(Unit))
     }
+
+    override fun playCallWaitingTone(callback: (Result<Unit>) -> Unit) {
+        audioManager.startCallWaitingTone()
+        callback(Result.success(Unit))
+    }
+
+    override fun stopCallWaitingTone(callback: (Result<Unit>) -> Unit) {
+        audioManager.stopCallWaitingTone()
+        callback(Result.success(Unit))
+    }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -122,17 +122,18 @@ class PhoneConnection internal constructor(
     /**
      * Invoked by the system when the incoming call interface should be displayed.
      *
-     * If there is already an active or held call, play a soft call-waiting tone through
-     * the voice call stream instead of the full ringtone. The ringtone uses TYPE_RINGTONE
-     * which routes through the earpiece at full ringtone volume during an active call,
-     * and can cause pain if the user has the phone pressed to their ear (WT-1388).
+     * If there is already an active or held call, suppress the full ringtone: the
+     * ringtone uses TYPE_RINGTONE which routes through the earpiece at full ringtone
+     * volume during an active call and can cause pain if the user has the phone
+     * pressed to their ear (WT-1388). In that case the soft call-waiting tone is
+     * played by the app via the sound API ([WebtritCallkeepSound.playCallWaitingTone]),
+     * so the trigger is consistent across iOS and Android (WT-1415).
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
         if (PhoneConnectionService.connectionManager.hasActiveOrHoldingConnection()) {
-            logger.d("Active call detected — playing call-waiting tone instead of ringtone for callId: $callId")
-            audioManager.startCallWaitingTone()
+            logger.d("Active call detected — suppressing ringtone; app plays the call-waiting tone for callId: $callId")
         } else {
             audioManager.startRingtone(metadata.ringtonePath)
         }
@@ -150,7 +151,6 @@ class PhoneConnection internal constructor(
     override fun onSilence() {
         logger.d("Silencing ringtone for callId: $callId")
         audioManager.stopRingtone()
-        audioManager.stopCallWaitingTone()
     }
 
     /**
@@ -185,7 +185,6 @@ class PhoneConnection internal constructor(
         notificationManager.cancelIncomingNotification(hasAnswered)
         notificationManager.cancelActiveCallNotification(callId)
         audioManager.stopRingtone()
-        audioManager.stopCallWaitingTone()
 
         dispatcher(eventForDisconnectCause(disconnectCause), metadata)
         onDisconnectCallback.invoke(this)
@@ -574,7 +573,6 @@ class PhoneConnection internal constructor(
     private fun onActiveConnection() {
         logger.i("Connection became active for callId: $callId")
         audioManager.stopRingtone()
-        audioManager.stopCallWaitingTone()
         // IncomingCallService release (IC_RELEASE_WITH_ANSWER) is intentionally NOT triggered
         // here from :callkeep_core. ForegroundService.handleCSReportAnswerCall() owns that
         // trigger and sets pendingReleaseCallback before firing it, ensuring performAnswerCall

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -1355,6 +1355,52 @@ class PHostSoundApi {
       return;
     }
   }
+
+  Future<void> playCallWaitingTone() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> stopCallWaitingTone() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }
 
 abstract class PDelegateBackgroundRegisterFlutterApi {

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -231,6 +231,16 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<void> playCallWaitingTone() {
+    return _soundApi.playCallWaitingTone();
+  }
+
+  @override
+  Future<void> stopCallWaitingTone() {
+    return _soundApi.stopCallWaitingTone();
+  }
+
+  @override
   Future<CallkeepConnection?> getConnection(String callId) async {
     return _connectionsApi.getConnection(callId).then((value) => value?.toCallkeep());
   }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -281,6 +281,12 @@ abstract class PHostSoundApi {
 
   @async
   void stopRingbackSound();
+
+  @async
+  void playCallWaitingTone();
+
+  @async
+  void stopCallWaitingTone();
 }
 
 @FlutterApi()

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
@@ -1221,4 +1221,38 @@ void SetUpWTPHostSoundApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, 
       [channel setMessageHandler:nil];
     }
   }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.playCallWaitingTone", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:WTGetGeneratedCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(playCallWaitingTone:)], @"WTPHostSoundApi api (%@) doesn't respond to @selector(playCallWaitingTone:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api playCallWaitingTone:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.stopCallWaitingTone", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:WTGetGeneratedCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(stopCallWaitingTone:)], @"WTPHostSoundApi api (%@) doesn't respond to @selector(stopCallWaitingTone:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api stopCallWaitingTone:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
 }

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -1,6 +1,7 @@
 #import "WebtritCallkeepPlugin.h"
 
 #import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioToolbox.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
 #import <Intents/Intents.h>
@@ -13,7 +14,18 @@
 static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 
 @interface WebtritCallkeepPlugin ()<PKPushRegistryDelegate, CXProviderDelegate, WTPPushRegistryHostApi, WTPHostApi, WTPHostSoundApi>
+// Call-waiting tone (WT-1415)
+- (void)ensureCallWaitingSound;
+- (void)replayCallWaitingToneIfActive;
 @end
+
+/// AudioServices completion callback: re-fire the tone while it is still active,
+/// producing a recurrent beep over the live call (the built-in trailing silence
+/// in the sound file sets the cadence).
+static void WTCallWaitingToneCompletion(SystemSoundID soundID, void *clientData) {
+  WebtritCallkeepPlugin *plugin = (__bridge WebtritCallkeepPlugin *)clientData;
+  [plugin replayCallWaitingToneIfActive];
+}
 
 @implementation WebtritCallkeepPlugin {
   NSObject<FlutterPluginRegistrar> *_registrar;
@@ -22,7 +34,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   WTPDelegateFlutterApi *_delegateFlutterApi;
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
-  AVAudioPlayer *_callWaitingTone;
+  SystemSoundID _callWaitingSoundID;
+  BOOL _callWaitingActive;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -94,12 +107,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
     }
 
-    // Create the call-waiting tone player up-front (like the ringback player),
-    // so its audio unit is ready before WebRTC takes over the audio session.
-    // A player created lazily mid-call was silent on a device (WT-1415).
-    if (_callWaitingTone == nil) {
-      _callWaitingTone = [self createCallWaitingTonePlayer];
-    }
+    [self ensureCallWaitingSound];
 
     _driveIdleTimerDisabled = iosOptions.driveIdleTimerDisabled;
   } else {
@@ -158,10 +166,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
     }
 
-    // Create the call-waiting tone player up-front (see restoreSetUp, WT-1415).
-    if (_callWaitingTone == nil) {
-      _callWaitingTone = [self createCallWaitingTonePlayer];
-    }
+    [self ensureCallWaitingSound];
 
     _driveIdleTimerDisabled = iosOptions.driveIdleTimerDisabled;
   } else {
@@ -474,59 +479,53 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 ///
 /// Driven from Dart (CallBloc) when a second call arrives while another call is
 /// connected — the app layer is the reliable source of that state on iOS, where
-/// foreground WebRTC calls are not fully reflected by CallKit. The tone is
-/// synthesized in memory (no bundled asset) and played through the active
-/// AVAudioSession via AVAudioPlayer — the same mechanism as the ringback player —
-/// so it routes to the earpiece/headset at in-call volume rather than blasting at
-/// ringtone volume (mirrors the Android fix in WT-1388). One loop is "beep-beep"
-/// followed by silence; it repeats until [stopCallWaitingTone] is called.
+/// foreground WebRTC calls are not fully reflected by CallKit.
+///
+/// Played via `AudioServicesPlaySystemSound` rather than `AVAudioPlayer`: while
+/// WebRTC owns the AVAudioSession in VoiceChat mode (voice-processing I/O unit),
+/// an AVAudioPlayer reports playing but is inaudible. System sounds use a separate
+/// playback path that is audible over the active call (WT-1415). The tone repeats
+/// via the system-sound completion callback until [stopCallWaitingTone].
 - (void)playCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
-    if (_callWaitingTone == nil) {
-        _callWaitingTone = [self createCallWaitingTonePlayer];
-    }
-    if (_callWaitingTone != nil) {
-        _callWaitingTone.numberOfLoops = -1;
-        [_callWaitingTone prepareToPlay];
-        BOOL started = [_callWaitingTone play];
-        NSLog(@"[Callkeep][playCallWaitingTone] started=%d", started);
-    } else {
-        NSLog(@"[Callkeep][playCallWaitingTone] player is nil — cannot play");
+    [self ensureCallWaitingSound];
+    _callWaitingActive = YES;
+    if (_callWaitingSoundID != 0) {
+        AudioServicesPlaySystemSound(_callWaitingSoundID);
     }
     completion(nil);
 }
 
 - (void)stopCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
-    if (_callWaitingTone != nil && _callWaitingTone.isPlaying) {
-        NSLog(@"[Callkeep][stopCallWaitingTone]");
-        [_callWaitingTone stop];
-        _callWaitingTone.currentTime = 0;
-    }
+    _callWaitingActive = NO;
     completion(nil);
 }
 
-/// Build an AVAudioPlayer for the synthesized call-waiting tone.
-///
-/// The synthesized WAV is written to a temporary file and loaded via
-/// `initWithContentsOfURL:` — the exact same path as the proven ringback player.
-/// (An in-memory `initWithData:` player was silent over the active WebRTC audio
-/// session on a device.)
-- (nullable AVAudioPlayer *)createCallWaitingTonePlayer {
+- (void)replayCallWaitingToneIfActive {
+    if (_callWaitingActive && _callWaitingSoundID != 0) {
+        AudioServicesPlaySystemSound(_callWaitingSoundID);
+    }
+}
+
+/// Register the synthesized call-waiting tone as a CoreAudio system sound (once).
+- (void)ensureCallWaitingSound {
+    if (_callWaitingSoundID != 0) {
+        return;
+    }
     NSData *wav = [self callWaitingToneWavData];
     NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"webtrit_call_waiting_tone.wav"];
     NSError *writeError = nil;
     if (![wav writeToFile:path options:NSDataWritingAtomic error:&writeError]) {
-        NSLog(@"[Callkeep][createCallWaitingTonePlayer] write failed: %@", writeError);
-        return nil;
+        NSLog(@"[Callkeep][ensureCallWaitingSound] write failed: %@", writeError);
+        return;
     }
-    NSError *error = nil;
-    AVAudioPlayer *player = [[AVAudioPlayer alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:&error];
-    if (error != nil) {
-        NSLog(@"[Callkeep][createCallWaitingTonePlayer] failed: %@", error);
-        return nil;
+    SystemSoundID soundID = 0;
+    OSStatus status = AudioServicesCreateSystemSoundID((__bridge CFURLRef)[NSURL fileURLWithPath:path], &soundID);
+    if (status != kAudioServicesNoError) {
+        NSLog(@"[Callkeep][ensureCallWaitingSound] create failed: %d", (int)status);
+        return;
     }
-    player.numberOfLoops = -1;
-    [player prepareToPlay];
-    return player;
+    _callWaitingSoundID = soundID;
+    AudioServicesAddSystemSoundCompletion(_callWaitingSoundID, NULL, NULL, WTCallWaitingToneCompletion, (__bridge void *)self);
 }
 
 /// Synthesize a 16-bit mono PCM WAV (8 kHz) for one call-waiting tone cycle:

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -1,7 +1,6 @@
 #import "WebtritCallkeepPlugin.h"
 
 #import <AVFoundation/AVFoundation.h>
-#import <AudioToolbox/AudioToolbox.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
 #import <Intents/Intents.h>
@@ -16,16 +15,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 @interface WebtritCallkeepPlugin ()<PKPushRegistryDelegate, CXProviderDelegate, WTPPushRegistryHostApi, WTPHostApi, WTPHostSoundApi>
 // Call-waiting tone (WT-1415)
 - (void)ensureCallWaitingSound;
-- (void)replayCallWaitingToneIfActive;
 @end
-
-/// AudioServices completion callback: re-fire the tone while it is still active,
-/// producing a recurrent beep over the live call (the built-in trailing silence
-/// in the sound file sets the cadence).
-static void WTCallWaitingToneCompletion(SystemSoundID soundID, void *clientData) {
-  WebtritCallkeepPlugin *plugin = (__bridge WebtritCallkeepPlugin *)clientData;
-  [plugin replayCallWaitingToneIfActive];
-}
 
 @implementation WebtritCallkeepPlugin {
   NSObject<FlutterPluginRegistrar> *_registrar;
@@ -34,8 +24,7 @@ static void WTCallWaitingToneCompletion(SystemSoundID soundID, void *clientData)
   WTPDelegateFlutterApi *_delegateFlutterApi;
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
-  SystemSoundID _callWaitingSoundID;
-  BOOL _callWaitingActive;
+  AVAudioPlayer *_callWaitingTone;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -481,34 +470,29 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 /// connected — the app layer is the reliable source of that state on iOS, where
 /// foreground WebRTC calls are not fully reflected by CallKit.
 ///
-/// Played via `AudioServicesPlaySystemSound` rather than `AVAudioPlayer`: while
-/// WebRTC owns the AVAudioSession in VoiceChat mode (voice-processing I/O unit),
-/// an AVAudioPlayer reports playing but is inaudible. System sounds use a separate
-/// playback path that is audible over the active call (WT-1415). The tone repeats
-/// via the system-sound completion callback until [stopCallWaitingTone].
+/// Played with an `AVAudioPlayer` looping the synthesized tone (numberOfLoops = -1),
+/// the same path the ringback uses — proven audible over an active WebRTC call in
+/// VoiceChat mode. The trailing silence baked into the tone sets the beep cadence.
 - (void)playCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
     [self ensureCallWaitingSound];
-    _callWaitingActive = YES;
-    if (_callWaitingSoundID != 0) {
-        AudioServicesPlaySystemSound(_callWaitingSoundID);
+    if (_callWaitingTone != nil) {
+        _callWaitingTone.currentTime = 0;
+        [_callWaitingTone play];
     }
     completion(nil);
 }
 
 - (void)stopCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
-    _callWaitingActive = NO;
+    if (_callWaitingTone != nil) {
+        [_callWaitingTone stop];
+        _callWaitingTone.currentTime = 0;
+    }
     completion(nil);
 }
 
-- (void)replayCallWaitingToneIfActive {
-    if (_callWaitingActive && _callWaitingSoundID != 0) {
-        AudioServicesPlaySystemSound(_callWaitingSoundID);
-    }
-}
-
-/// Register the synthesized call-waiting tone as a CoreAudio system sound (once).
+/// Create the looping call-waiting tone player from the synthesized WAV (once).
 - (void)ensureCallWaitingSound {
-    if (_callWaitingSoundID != 0) {
+    if (_callWaitingTone != nil) {
         return;
     }
     NSData *wav = [self callWaitingToneWavData];
@@ -518,14 +502,15 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
         NSLog(@"[Callkeep][ensureCallWaitingSound] write failed: %@", writeError);
         return;
     }
-    SystemSoundID soundID = 0;
-    OSStatus status = AudioServicesCreateSystemSoundID((__bridge CFURLRef)[NSURL fileURLWithPath:path], &soundID);
-    if (status != kAudioServicesNoError) {
-        NSLog(@"[Callkeep][ensureCallWaitingSound] create failed: %d", (int)status);
+    NSError *playerError = nil;
+    AVAudioPlayer *player = [[AVAudioPlayer alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:&playerError];
+    if (player == nil) {
+        NSLog(@"[Callkeep][ensureCallWaitingSound] player init failed: %@", playerError);
         return;
     }
-    _callWaitingSoundID = soundID;
-    AudioServicesAddSystemSoundCompletion(_callWaitingSoundID, NULL, NULL, WTCallWaitingToneCompletion, (__bridge void *)self);
+    player.numberOfLoops = -1;
+    [player prepareToPlay];
+    _callWaitingTone = player;
 }
 
 /// Synthesize a 16-bit mono PCM WAV (8 kHz) for one call-waiting tone cycle:

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -93,7 +93,14 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     if (iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
     }
- 
+
+    // Create the call-waiting tone player up-front (like the ringback player),
+    // so its audio unit is ready before WebRTC takes over the audio session.
+    // A player created lazily mid-call was silent on a device (WT-1415).
+    if (_callWaitingTone == nil) {
+      _callWaitingTone = [self createCallWaitingTonePlayer];
+    }
+
     _driveIdleTimerDisabled = iosOptions.driveIdleTimerDisabled;
   } else {
 #ifdef DEBUG
@@ -150,7 +157,12 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     if (_ringback == nil && iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
     }
-    
+
+    // Create the call-waiting tone player up-front (see restoreSetUp, WT-1415).
+    if (_callWaitingTone == nil) {
+      _callWaitingTone = [self createCallWaitingTonePlayer];
+    }
+
     _driveIdleTimerDisabled = iosOptions.driveIdleTimerDisabled;
   } else {
 #ifdef DEBUG

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -22,6 +22,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   WTPDelegateFlutterApi *_delegateFlutterApi;
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
+  AVAudioPlayer *_callWaitingTone;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -449,10 +450,122 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     completion(nil);
 }
 
-- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{ 
+- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{
     if(_ringback != nil)[_ringback pause];
-    
+
     completion(nil);
+}
+
+#pragma mark - WTPHostSoundApi - call-waiting tone (WT-1415)
+
+/// Play a soft, recurrent call-waiting beep over the active call audio.
+///
+/// Driven from Dart (CallBloc) when a second call arrives while another call is
+/// connected — the app layer is the reliable source of that state on iOS, where
+/// foreground WebRTC calls are not fully reflected by CallKit. The tone is
+/// synthesized in memory (no bundled asset) and played through the active
+/// AVAudioSession via AVAudioPlayer — the same mechanism as the ringback player —
+/// so it routes to the earpiece/headset at in-call volume rather than blasting at
+/// ringtone volume (mirrors the Android fix in WT-1388). One loop is "beep-beep"
+/// followed by silence; it repeats until [stopCallWaitingTone] is called.
+- (void)playCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
+    if (_callWaitingTone == nil) {
+        _callWaitingTone = [self createCallWaitingTonePlayer];
+    }
+    if (_callWaitingTone != nil) {
+        _callWaitingTone.numberOfLoops = -1;
+        [_callWaitingTone prepareToPlay];
+        BOOL started = [_callWaitingTone play];
+        NSLog(@"[Callkeep][playCallWaitingTone] started=%d", started);
+    } else {
+        NSLog(@"[Callkeep][playCallWaitingTone] player is nil — cannot play");
+    }
+    completion(nil);
+}
+
+- (void)stopCallWaitingTone:(void (^)(FlutterError * _Nullable))completion {
+    if (_callWaitingTone != nil && _callWaitingTone.isPlaying) {
+        NSLog(@"[Callkeep][stopCallWaitingTone]");
+        [_callWaitingTone stop];
+        _callWaitingTone.currentTime = 0;
+    }
+    completion(nil);
+}
+
+/// Build an AVAudioPlayer for the synthesized call-waiting tone.
+- (nullable AVAudioPlayer *)createCallWaitingTonePlayer {
+    NSData *wav = [self callWaitingToneWavData];
+    NSError *error = nil;
+    AVAudioPlayer *player = [[AVAudioPlayer alloc] initWithData:wav error:&error];
+    if (error != nil) {
+        NSLog(@"[Callkeep][createCallWaitingTonePlayer] failed: %@", error);
+        return nil;
+    }
+    return player;
+}
+
+/// Synthesize a 16-bit mono PCM WAV (8 kHz) for one call-waiting tone cycle:
+/// beep (400 ms) — gap (200 ms) — beep (400 ms) — silence (2000 ms), 440 Hz,
+/// matching the ~3 s cadence of the Android call-waiting tone.
+- (NSData *)callWaitingToneWavData {
+    const double sampleRate = 8000.0;
+    const double frequency = 440.0;
+    const double amplitude = 0.5;
+    const NSUInteger segmentCount = 4;
+    const double segmentFreq[4] = {frequency, 0.0, frequency, 0.0};
+    const double segmentMs[4] = {400.0, 200.0, 400.0, 2000.0};
+
+    NSMutableData *samples = [NSMutableData data];
+    double phase = 0.0;
+    const double phaseIncrement = 2.0 * M_PI * frequency / sampleRate;
+    for (NSUInteger s = 0; s < segmentCount; s++) {
+        NSUInteger frames = (NSUInteger)(sampleRate * segmentMs[s] / 1000.0);
+        BOOL tone = segmentFreq[s] > 0.0;
+        for (NSUInteger i = 0; i < frames; i++) {
+            int16_t value = 0;
+            if (tone) {
+                value = (int16_t)(sin(phase) * amplitude * INT16_MAX);
+                phase += phaseIncrement;
+                if (phase > 2.0 * M_PI) {
+                    phase -= 2.0 * M_PI;
+                }
+            } else {
+                phase = 0.0;
+            }
+            [samples appendBytes:&value length:sizeof(int16_t)];
+        }
+    }
+    return [self wavDataFromPCM:samples sampleRate:(uint32_t)sampleRate channels:1 bitsPerSample:16];
+}
+
+/// Wrap raw little-endian PCM samples in a minimal RIFF/WAVE container.
+- (NSData *)wavDataFromPCM:(NSData *)pcm
+                sampleRate:(uint32_t)sampleRate
+                  channels:(uint16_t)channels
+             bitsPerSample:(uint16_t)bitsPerSample {
+    uint32_t dataSize = (uint32_t)pcm.length;
+    uint16_t blockAlign = channels * (bitsPerSample / 8);
+    uint32_t byteRate = sampleRate * blockAlign;
+    uint32_t chunkSize = 36 + dataSize;
+    uint16_t audioFormat = 1; // PCM
+    uint16_t fmtChunkSize = 16;
+
+    NSMutableData *wav = [NSMutableData data];
+    [wav appendBytes:"RIFF" length:4];
+    [wav appendBytes:&chunkSize length:4];
+    [wav appendBytes:"WAVE" length:4];
+    [wav appendBytes:"fmt " length:4];
+    [wav appendBytes:&fmtChunkSize length:4];
+    [wav appendBytes:&audioFormat length:2];
+    [wav appendBytes:&channels length:2];
+    [wav appendBytes:&sampleRate length:4];
+    [wav appendBytes:&byteRate length:4];
+    [wav appendBytes:&blockAlign length:2];
+    [wav appendBytes:&bitsPerSample length:2];
+    [wav appendBytes:"data" length:4];
+    [wav appendBytes:&dataSize length:4];
+    [wav appendData:pcm];
+    return wav;
 }
 
 #pragma mark - FlutterApplicationLifeCycleDelegate

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -493,14 +493,27 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 }
 
 /// Build an AVAudioPlayer for the synthesized call-waiting tone.
+///
+/// The synthesized WAV is written to a temporary file and loaded via
+/// `initWithContentsOfURL:` — the exact same path as the proven ringback player.
+/// (An in-memory `initWithData:` player was silent over the active WebRTC audio
+/// session on a device.)
 - (nullable AVAudioPlayer *)createCallWaitingTonePlayer {
     NSData *wav = [self callWaitingToneWavData];
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"webtrit_call_waiting_tone.wav"];
+    NSError *writeError = nil;
+    if (![wav writeToFile:path options:NSDataWritingAtomic error:&writeError]) {
+        NSLog(@"[Callkeep][createCallWaitingTonePlayer] write failed: %@", writeError);
+        return nil;
+    }
     NSError *error = nil;
-    AVAudioPlayer *player = [[AVAudioPlayer alloc] initWithData:wav error:&error];
+    AVAudioPlayer *player = [[AVAudioPlayer alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:&error];
     if (error != nil) {
         NSLog(@"[Callkeep][createCallWaitingTonePlayer] failed: %@", error);
         return nil;
     }
+    player.numberOfLoops = -1;
+    [player prepareToPlay];
     return player;
 }
 

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
@@ -254,6 +254,8 @@ extern void SetUpWTAndroidHelperHostApiWithSuffix(id<FlutterBinaryMessenger> bin
 @protocol WTPHostSoundApi
 - (void)playRingbackSound:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopRingbackSound:(void (^)(FlutterError *_Nullable))completion;
+- (void)playCallWaitingTone:(void (^)(FlutterError *_Nullable))completion;
+- (void)stopCallWaitingTone:(void (^)(FlutterError *_Nullable))completion;
 @end
 
 extern void SetUpWTPHostSoundApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<WTPHostSoundApi> *_Nullable api);

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -1605,4 +1605,50 @@ class PHostSoundApi {
       return;
     }
   }
+
+  Future<void> playCallWaitingTone() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.playCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> stopCallWaitingTone() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.stopCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
+++ b/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
@@ -191,6 +191,16 @@ class WebtritCallkeep extends WebtritCallkeepPlatform {
   Future<void> stopRingbackSound() {
     return _soundApi.stopRingbackSound();
   }
+
+  @override
+  Future<void> playCallWaitingTone() {
+    return _soundApi.playCallWaitingTone();
+  }
+
+  @override
+  Future<void> stopCallWaitingTone() {
+    return _soundApi.stopCallWaitingTone();
+  }
 }
 
 class _CallkeepDelegateRelay implements PDelegateFlutterApi {

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -4,8 +4,8 @@ import 'package:pigeon/pigeon.dart';
   PigeonOptions(
     dartOut: 'lib/src/common/callkeep.pigeon.dart',
     dartTestOut: 'test/src/common/test_callkeep.pigeon.dart',
-    objcHeaderOut: 'ios/Classes/Generated.h',
-    objcSourceOut: 'ios/Classes/Generated.m',
+    objcHeaderOut: 'ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h',
+    objcSourceOut: 'ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m',
     objcOptions: ObjcOptions(
       prefix: 'WT',
     ),
@@ -290,4 +290,12 @@ abstract class PHostSoundApi {
   @ObjCSelector('stopRingbackSound')
   @async
   void stopRingbackSound();
+
+  @ObjCSelector('playCallWaitingTone')
+  @async
+  void playCallWaitingTone();
+
+  @ObjCSelector('stopCallWaitingTone')
+  @async
+  void stopCallWaitingTone();
 }

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -231,6 +231,20 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('stopRingbackSound() has not been implemented.');
   }
 
+  /// Play the call-waiting tone.
+  /// A soft, recurrent beep played over the active call audio to indicate a
+  /// second incoming call while another call is active.
+  /// Returns [Future] that resolves on sound was successfully played.
+  Future<void> playCallWaitingTone() {
+    throw UnimplementedError('playCallWaitingTone() has not been implemented.');
+  }
+
+  /// Stop the call-waiting tone.
+  /// Returns [Future] that resolves on sound was successfully stopped.
+  Future<void> stopCallWaitingTone() {
+    throw UnimplementedError('stopCallWaitingTone() has not been implemented.');
+  }
+
   /// Get the connection details for the given [callId].
   ///
   /// Returns a [Future] resolving to a [CallkeepConnection] if found, or null otherwise.


### PR DESCRIPTION
## WT-1415 — call-waiting tone on a second call during an active call

Adds a shared, app-driven sound API for the call-waiting tone so the trigger is consistent across iOS and Android.

### Why
On iOS, foreground WebRTC calls are barely reflected by CallKit, so the plugin cannot reliably self-detect the active call (confirmed empirically: a Dart-driven probe produced sound, plugin-side auto-detection produced silence). `CallBloc` is the reliable source of call state on both platforms, so it now decides when the tone plays; the platform only plays it.

### Changes
- **platform_interface + WebtritCallkeepSound**: `playCallWaitingTone()` / `stopCallWaitingTone()`.
- **iOS**: synthesize a soft 440 Hz beep-beep loop in memory and play it via `AVAudioPlayer` over the active `AVAudioSession` (same proven path as ringback).
- **Android**: `SoundApi` plays the existing `AudioManager` call-waiting tone; `PhoneConnection` no longer auto-plays it — it only suppresses the full ringtone when a call is active (WT-1388 behavior preserved), and the app triggers the tone via the same API.
- Pigeon definitions + generated bindings updated (iOS Obj-C, Android Kotlin, Dart).

### Companion
- App side: WebTrit/webtrit_phone `feat/wt-1415-call-waiting-tone-api` (calls the new API from `CallBloc.onChange`).

### Status
Draft — pending on-device verification on both platforms.