### PR TITLE
fix(android): stop surfacing literal "undefined" as the caller number

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallHandle.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallHandle.kt
@@ -12,8 +12,16 @@ data class CallHandle(
     }
 
     companion object {
-        fun fromBundle(bundle: Bundle?): CallHandle {
-            val number = bundle?.getString("number") ?: "undefined"
+        /**
+         * Builds a [CallHandle] from a bundle, or returns `null` when the number is absent.
+         *
+         * A missing number must propagate upward as an absence so callers can decide the
+         * fallback display value. It must never become a literal placeholder string, which
+         * would otherwise be shown by the Telecom UI as the caller's phone number and would
+         * break contact lookup.
+         */
+        fun fromBundle(bundle: Bundle?): CallHandle? {
+            val number = bundle?.getString("number") ?: return null
             return CallHandle(number)
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
@@ -55,7 +55,7 @@ data class CallMetadata(
      * with a placeholder string here; each consumer (Telecom presentation, notification text,
      * the Flutter client) decides how to render an unknown caller.
      */
-    val name: String? get() = displayName?.takeIf { it.isNotEmpty() } ?: number
+    val name: String? get() = displayName?.takeIf { it.isNotBlank() } ?: number
 
     fun toBundle(): Bundle =
         Bundle().apply {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
@@ -46,8 +46,8 @@ data class CallMetadata(
     val createdTime: Long? = null,
     val acceptedTime: Long? = null,
 ) {
-    val number: String get() = handle?.number ?: "Undefined"
-    val name: String get() = displayName?.takeIf { it.isNotEmpty() } ?: number
+    val number: String? get() = handle?.number
+    val name: String get() = displayName?.takeIf { it.isNotEmpty() } ?: number.orEmpty()
 
     fun toBundle(): Bundle =
         Bundle().apply {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
@@ -47,7 +47,15 @@ data class CallMetadata(
     val acceptedTime: Long? = null,
 ) {
     val number: String? get() = handle?.number
-    val name: String get() = displayName?.takeIf { it.isNotEmpty() } ?: number.orEmpty()
+
+    /**
+     * Best human-readable label for the call: the display name, falling back to the number.
+     *
+     * Returns `null` when neither is known. The absence is propagated rather than replaced
+     * with a placeholder string here; each consumer (Telecom presentation, notification text,
+     * the Flutter client) decides how to render an unknown caller.
+     */
+    val name: String? get() = displayName?.takeIf { it.isNotEmpty() } ?: number
 
     fun toBundle(): Bundle =
         Bundle().apply {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/InvalidCallMetadataException.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/InvalidCallMetadataException.kt
@@ -1,0 +1,13 @@
+package com.webtrit.callkeep.models
+
+/**
+ * Thrown when call metadata is missing a field required to proceed -- e.g. an outgoing
+ * call without a destination number, or a connection broadcast that arrives without a
+ * handle.
+ *
+ * Surfaced through the normal failure channels (dispatch error / failed-call store)
+ * rather than crashing the service or leaving a half-established "ghost" call.
+ */
+class InvalidCallMetadataException(
+    message: String,
+) : Exception(message)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/ActiveCallNotificationBuilder.kt
@@ -26,7 +26,7 @@ class ActiveCallNotificationBuilder : NotificationBuilder() {
                 context.getString(R.string.push_notification_active_call_channel_title)
             }
 
-        val text = callsMetaData.joinToString { it.name }
+        val text = callsMetaData.joinToString { it.name ?: context.getString(R.string.unknown_caller) }
 
         val hungUpAction: Notification.Action =
             Notification.Action

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -80,8 +80,9 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
         val icDecline = R.drawable.ic_call_hungup
         val icAnswer = R.drawable.ic_call_answer
 
+        val callerName = meta.name ?: context.getString(R.string.unknown_caller)
         val title = context.getString(R.string.incoming_call_title)
-        val description = context.getString(R.string.incoming_call_description, meta.name)
+        val description = context.getString(R.string.incoming_call_description, callerName)
 
         val answerButton = R.string.answer_call_button_text
         val declineButton = R.string.decline_button_text
@@ -111,7 +112,7 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
             val person =
                 Person
                     .Builder()
-                    .setName(meta.name)
+                    .setName(callerName)
                     .setImportant(true)
                     .build()
             val style = Notification.CallStyle.forIncomingCall(person, declineIntent, answerIntent)
@@ -133,8 +134,9 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
         val meta =
             requireNotNull(callMetaData) { "Call metadata must be set before updating the notification." }
 
+        val callerName = meta.name ?: context.getString(R.string.unknown_caller)
         val title = context.getString(R.string.incoming_call_title)
-        val description = context.getString(R.string.incoming_call_description, meta.name)
+        val description = context.getString(R.string.incoming_call_description, callerName)
 
         return NotificationCompat
             .Builder(context, INCOMING_CALL_NOTIFICATION_CHANNEL_ID)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
@@ -75,8 +75,9 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
         val answerIntent = createActionIntent(meta, StandaloneServiceAction.AnswerCall)
         val declineIntent = createActionIntent(meta, StandaloneServiceAction.DeclineCall)
 
+        val callerName = meta.name ?: context.getString(R.string.unknown_caller)
         val title = context.getString(R.string.incoming_call_title)
-        val text = context.getString(R.string.incoming_call_description, meta.name)
+        val text = context.getString(R.string.incoming_call_description, callerName)
 
         val builder =
             baseBuilder(title, text).apply {
@@ -97,7 +98,7 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
             val person =
                 Person
                     .Builder()
-                    .setName(meta.name)
+                    .setName(callerName)
                     .setImportant(true)
                     .build()
             builder

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -551,7 +551,15 @@ class PhoneConnection internal constructor(
             // surfacing a placeholder string as the caller's phone number.
             setAddress(null, TelecomManager.PRESENTATION_UNKNOWN)
         }
-        setCallerDisplayName(metadata.name, TelecomManager.PRESENTATION_ALLOWED)
+
+        val name = metadata.name
+        if (name != null) {
+            setCallerDisplayName(name, TelecomManager.PRESENTATION_ALLOWED)
+        } else {
+            // No display name or number to show; let the Telecom UI render its own
+            // "unknown" label rather than a fabricated placeholder.
+            setCallerDisplayName(null, TelecomManager.PRESENTATION_UNKNOWN)
+        }
 
         if (previousHasVideo != metadata.hasVideo) {
             metadata.hasVideo?.let { applyVideoState(it) }
@@ -926,7 +934,12 @@ class PhoneConnection internal constructor(
             onDisconnectCallback = onDisconnect,
             timeout = ConnectionTimeout.createOutgoingConnectionTimeout(context),
         ).apply {
-            setCallerDisplayName(metadata.name, TelecomManager.PRESENTATION_ALLOWED)
+            val name = metadata.name
+            if (name != null) {
+                setCallerDisplayName(name, TelecomManager.PRESENTATION_ALLOWED)
+            } else {
+                setCallerDisplayName(null, TelecomManager.PRESENTATION_UNKNOWN)
+            }
             setInitialized()
             setDialing()
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -543,7 +543,14 @@ class PhoneConnection internal constructor(
         metadata = metadata.mergeWith(requestCallMetadata)
         extras = metadata.toBundle()
 
-        setAddress(metadata.number.toUri(), TelecomManager.PRESENTATION_ALLOWED)
+        val number = metadata.number
+        if (number != null) {
+            setAddress(number.toUri(), TelecomManager.PRESENTATION_ALLOWED)
+        } else {
+            // No real number to present; mark the address as unknown rather than
+            // surfacing a placeholder string as the caller's phone number.
+            setAddress(null, TelecomManager.PRESENTATION_UNKNOWN)
+        }
         setCallerDisplayName(metadata.name, TelecomManager.PRESENTATION_ALLOWED)
 
         if (previousHasVideo != metadata.hasVideo) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -20,6 +20,7 @@ import com.webtrit.callkeep.common.TelephonyUtils
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.EmergencyNumberException
 import com.webtrit.callkeep.models.FailureMetadata
+import com.webtrit.callkeep.models.InvalidCallMetadataException
 import com.webtrit.callkeep.models.OutgoingFailureType
 import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
@@ -680,7 +681,7 @@ class PhoneConnectionService : ConnectionService() {
 
             val number =
                 metadata.number
-                    ?: throw IllegalArgumentException(
+                    ?: throw InvalidCallMetadataException(
                         "startOutgoingCall: missing destination number for callId=${metadata.callId}",
                     )
             val uri: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -678,11 +678,16 @@ class PhoneConnectionService : ConnectionService() {
         ) {
             Log.i(TAG, "onOutgoingCall, callId: ${metadata.callId}")
 
-            val uri: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, metadata.number, null)
+            val number =
+                metadata.number
+                    ?: throw IllegalArgumentException(
+                        "startOutgoingCall: missing destination number for callId=${metadata.callId}",
+                    )
+            val uri: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null)
             val telephonyUtils = TelephonyUtils(context)
 
-            if (telephonyUtils.isEmergencyNumber(metadata.number)) {
-                Log.i(TAG, "onOutgoingCall, trying to call on emergency number: ${metadata.number}")
+            if (telephonyUtils.isEmergencyNumber(number)) {
+                Log.i(TAG, "onOutgoingCall, trying to call on emergency number: $number")
 
                 val failureMetadata =
                     FailureMetadata(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -33,6 +33,7 @@ import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.EmergencyNumberException
 import com.webtrit.callkeep.models.FailedCallInfo
 import com.webtrit.callkeep.models.FailureMetadata
+import com.webtrit.callkeep.models.InvalidCallMetadataException
 import com.webtrit.callkeep.models.OutgoingFailureSource
 import com.webtrit.callkeep.models.OutgoingFailureType
 import com.webtrit.callkeep.models.toAudioDevice
@@ -332,9 +333,23 @@ class ForegroundService :
                             // Outgoing call is now active in Telecom — promote from pending.
                             core.promote(callMetaData.callId, callMetaData, PCallkeepConnectionState.STATE_DIALING)
                             syncScreenWakelock()
+                            val handle = callMetaData.handle
+                            if (handle == null) {
+                                // Should not happen for a confirmed outgoing call. Fail the request
+                                // through the normal channel instead of crashing on handle!! or
+                                // leaving a ghost call that Telecom shows but Flutter never learns of.
+                                val error =
+                                    InvalidCallMetadataException(
+                                        "OngoingCall confirmed for ${callMetaData.callId} without a handle",
+                                    )
+                                logger.e("$logContext: ${error.message}")
+                                saveFailedOutgoingCall(metadata, OutgoingFailureSource.CS_CALLBACK, error)
+                                finish(Result.failure(error))
+                                return
+                            }
                             flutterDelegateApi?.performStartCall(
                                 callMetaData.callId,
-                                callMetaData.handle!!.toPHandle(),
+                                handle.toPHandle(),
                                 // Pass the resolved label (display name or number), or null when
                                 // unknown; the pigeon contract is nullable and the Flutter client
                                 // decides how to render an unknown caller.
@@ -993,8 +1008,15 @@ class ForegroundService :
                 return@let
             }
 
+            val handle = metadata.handle
+            if (handle == null) {
+                // Cannot build a PHandle without a number; skip rather than crash on a
+                // malformed/handle-less broadcast (the call is already promoted above).
+                logger.w("handleCSReportDidPushIncomingCall: missing handle for callId=${metadata.callId}; skipping didPushIncomingCall")
+                return@let
+            }
             flutterDelegateApi?.didPushIncomingCall(
-                handleArg = metadata.handle!!.toPHandle(),
+                handleArg = handle.toPHandle(),
                 displayNameArg = metadata.displayName,
                 videoArg = metadata.hasVideo ?: false,
                 callIdArg = metadata.callId,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -335,9 +335,9 @@ class ForegroundService :
                             flutterDelegateApi?.performStartCall(
                                 callMetaData.callId,
                                 callMetaData.handle!!.toPHandle(),
-                                // handle is non-null here, so name resolves to the number at worst;
-                                // orEmpty() only satisfies the non-null pigeon contract.
-                                callMetaData.name.orEmpty(),
+                                // handle is force-unwrapped above, so name always resolves to the
+                                // display name or the number here, never null.
+                                callMetaData.name!!,
                                 callMetaData.hasVideo ?: false,
                             ) {}
                             finish(Result.success(null))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -335,9 +335,10 @@ class ForegroundService :
                             flutterDelegateApi?.performStartCall(
                                 callMetaData.callId,
                                 callMetaData.handle!!.toPHandle(),
-                                // handle is force-unwrapped above, so name always resolves to the
-                                // display name or the number here, never null.
-                                callMetaData.name!!,
+                                // Pass the resolved label (display name or number), or null when
+                                // unknown; the pigeon contract is nullable and the Flutter client
+                                // decides how to render an unknown caller.
+                                callMetaData.name,
                                 callMetaData.hasVideo ?: false,
                             ) {}
                             finish(Result.success(null))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -335,7 +335,9 @@ class ForegroundService :
                             flutterDelegateApi?.performStartCall(
                                 callMetaData.callId,
                                 callMetaData.handle!!.toPHandle(),
-                                callMetaData.name,
+                                // handle is non-null here, so name resolves to the number at worst;
+                                // orEmpty() only satisfies the non-null pigeon contract.
+                                callMetaData.name.orEmpty(),
                                 callMetaData.hasVideo ?: false,
                             ) {}
                             finish(Result.success(null))

--- a/webtrit_callkeep_android/android/src/main/res/values/strings.xml
+++ b/webtrit_callkeep_android/android/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="push_notification_foreground_call_service_title">Ongoing call</string>
     <string name="push_notification_foreground_call_service_description">This service keeps the call active in the background</string>
     <string name="incoming_call_connecting">Connecting…</string>
+    <string name="unknown_caller">Unknown caller</string>
 </resources>

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallHandleTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallHandleTest.kt
@@ -1,0 +1,65 @@
+package com.webtrit.callkeep.models
+
+import android.os.Build
+import android.os.Bundle
+import com.webtrit.callkeep.common.CallDataConst
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [CallHandle] bundle (de)serialization and the absence propagation
+ * introduced for WT-1141: a missing number must surface as `null`, never as a
+ * literal placeholder string.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class CallHandleTest {
+    @Test
+    fun `fromBundle returns null for a null bundle`() {
+        assertNull(CallHandle.fromBundle(null))
+    }
+
+    @Test
+    fun `fromBundle returns null when the number key is absent`() {
+        assertNull(CallHandle.fromBundle(Bundle()))
+    }
+
+    @Test
+    fun `fromBundle reads the number when present`() {
+        val bundle = Bundle().apply { putString("number", "555001") }
+
+        assertEquals(CallHandle("555001"), CallHandle.fromBundle(bundle))
+    }
+
+    @Test
+    fun `toBundle and fromBundle round-trip preserves the number`() {
+        val original = CallHandle("555002")
+
+        assertEquals(original, CallHandle.fromBundle(original.toBundle()))
+    }
+
+    /**
+     * A NUMBER sub-bundle present but missing the "number" key must leave
+     * [CallMetadata.handle] (and therefore [CallMetadata.number]) null rather than
+     * fabricating a placeholder.
+     */
+    @Test
+    fun `fromBundleOrNull leaves handle null when the number key is missing`() {
+        val bundle =
+            Bundle().apply {
+                putString(CallDataConst.CALL_ID, "call-1")
+                putBundle(CallDataConst.NUMBER, Bundle())
+            }
+
+        val metadata = CallMetadata.fromBundleOrNull(bundle)
+
+        assertNotNull(metadata)
+        assertNull(metadata!!.handle)
+        assertNull(metadata.number)
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
@@ -282,14 +282,26 @@ class CallMetadataUpdateTest {
 
     /**
      * Scenario: Blank Name Fallback.
-     * An empty (blank) display name must not win over the number.
+     * A blank display name (empty or whitespace-only) must not win over the number.
      */
     @Test
-    fun `name falls back to number when display name is blank`() {
+    fun `name falls back to number when display name is empty`() {
         val metadata =
             CallMetadata(
-                callId = "blank-name",
+                callId = "empty-name",
                 displayName = "",
+                handle = CallHandle("555002"),
+            )
+
+        assertEquals("555002", metadata.name)
+    }
+
+    @Test
+    fun `name falls back to number when display name is whitespace only`() {
+        val metadata =
+            CallMetadata(
+                callId = "whitespace-name",
+                displayName = "   ",
                 handle = CallHandle("555002"),
             )
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
@@ -1,13 +1,17 @@
 package com.webtrit.callkeep.models
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * Tests for [CallMetadata.mergeWith].
+ * Tests for [CallMetadata.mergeWith] and for the derived [CallMetadata.number]/[CallMetadata.name]
+ * getters.
  *
  * Verifies that partial updates (patching) work correctly, ensuring that
- * specific fields can be updated without resetting other fields to null/defaults.
+ * specific fields can be updated without resetting other fields to null/defaults,
+ * and that a missing number is surfaced as an absence rather than a literal
+ * placeholder string (see WT-1141).
  */
 class CallMetadataUpdateTest {
     /**
@@ -227,5 +231,108 @@ class CallMetadataUpdateTest {
         val result = initial.mergeWith(update)
 
         assertEquals(true, result.speakerOnVideo)
+    }
+
+    /**
+     * Scenario: Missing Number (WT-1141).
+     * When no handle is set, `number` must be null (an absence to be decided by
+     * callers), NOT a literal placeholder string such as "Undefined" that would
+     * leak into the Telecom UI as the caller's phone number.
+     */
+    @Test
+    fun `number is null when handle is absent`() {
+        val metadata = CallMetadata(callId = "no-handle")
+
+        assertNull(metadata.number)
+    }
+
+    /**
+     * Scenario: Number Present.
+     * When a handle is set, `number` returns the handle's number verbatim.
+     */
+    @Test
+    fun `number returns handle value when handle is present`() {
+        val metadata = CallMetadata(callId = "with-handle", handle = CallHandle("100"))
+
+        assertEquals("100", metadata.number)
+    }
+
+    /**
+     * Scenario: Missing Number and Missing Name (WT-1141).
+     * With neither a display name nor a handle, `name` must fall back to an empty
+     * string rather than the old "Undefined" placeholder.
+     */
+    @Test
+    fun `name is empty when display name and handle are absent`() {
+        val metadata = CallMetadata(callId = "anonymous")
+
+        assertEquals("", metadata.name)
+    }
+
+    /**
+     * Scenario: Name Fallback To Number.
+     * Without a display name, `name` falls back to the number.
+     */
+    @Test
+    fun `name falls back to number when display name is absent`() {
+        val metadata = CallMetadata(callId = "fallback", handle = CallHandle("555001"))
+
+        assertEquals("555001", metadata.name)
+    }
+
+    /**
+     * Scenario: Blank Name Fallback.
+     * An empty (blank) display name must not win over the number.
+     */
+    @Test
+    fun `name falls back to number when display name is blank`() {
+        val metadata =
+            CallMetadata(
+                callId = "blank-name",
+                displayName = "",
+                handle = CallHandle("555002"),
+            )
+
+        assertEquals("555002", metadata.name)
+    }
+
+    /**
+     * Scenario: Name Preference.
+     * A non-empty display name takes precedence over the number.
+     */
+    @Test
+    fun `name prefers display name over number`() {
+        val metadata =
+            CallMetadata(
+                callId = "named",
+                displayName = "Alice",
+                handle = CallHandle("555003"),
+            )
+
+        assertEquals("Alice", metadata.name)
+    }
+
+    /**
+     * Scenario: Number Survives Partial Update (WT-1141).
+     * A partial update without a handle must preserve the existing handle, so the
+     * number is not lost (and does not regress to a placeholder) during merges.
+     */
+    @Test
+    fun `mergeWith preserves number when update omits handle`() {
+        val initial =
+            CallMetadata(
+                callId = "merge-keep-number",
+                handle = CallHandle("100"),
+            )
+        val update =
+            CallMetadata(
+                callId = "merge-keep-number",
+                hasMute = true,
+            )
+
+        val result = initial.mergeWith(update)
+
+        assertEquals("100", result.number)
+        assertEquals(true, result.hasMute)
     }
 }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/models/CallMetadataUpdateTest.kt
@@ -259,14 +259,14 @@ class CallMetadataUpdateTest {
 
     /**
      * Scenario: Missing Number and Missing Name (WT-1141).
-     * With neither a display name nor a handle, `name` must fall back to an empty
-     * string rather than the old "Undefined" placeholder.
+     * With neither a display name nor a handle, `name` must be null (an absence for
+     * consumers to render) rather than a placeholder such as "Undefined" or "".
      */
     @Test
-    fun `name is empty when display name and handle are absent`() {
+    fun `name is null when display name and handle are absent`() {
         val metadata = CallMetadata(callId = "anonymous")
 
-        assertEquals("", metadata.name)
+        assertNull(metadata.name)
     }
 
     /**


### PR DESCRIPTION
## Overview

`CallHandle.fromBundle` substituted the literal string `"undefined"` when the
`number` key was missing, and `CallMetadata.number` carried a second `"Undefined"`
fallback. That value reached the Telecom framework via `PhoneConnection.setAddress`,
so the system call UI displayed `undefined` as the caller's phone number and contact
lookup failed (no entry matches `"undefined"`).

## Changes

- `CallHandle.fromBundle` now returns `CallHandle?` (null when the number is absent)
  instead of a placeholder string, propagating the absence upward.
- `CallMetadata.number` is now nullable; `name` falls back to an empty string rather
  than to a placeholder.
- `PhoneConnection.updateData` presents `PRESENTATION_UNKNOWN` (no address) when there
  is no real number, instead of a fabricated one.
- `PhoneConnectionService.startOutgoingCall` rejects a missing destination number
  (handled by the existing dispatch error path) instead of dialing a placeholder.

## Scope / risk

The placeholder only ever appeared in the edge case of a missing `number` (e.g. an
incomplete payload, or metadata built without a handle); normal incoming/outgoing
calls always carry a number and are unaffected. Priority Low / Severity Minor.