### PR TITLE
fix(android): replace unsafe !! assertions across critical call paths (WT-1116)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -154,8 +154,10 @@ class PermissionsApi(
             }
         } catch (e: Exception) {
             handler.removeCallbacks(runnable)
-            timeoutRunnable = null
-            pendingPermissionCallback = null
+            synchronized(this) {
+                timeoutRunnable = null
+                pendingPermissionCallback = null
+            }
             callback.invoke(Result.failure(e))
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -128,7 +128,7 @@ class PermissionsApi(
             pendingPermissionCallback = callback
         }
 
-        timeoutRunnable =
+        val runnable =
             Runnable {
                 synchronized(this) {
                     if (pendingPermissionCallback != null) {
@@ -140,8 +140,9 @@ class PermissionsApi(
                     }
                 }
             }
+        timeoutRunnable = runnable
 
-        handler.postDelayed(timeoutRunnable!!, PERMISSION_REQUEST_TIMEOUT_MS)
+        handler.postDelayed(runnable, PERMISSION_REQUEST_TIMEOUT_MS)
 
         try {
             activity.runOnUiThread {
@@ -152,7 +153,7 @@ class PermissionsApi(
                 )
             }
         } catch (e: Exception) {
-            handler.removeCallbacks(timeoutRunnable!!)
+            handler.removeCallbacks(runnable)
             timeoutRunnable = null
             pendingPermissionCallback = null
             callback.invoke(Result.failure(e))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -262,8 +262,9 @@ class WebtritCallkeepPlugin :
             binding.addRequestPermissionsResultListener(it)
         }
 
-        lifeCycle = (binding.lifecycle as HiddenLifecycleReference).lifecycle
-        lifeCycle!!.addObserver(this)
+        val lifecycle = (binding.lifecycle as HiddenLifecycleReference).lifecycle
+        lifeCycle = lifecycle
+        lifecycle.addObserver(this)
 
         // Register the proxy immediately so setUp() calls from Dart are never lost
         // during the asynchronous bindService() window.
@@ -324,8 +325,9 @@ class WebtritCallkeepPlugin :
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         Log.i(TAG, "onReattachedToActivityForConfigChanges id:${binding.hashCode()}")
-        lifeCycle = (binding.lifecycle as HiddenLifecycleReference).lifecycle
-        lifeCycle!!.addObserver(this)
+        val lifecycle = (binding.lifecycle as HiddenLifecycleReference).lifecycle
+        lifeCycle = lifecycle
+        lifecycle.addObserver(this)
     }
 
     override fun onStateChanged(
@@ -390,7 +392,7 @@ class WebtritCallkeepPlugin :
 
     private fun bindForegroundService(activity: Context) {
         val intent = Intent(activity, ForegroundService::class.java)
-        serviceConnection =
+        val foregroundServiceConnection =
             object : ServiceConnection {
                 override fun onServiceConnected(
                     name: ComponentName?,
@@ -417,7 +419,8 @@ class WebtritCallkeepPlugin :
                     foregroundService = null
                 }
             }
-        activity.bindService(intent, serviceConnection!!, Context.BIND_AUTO_CREATE)
+        serviceConnection = foregroundServiceConnection
+        activity.bindService(intent, foregroundServiceConnection, Context.BIND_AUTO_CREATE)
     }
 
     private fun unbindAndStopForegroundService(activity: Context) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/AudioDevice.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/AudioDevice.kt
@@ -27,7 +27,7 @@ class AudioDevice(
         fun fromBundle(bundle: Bundle?): AudioDevice? =
             bundle?.let {
                 val typeStr = it.getString("type") ?: return@let null
-                val type = runCatching { AudioDeviceType.valueOf(typeStr) }.getOrNull() ?: return@let null
+                val type = runCatching { AudioDeviceType.valueOf(typeStr) }.getOrDefault(AudioDeviceType.UNKNOWN)
                 val name = it.getString("name")
                 val id = it.getString("id")
                 AudioDevice(type, name, id)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/AudioDevice.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/AudioDevice.kt
@@ -26,7 +26,8 @@ class AudioDevice(
     companion object {
         fun fromBundle(bundle: Bundle?): AudioDevice? =
             bundle?.let {
-                val type = AudioDeviceType.valueOf(it.getString("type")!!)
+                val typeStr = it.getString("type") ?: return@let null
+                val type = runCatching { AudioDeviceType.valueOf(typeStr) }.getOrNull() ?: return@let null
                 val name = it.getString("name")
                 val id = it.getString("id")
                 AudioDevice(type, name, id)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/IncomingCallNotificationBuilder.kt
@@ -27,12 +27,12 @@ class IncomingCallNotificationBuilder : NotificationBuilder() {
     }
 
     private fun createCallActionIntent(action: String): PendingIntent {
-        requireNotNull(callMetaData) { "Call metadata must be set before creating the intent." }
+        val metadata = requireNotNull(callMetaData) { "Call metadata must be set before creating the intent." }
 
         val intent =
             Intent(context, IncomingCallService::class.java).apply {
                 this.action = action
-                putExtras(callMetaData!!.toBundle())
+                putExtras(metadata.toBundle())
             }
         return PendingIntent.getService(
             context,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -961,8 +961,9 @@ class ConnectionTimeout(
      */
     fun start(timeoutCallback: () -> Unit) {
         cancel()
-        timeoutRunnable = Runnable(timeoutCallback)
-        handler.postDelayed(timeoutRunnable!!, timeoutDurationMs)
+        val runnable = Runnable(timeoutCallback)
+        timeoutRunnable = runnable
+        handler.postDelayed(runnable, timeoutDurationMs)
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -316,7 +316,7 @@ class ForegroundService :
             callback(result)
         }
 
-        receiver =
+        val callEventReceiver =
             object : BroadcastReceiver() {
                 override fun onReceive(
                     context: Context?,
@@ -383,11 +383,12 @@ class ForegroundService :
                     }
                 }
             }
+        receiver = callEventReceiver
 
         core.registerConnectionEvents(
             baseContext,
             listOf(CallLifecycleEvent.OngoingCall, CallLifecycleEvent.OutgoingFailure),
-            receiver!!,
+            callEventReceiver,
             exported = false,
         )
 
@@ -736,7 +737,7 @@ class ForegroundService :
             callback.invoke(Result.success(Unit))
         }
 
-        tearDownAckReceiver =
+        val ackReceiver =
             object : BroadcastReceiver() {
                 override fun onReceive(
                     context: Context?,
@@ -748,22 +749,24 @@ class ForegroundService :
                     }
                 }
             }
+        tearDownAckReceiver = ackReceiver
 
         core.registerConnectionEvents(
             baseContext,
             listOf(CallCommandEvent.TearDownComplete),
-            tearDownAckReceiver!!,
+            ackReceiver,
             exported = false,
         )
 
         // Safety timeout: if TearDownComplete never arrives (e.g. CS was not running),
         // proceed anyway so tearDown() always resolves.
-        tearDownTimeoutRunnable =
+        val timeoutRunnable =
             Runnable {
                 logger.w("tearDown: TearDownComplete ack timed out, proceeding")
                 finishTearDown()
             }
-        mainHandler.postDelayed(tearDownTimeoutRunnable!!, TEAR_DOWN_ACK_TIMEOUT_MS)
+        tearDownTimeoutRunnable = timeoutRunnable
+        mainHandler.postDelayed(timeoutRunnable, TEAR_DOWN_ACK_TIMEOUT_MS)
 
         core.sendTearDownConnections()
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1114,9 +1114,13 @@ class ForegroundService :
         logger.d("handleCSReportAudioDeviceSet")
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
+            val audioDevice = callMetaData.audioDevice ?: run {
+                logger.w("handleCSReportAudioDeviceSet: audioDevice not set for callId=${callMetaData.callId}")
+                return
+            }
             flutterDelegateApi?.performAudioDeviceSet(
                 callMetaData.callId,
-                callMetaData.audioDevice!!.toPAudioDevice(),
+                audioDevice.toPAudioDevice(),
             ) {}
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -183,7 +183,15 @@ class IncomingCallService :
         }
 
         return when (action) {
-            PushNotificationServiceEnums.IC_INITIALIZE.name -> handleLaunch(metadata!!)
+            PushNotificationServiceEnums.IC_INITIALIZE.name -> {
+                if (metadata == null) {
+                    Log.w(TAG, "onStartCommand: IC_INITIALIZE missing metadata, stopping")
+                    stopSelf()
+                    START_NOT_STICKY
+                } else {
+                    handleLaunch(metadata)
+                }
+            }
 
             // IC_RELEASE_WITH_ANSWER / IC_RELEASE_WITH_DECLINE are now delivered via
             // releaseReceiver (BroadcastReceiver registered in onCreate). They no longer
@@ -191,9 +199,21 @@ class IncomingCallService :
             // of startService(), so the service is never restarted after it has stopped.
 
             // Listen push notification actions (Only notify connection service)
-            NotificationAction.Answer.action -> reportAnswerToConnectionService(metadata!!)
+            NotificationAction.Answer.action -> {
+                if (metadata != null) reportAnswerToConnectionService(metadata)
+                else {
+                    Log.w(TAG, "onStartCommand: Answer action missing metadata")
+                    START_NOT_STICKY
+                }
+            }
 
-            NotificationAction.Decline.action -> reportHungUpToConnectionService(metadata!!)
+            NotificationAction.Decline.action -> {
+                if (metadata != null) reportHungUpToConnectionService(metadata)
+                else {
+                    Log.w(TAG, "onStartCommand: Decline action missing metadata")
+                    START_NOT_STICKY
+                }
+            }
 
             else -> handleUnknownAction(action)
         }


### PR DESCRIPTION
## Overview

Replaces unsafe non-null assertions (`!!`) with local `val` captures across critical Android call paths. Each group is a separate commit so the branch can be reviewed incrementally.

WT-1116

## Groups

- [x] Group 1 -- ForegroundService teardown race (`receiver!!`, `tearDownAckReceiver!!`, `tearDownTimeoutRunnable!!`)
- [x] Group 2 -- WebtritCallkeepPlugin lifecycle/bind detach (`lifeCycle!!`, `serviceConnection!!`)
- [x] Group 3 -- IncomingCallService notification action metadata (`metadata!!`)
- [x] Group 4 -- Timeout runnables (`PhoneConnection`, `PermissionsApi`)
- [x] Group 5 -- Scattered singles (`audioDevice!!`, `AudioDevice`, `IncomingCallNotificationBuilder`)

## Test plan

- Outgoing call happy path -- call connects and audio works
- Outgoing call teardown -- hangup during dialing cleans up without crash
- Incoming call via notification action -- answer/decline buttons work