### PR TITLE
ci: fix cspell findings in incoming-call-handling doc

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -26,6 +26,7 @@
     "Siri",
     "jsep",
     "Servicee",
-    "anwser"
+    "anwser",
+    "autonumber"
   ]
 }

--- a/webtrit_callkeep_android/docs/incoming-call-handling.md
+++ b/webtrit_callkeep_android/docs/incoming-call-handling.md
@@ -10,7 +10,7 @@ Related: step-by-step flows in [call-flows.md](call-flows.md); services in
 hosting callkeep on an app-owned engine in
 [../../docs/external-flutter-engines.md](../../docs/external-flutter-engines.md).
 
-Colour: blue = callkeep, orange = host app, grey = external (Telecom / system UI), yellow = decision.
+Color: blue = callkeep, orange = host app, grey = external (Telecom / system UI), yellow = decision.
 
 ## Who owns the background work
 


### PR DESCRIPTION
Spell-check (cspell) was failing on `webtrit_callkeep_android/docs/incoming-call-handling.md`:
- `Colour` -> `Color` (match the American VGV dictionary used by the project)
- `autonumber` (Mermaid sequence-diagram keyword) added to `.github/cspell.json` words

Pre-existing on develop; surfaced on the release/1.2.0 PR (#305).