### PR TITLE
ci: read version with awk to keep error path reachable

### DIFF
--- a/.github/workflows/auto-tag-version.yaml
+++ b/.github/workflows/auto-tag-version.yaml
@@ -28,7 +28,10 @@ jobs:
       - name: Create version tag if missing
         run: |
           set -euo pipefail
-          VERSION_FIELD=$(grep -m1 '^version:' webtrit_callkeep/pubspec.yaml | awk '{print $2}')
+          # awk (not grep|awk): returns 0 even with no match, so a missing
+          # version yields an empty VERSION and reaches the error below
+          # instead of aborting on pipefail.
+          VERSION_FIELD=$(awk '/^version:/{print $2; exit}' webtrit_callkeep/pubspec.yaml)
           VERSION="${VERSION_FIELD%%+*}"
           if [ -z "$VERSION" ]; then
             echo "::error::Could not read version from webtrit_callkeep/pubspec.yaml"


### PR DESCRIPTION
Follow-up to the auto-tag workflow (#307, already merged), applying the same review fix raised on the phone PR.

`grep -m1 '^version:' | awk` under `set -euo pipefail` aborts the script on the pipeline's non-zero exit when `version:` is absent - before the explicit `::error::` block, so the friendly message is dead code. Plain `awk '/^version:/{print $2; exit}'` returns 0 even with no match, leaving VERSION empty so the `[ -z ]` check fires as intended.

No behaviour change on the happy path.