### PR TITLE
ci: auto-tag main with umbrella version on release merge

### DIFF
--- a/.github/workflows/auto-tag-version.yaml
+++ b/.github/workflows/auto-tag-version.yaml
@@ -1,0 +1,45 @@
+name: auto-tag-version
+
+# After a release PR lands on main, publish the version tag automatically.
+# Reads the umbrella webtrit_callkeep/pubspec.yaml version and creates an annotated
+# tag X.Y.Z on the merged main commit if it does not already exist.
+# Idempotent: pushes that do not change the version (or where the tag already exists)
+# are no-ops. The tag-version-check workflow remains the enforcement net for any
+# manually pushed tag. See docs/release_process.md.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - webtrit_callkeep/pubspec.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag if missing
+        run: |
+          set -euo pipefail
+          VERSION_FIELD=$(grep -m1 '^version:' webtrit_callkeep/pubspec.yaml | awk '{print $2}')
+          VERSION="${VERSION_FIELD%%+*}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from webtrit_callkeep/pubspec.yaml"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag '$VERSION' already exists - nothing to do."
+            exit 0
+          fi
+          echo "Creating tag '$VERSION' on $GITHUB_SHA"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "release $VERSION"
+          git push origin "$VERSION"


### PR DESCRIPTION
Adds `.github/workflows/auto-tag-version.yaml`: on push to `main` that touches `webtrit_callkeep/pubspec.yaml`, reads the umbrella version and creates annotated tag `X.Y.Z` if it does not already exist.

## Why
Unifies release into one flow - no manual `git tag` step after merge. Tags are created at the only safe point (the merged `main` commit), avoiding orphaned tags from squash-merge / rebased release branches.

## Notes
- Idempotent: no-op if the tag already exists or the version did not change.
- `tag-version-check.yaml` stays as the enforcement net for any manually pushed tag.
- Activates for releases landing on `main` after this workflow is present there.