### PR TITLE
feat(android): expose call delivery mode (Telecom vs standalone) to Flutter

### DIFF
--- a/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
@@ -74,6 +74,24 @@ class WebtritCallkeepPermissions {
     return platform.getBatteryMode();
   }
 
+  /// Returns how incoming calls are delivered on this device.
+  ///
+  /// On devices without `android.software.telecom` this reports
+  /// [CallkeepAndroidCallDeliveryMode.standalone], a limited path the system may
+  /// throttle. On non-Android platforms returns
+  /// [CallkeepAndroidCallDeliveryMode.unknown].
+  Future<CallkeepAndroidCallDeliveryMode> getCallDeliveryMode() {
+    if (kIsWeb) {
+      return Future.value(CallkeepAndroidCallDeliveryMode.unknown);
+    }
+
+    if (!Platform.isAndroid) {
+      return Future.value(CallkeepAndroidCallDeliveryMode.unknown);
+    }
+
+    return platform.getCallDeliveryMode();
+  }
+
   /// Requests the specified [permissions] on Android.
   ///
   /// Returns a [Map] where:

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -135,6 +135,19 @@ enum class PCallkeepAndroidBatteryMode(
     }
 }
 
+enum class PCallkeepAndroidCallDeliveryMode(
+    val raw: Int,
+) {
+    TELECOM(0),
+    STANDALONE(1),
+    UNKNOWN(2),
+    ;
+
+    companion object {
+        fun ofRaw(raw: Int): PCallkeepAndroidCallDeliveryMode? = values().firstOrNull { it.raw == raw }
+    }
+}
+
 enum class PHandleTypeEnum(
     val raw: Int,
 ) {
@@ -968,6 +981,12 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
                 }
             }
 
+            155.toByte() -> {
+                return (readValue(buffer) as Long?)?.let {
+                    PCallkeepAndroidCallDeliveryMode.ofRaw(it.toInt())
+                }
+            }
+
             else -> {
                 super.readValueOfType(type, buffer)
             }
@@ -1107,6 +1126,11 @@ private open class GeneratedPigeonCodec : StandardMessageCodec() {
             is PCallkeepConnection -> {
                 stream.write(154)
                 writeValue(stream, value.toList())
+            }
+
+            is PCallkeepAndroidCallDeliveryMode -> {
+                stream.write(155)
+                writeValue(stream, value.raw)
             }
 
             else -> {
@@ -1325,6 +1349,8 @@ interface PHostPermissionsApi {
 
     fun getBatteryMode(callback: (Result<PCallkeepAndroidBatteryMode>) -> Unit)
 
+    fun getCallDeliveryMode(callback: (Result<PCallkeepAndroidCallDeliveryMode>) -> Unit)
+
     fun requestPermissions(
         permissions: List<PCallkeepPermission>,
         callback: (Result<List<PPermissionResult>>) -> Unit,
@@ -1406,6 +1432,24 @@ interface PHostPermissionsApi {
                 if (api != null) {
                     channel.setMessageHandler { _, reply ->
                         api.getBatteryMode { result: Result<PCallkeepAndroidBatteryMode> ->
+                            val error = result.exceptionOrNull()
+                            if (error != null) {
+                                reply.reply(GeneratedPigeonUtils.wrapError(error))
+                            } else {
+                                val data = result.getOrNull()
+                                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+                            }
+                        }
+                    }
+                } else {
+                    channel.setMessageHandler(null)
+                }
+            }
+            run {
+                val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getCallDeliveryMode$separatedMessageChannelSuffix", codec)
+                if (api != null) {
+                    channel.setMessageHandler { _, reply ->
+                        api.getCallDeliveryMode { result: Result<PCallkeepAndroidCallDeliveryMode> ->
                             val error = result.exceptionOrNull()
                             if (error != null) {
                                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.BatteryModeHelper
 import com.webtrit.callkeep.common.PermissionsHelper
+import com.webtrit.callkeep.common.TelephonyUtils
 import com.webtrit.callkeep.common.toAndroidPermissions
 import com.webtrit.callkeep.common.toPPermissionResults
 import io.flutter.plugin.common.PluginRegistry
@@ -71,6 +72,23 @@ class PermissionsApi(
                 batteryMode.isRestricted() -> PCallkeepAndroidBatteryMode.RESTRICTED
                 batteryMode.isOptimized() -> PCallkeepAndroidBatteryMode.OPTIMIZED
                 else -> PCallkeepAndroidBatteryMode.UNKNOWN
+            }
+        callback.invoke(Result.success(mode))
+    }
+
+    /**
+     * Reports whether incoming calls are delivered via the Telecom
+     * [android.telecom.ConnectionService] path or the limited standalone
+     * foreground-service path used when the device lacks
+     * `android.software.telecom`. Mirrors the same feature gate the router uses,
+     * so the value reflects the actually active delivery path.
+     */
+    override fun getCallDeliveryMode(callback: (Result<PCallkeepAndroidCallDeliveryMode>) -> Unit) {
+        val mode =
+            if (TelephonyUtils.isTelecomSupported(context)) {
+                PCallkeepAndroidCallDeliveryMode.TELECOM
+            } else {
+                PCallkeepAndroidCallDeliveryMode.STANDALONE
             }
         callback.invoke(Result.success(mode))
     }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -45,6 +45,8 @@ enum PSpecialPermissionStatusTypeEnum { denied, granted, unknown }
 
 enum PCallkeepAndroidBatteryMode { unrestricted, optimized, restricted, unknown }
 
+enum PCallkeepAndroidCallDeliveryMode { telecom, standalone, unknown }
+
 enum PHandleTypeEnum { generic, number, email }
 
 enum PCallInfoConsts { uuid, dtmf, isVideo, number, name }
@@ -816,6 +818,9 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PCallkeepConnection) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
+    } else if (value is PCallkeepAndroidCallDeliveryMode) {
+      buffer.putUint8(155);
+      writeValue(buffer, value.index);
     } else {
       super.writeValue(buffer, value);
     }
@@ -886,6 +891,9 @@ class _PigeonCodec extends StandardMessageCodec {
         return PCallkeepDisconnectCause.decode(readValue(buffer)!);
       case 154:
         return PCallkeepConnection.decode(readValue(buffer)!);
+      case 155:
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : PCallkeepAndroidCallDeliveryMode.values[value];
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -1195,6 +1203,34 @@ class PHostPermissionsApi {
       );
     } else {
       return (pigeonVar_replyList[0] as PCallkeepAndroidBatteryMode?)!;
+    }
+  }
+
+  Future<PCallkeepAndroidCallDeliveryMode> getCallDeliveryMode() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getCallDeliveryMode$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as PCallkeepAndroidCallDeliveryMode?)!;
     }
   }
 

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -198,6 +198,19 @@ extension PCallkeepAndroidBatteryModeConverter on PCallkeepAndroidBatteryMode {
   }
 }
 
+extension PCallkeepAndroidCallDeliveryModeConverter on PCallkeepAndroidCallDeliveryMode {
+  CallkeepAndroidCallDeliveryMode toCallkeep() {
+    switch (this) {
+      case PCallkeepAndroidCallDeliveryMode.telecom:
+        return CallkeepAndroidCallDeliveryMode.telecom;
+      case PCallkeepAndroidCallDeliveryMode.standalone:
+        return CallkeepAndroidCallDeliveryMode.standalone;
+      case PCallkeepAndroidCallDeliveryMode.unknown:
+        return CallkeepAndroidCallDeliveryMode.unknown;
+    }
+  }
+}
+
 extension CallkeepLifecycleTypeConverter on CallkeepLifecycleEvent {
   PCallkeepLifecycleEvent toPigeon() {
     switch (this) {

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -197,6 +197,11 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<CallkeepAndroidCallDeliveryMode> getCallDeliveryMode() {
+    return _permissionsApi.getCallDeliveryMode().then((value) => value.toCallkeep());
+  }
+
+  @override
   Future<Map<String, dynamic>> getDiagnosticReport() async {
     final rawData = await _diagnosticsApi.getDiagnosticReport();
     return rawData.cast<String, dynamic>();

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -66,6 +66,8 @@ class PPermissionResult {
 
 enum PCallkeepAndroidBatteryMode { unrestricted, optimized, restricted, unknown }
 
+enum PCallkeepAndroidCallDeliveryMode { telecom, standalone, unknown }
+
 enum PHandleTypeEnum { generic, number, email }
 
 enum PCallInfoConsts { uuid, dtmf, isVideo, number, name }
@@ -260,6 +262,11 @@ abstract class PHostPermissionsApi {
 
   @async
   PCallkeepAndroidBatteryMode getBatteryMode();
+
+  /// How incoming calls are delivered: Telecom `ConnectionService` vs the
+  /// limited standalone foreground service (device without `android.software.telecom`).
+  @async
+  PCallkeepAndroidCallDeliveryMode getCallDeliveryMode();
 
   @async
   List<PPermissionResult> requestPermissions(List<PCallkeepPermission> permissions);

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -421,6 +421,24 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // PCallkeepAndroidCallDeliveryModeConverter
+  // ---------------------------------------------------------------------------
+
+  group('PCallkeepAndroidCallDeliveryModeConverter.toCallkeep()', () {
+    test('telecom maps to CallkeepAndroidCallDeliveryMode.telecom', () {
+      expect(PCallkeepAndroidCallDeliveryMode.telecom.toCallkeep(), CallkeepAndroidCallDeliveryMode.telecom);
+    });
+
+    test('standalone maps to CallkeepAndroidCallDeliveryMode.standalone', () {
+      expect(PCallkeepAndroidCallDeliveryMode.standalone.toCallkeep(), CallkeepAndroidCallDeliveryMode.standalone);
+    });
+
+    test('unknown maps to CallkeepAndroidCallDeliveryMode.unknown', () {
+      expect(PCallkeepAndroidCallDeliveryMode.unknown.toCallkeep(), CallkeepAndroidCallDeliveryMode.unknown);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CallkeepLifecycleTypeConverter (CallkeepLifecycleEvent -> PCallkeepLifecycleEvent)
   // ---------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
+++ b/webtrit_callkeep_android/test/webtrit_callkeep_android_api_test.dart
@@ -305,6 +305,21 @@ void main() {
       expect(await WebtritCallkeepPlatform.instance.getBatteryMode(), CallkeepAndroidBatteryMode.restricted);
     });
 
+    test('getCallDeliveryMode returns telecom', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getCallDeliveryMode', PCallkeepAndroidCallDeliveryMode.telecom);
+      expect(await WebtritCallkeepPlatform.instance.getCallDeliveryMode(), CallkeepAndroidCallDeliveryMode.telecom);
+    });
+
+    test('getCallDeliveryMode returns standalone', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getCallDeliveryMode', PCallkeepAndroidCallDeliveryMode.standalone);
+      expect(await WebtritCallkeepPlatform.instance.getCallDeliveryMode(), CallkeepAndroidCallDeliveryMode.standalone);
+    });
+
+    test('getCallDeliveryMode returns unknown', () async {
+      _mockPigeon('$_prefix.PHostPermissionsApi.getCallDeliveryMode', PCallkeepAndroidCallDeliveryMode.unknown);
+      expect(await WebtritCallkeepPlatform.instance.getCallDeliveryMode(), CallkeepAndroidCallDeliveryMode.unknown);
+    });
+
     test('requestPermissions maps readPhoneState to granted', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         '$_prefix.PHostPermissionsApi.requestPermissions',

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_android_call_delivery_mode.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_android_call_delivery_mode.dart
@@ -1,7 +1,7 @@
 /// How incoming calls are delivered on Android.
 ///
 /// - [telecom]: the device supports `android.software.telecom`, so calls go
-///   through the system Telecom [ConnectionService] path (full integration).
+///   through the system Telecom `android.telecom.ConnectionService` path (full integration).
 /// - [standalone]: the device lacks Telecom, so calls use a limited standalone
 ///   foreground service. Delivery may be throttled by the system (Doze,
 ///   background restrictions) and outgoing calls, hold and Bluetooth/wired

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_android_call_delivery_mode.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_android_call_delivery_mode.dart
@@ -1,0 +1,10 @@
+/// How incoming calls are delivered on Android.
+///
+/// - [telecom]: the device supports `android.software.telecom`, so calls go
+///   through the system Telecom [ConnectionService] path (full integration).
+/// - [standalone]: the device lacks Telecom, so calls use a limited standalone
+///   foreground service. Delivery may be throttled by the system (Doze,
+///   background restrictions) and outgoing calls, hold and Bluetooth/wired
+///   headset selection are not available.
+/// - [unknown]: the mode could not be determined or the platform is not Android.
+enum CallkeepAndroidCallDeliveryMode { telecom, standalone, unknown }

--- a/webtrit_callkeep_platform_interface/lib/src/models/models.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/models.dart
@@ -1,4 +1,5 @@
 export 'callkeep_android_battery_mode.dart';
+export 'callkeep_android_call_delivery_mode.dart';
 export 'callkeep_incoming_call_metadata.dart';
 export 'callkeep_audio_device.dart';
 export 'callkeep_call_request_error.dart';

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -190,6 +190,11 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('getBatteryMode() has not been implemented.');
   }
 
+  /// Returns how incoming calls are delivered (Telecom vs limited standalone).
+  Future<CallkeepAndroidCallDeliveryMode> getCallDeliveryMode() {
+    throw UnimplementedError('getCallDeliveryMode() has not been implemented.');
+  }
+
   /// Requests the specified [permissions] on Android.
   ///
   /// Returns a [Map] where:

--- a/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
+++ b/webtrit_callkeep_web/lib/webtrit_callkeep_web.dart
@@ -261,6 +261,9 @@ class WebtritCallkeepWeb extends WebtritCallkeepPlatform {
   Future<CallkeepAndroidBatteryMode> getBatteryMode() async => CallkeepAndroidBatteryMode.unknown;
 
   @override
+  Future<CallkeepAndroidCallDeliveryMode> getCallDeliveryMode() async => CallkeepAndroidCallDeliveryMode.unknown;
+
+  @override
   Future<Map<CallkeepPermission, CallkeepSpecialPermissionStatus>> requestPermissions(
     List<CallkeepPermission> permissions,
   ) async {


### PR DESCRIPTION
## Overview

On devices without `android.software.telecom` (many tablets, Android Go, some OEM/ChromeOS) the plugin falls back from the Telecom `ConnectionService` path to the limited `StandaloneCallService`. That state was detected natively (`TelephonyUtils.isTelecomSupported` / `CallServiceRouter`) but never surfaced to Flutter, so the app cannot tell the user their device runs in the restricted standalone mode.

This adds a getter that exposes the active call-delivery mode to Flutter. It is the callkeep half of WT-1195; the webtrit_phone half (warning the user) builds on it.

## Changes

- New `PHostPermissionsApi.getCallDeliveryMode()` in the pigeon definition, returning a new `CallkeepAndroidCallDeliveryMode` enum (`telecom` / `standalone` / `unknown`).
- Kotlin host implementation in `PermissionsApi` reuses the same `TelephonyUtils.isTelecomSupported(context)` gate the router uses, so the reported value matches the actually active delivery path.
- Wired through every layer: android platform plugin + converter, platform interface (abstract method + model), and the public `WebtritCallkeepPermissions` API. Non-Android platforms return `unknown`.

## Notes

- This is distinct from the existing `batteryOptimizationWarning` (socket mode + battery exemption).
- The generated pigeon files (`callkeep.pigeon.dart`, `Generated.kt`) were edited additively for this one getter; a full pigeon regeneration was intentionally avoided because the committed `Generated.kt` on `develop` is already stale relative to its pigeon source (the logging refactor removed `PLogTypeEnum` / `PDelegateLogsFlutterApi` from the source while `Log.kt` / `WebtritCallkeepPlugin.kt` still reference them), so a wholesale regen would drop symbols the Kotlin still needs and break the build. Worth a separate cleanup.

## Test plan

- [x] `flutter analyze` clean across all packages
- [x] `flutter test` (webtrit_callkeep_android) - all pass, incl. new converter + API tests
- [x] `./gradlew testDebugUnitTest` (Kotlin) - compiles and passes