### PR TITLE
ci: enforce callkeep tag == version on tag push

### DIFF
--- a/.github/workflows/tag-version-check.yaml
+++ b/.github/workflows/tag-version-check.yaml
@@ -1,0 +1,30 @@
+name: tag-version-check
+
+# Enforces the release invariant: a version tag X.Y.Z must sit on a commit whose
+# umbrella webtrit_callkeep/pubspec.yaml version is X.Y.Z (see docs/release_process.md).
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify umbrella version matches the tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION_FIELD=$(grep -m1 '^version:' webtrit_callkeep/pubspec.yaml | awk '{print $2}')
+          VERSION="${VERSION_FIELD%%+*}"
+          echo "tag=$TAG  pubspec version=$VERSION_FIELD (base $VERSION)"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::Tag '$TAG' does not match webtrit_callkeep version '$VERSION_FIELD'. The tag must sit on the version-bump commit (see docs/release_process.md)."
+            exit 1
+          fi
+          echo "OK: tag matches the umbrella version."

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -42,3 +42,27 @@ where that version is already set. Tags are **immutable** - never move a publish
 A CI check validates the invariant on tag push: it reads `webtrit_callkeep/pubspec.yaml` at the
 tagged commit and fails if the `X.Y.Z` part of `version:` does not equal the tag name. This makes
 every published tag a reliable, immutable pointer to its exact release.
+
+## Tag corrections
+
+Tags are immutable; we do not move them. The one exception is repairing a historically broken tag
+(one that predates the invariant above and points at a commit whose `version:` does not match).
+When a tag must be corrected, force-move it AND record it here, because anyone who already fetched
+the old tag must re-fetch:
+
+```bash
+git fetch --tags -f
+```
+
+Use a descriptive annotated tag message when correcting, e.g.:
+
+```bash
+git tag -f -a 0.0.2 6ae789f -m "release 0.0.2 (corrected: previous tag was on a pre-bump commit with version 0.3.5+0)"
+git push -f origin 0.0.2
+```
+
+### Log
+
+| Date       | Tag   | From (old commit)        | To (correct commit)      | Reason                                                |
+|------------|-------|--------------------------|--------------------------|-------------------------------------------------------|
+| 2026-06-04 | 0.0.2 | `0922c30` (version 0.3.5+0) | `6ae789f` (version 0.0.2+0) | Original tag predated the version-bump commit on `release/0.0.2`. |

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -5,11 +5,11 @@ How a `webtrit_callkeep` release is versioned and tagged.
 ## Versioning model
 
 This is a federated plugin monorepo. The consumer-facing package is the umbrella
-**`webtrit_callkeep`** — its `version:` is the release version of the whole plugin.
+**`webtrit_callkeep`** - its `version:` is the release version of the whole plugin.
 
 The platform packages (`webtrit_callkeep_android`, `webtrit_callkeep_ios`,
-`webtrit_callkeep_platform_interface`, `…_macos`, `…_linux`, `…_web`, `…_windows`) are internal,
-wired together by relative paths, and are **not** independently versioned — they stay at
+`webtrit_callkeep_platform_interface`, `..._macos`, `..._linux`, `..._web`, `..._windows`) are internal,
+wired together by relative paths, and are **not** independently versioned - they stay at
 `0.0.0+0`. Only the umbrella carries the meaningful version.
 
 Versions follow `X.Y.Z+N` (semantic version `X.Y.Z` plus an optional build number `N`).
@@ -21,13 +21,13 @@ git tag  X.Y.Z   ==   webtrit_callkeep/pubspec.yaml  version: X.Y.Z+N
 ```
 
 The tag name equals the `X.Y.Z` part of the umbrella `version:`, and the tag points at the commit
-where that version is already set. Tags are **immutable** — never move a published tag.
+where that version is already set. Tags are **immutable** - never move a published tag.
 
 ## Cutting a release
 
 1. Bump the umbrella version in `webtrit_callkeep/pubspec.yaml` to `X.Y.Z+N`. This is the
    version-bump commit. (Platform packages are left at `0.0.0+0`.)
-2. Tag **that** commit — not an earlier one:
+2. Tag **that** commit - not an earlier one:
    ```bash
    git tag -a X.Y.Z -m "release X.Y.Z"
    git push origin X.Y.Z

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -39,9 +39,10 @@ where that version is already set. Tags are **immutable** - never move a publish
 
 ## Enforcement
 
-A CI check validates the invariant on tag push: it reads `webtrit_callkeep/pubspec.yaml` at the
-tagged commit and fails if the `X.Y.Z` part of `version:` does not equal the tag name. This makes
-every published tag a reliable, immutable pointer to its exact release.
+A CI check (`.github/workflows/tag-version-check.yaml`) validates the invariant on tag push: it
+reads `webtrit_callkeep/pubspec.yaml` at the tagged commit and fails if the `X.Y.Z` part of
+`version:` does not equal the tag name. This makes every published tag a reliable, immutable
+pointer to its exact release.
 
 ## Tag corrections
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -66,3 +66,8 @@ git push -f origin 0.0.2
 | Date       | Tag   | From (old commit)        | To (correct commit)      | Reason                                                |
 |------------|-------|--------------------------|--------------------------|-------------------------------------------------------|
 | 2026-06-04 | 0.0.2 | `0922c30` (version 0.3.5+0) | `6ae789f` (version 0.0.2+0) | Original tag predated the version-bump commit on `release/0.0.2`. |
+| 2026-06-04 | 0.3.1 | `da8884c` (version 0.3.0+0) | `086c118` (version 0.3.1+0) | Original tag predated the version-bump commit on `release/0.3.1`. |
+
+> `0.2.0` is also broken (tag has version 0.1.2+0) but **cannot be corrected by re-tagging**: no
+> commit on `release/0.2.0` ever set `version:` to `0.2.0`. Fixing it would require adding a new
+> version-bump commit, so it is left as-is for now.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,44 @@
+# Release Process
+
+How a `webtrit_callkeep` release is versioned and tagged.
+
+## Versioning model
+
+This is a federated plugin monorepo. The consumer-facing package is the umbrella
+**`webtrit_callkeep`** — its `version:` is the release version of the whole plugin.
+
+The platform packages (`webtrit_callkeep_android`, `webtrit_callkeep_ios`,
+`webtrit_callkeep_platform_interface`, `…_macos`, `…_linux`, `…_web`, `…_windows`) are internal,
+wired together by relative paths, and are **not** independently versioned — they stay at
+`0.0.0+0`. Only the umbrella carries the meaningful version.
+
+Versions follow `X.Y.Z+N` (semantic version `X.Y.Z` plus an optional build number `N`).
+
+## The invariant
+
+```
+git tag  X.Y.Z   ==   webtrit_callkeep/pubspec.yaml  version: X.Y.Z+N
+```
+
+The tag name equals the `X.Y.Z` part of the umbrella `version:`, and the tag points at the commit
+where that version is already set. Tags are **immutable** — never move a published tag.
+
+## Cutting a release
+
+1. Bump the umbrella version in `webtrit_callkeep/pubspec.yaml` to `X.Y.Z+N`. This is the
+   version-bump commit. (Platform packages are left at `0.0.0+0`.)
+2. Tag **that** commit — not an earlier one:
+   ```bash
+   git tag -a X.Y.Z -m "release X.Y.Z"
+   git push origin X.Y.Z
+   ```
+
+> Common past mistake: tagging **before** the version-bump commit, so the tag pointed at a commit
+> whose umbrella `version:` was stale (e.g. tag `0.0.2` once sat on a commit reading
+> `version: 0.3.5+0`). The tag must sit on the commit where `version:` already reads `X.Y.Z+N`.
+
+## Enforcement
+
+A CI check validates the invariant on tag push: it reads `webtrit_callkeep/pubspec.yaml` at the
+tagged commit and fails if the `X.Y.Z` part of `version:` does not equal the tag name. This makes
+every published tag a reliable, immutable pointer to its exact release.


### PR DESCRIPTION
Documents the callkeep release/tagging process and enforces it in CI.

- `docs/release_process.md` - versioning model (umbrella carries the version; platform packages stay at `0.0.0+0`), the `tag == umbrella version` invariant, the release procedure, and a Tag corrections log.
- `.github/workflows/tag-version-check.yaml` - on tag push (`*.*.*`), reads `webtrit_callkeep/pubspec.yaml` at the tagged commit and fails if the `X.Y.Z` part of `version:` does not equal the tag name. This is what makes published tags reliable going forward.

Tag corrections already applied (force-moved to the correct commits):
- `0.0.2`: `0922c30` (version 0.3.5+0) -> `6ae789f` (0.0.2+0)
- `0.3.1`: `da8884c` (version 0.3.0+0) -> `086c118` (0.3.1+0)
- `0.2.0` is broken too but cannot be corrected by re-tagging (no commit ever set version 0.2.0); left as-is and noted in the doc.

Anyone who fetched the old `0.0.2`/`0.3.1` tags must run `git fetch --tags -f`.

Phone-agnostic - describes only callkeep's own process.