### PR TITLE
chore(android): upgrade Gradle to 9.5.1 and fix unit tests on JDK 26

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -1,0 +1,37 @@
+name: Android Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - "webtrit_callkeep_android/**"
+      - ".github/workflows/android-unit-tests.yml"
+
+jobs:
+  unit-tests:
+    name: Robolectric unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+        working-directory: webtrit_callkeep_android/android
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: webtrit_callkeep_android/android/build/reports/tests/testDebugUnitTest/
+          retention-days: 7

--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -101,6 +101,6 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "androidx.test:core:1.7.0"
-    testImplementation "org.robolectric:robolectric:4.16"
+    testImplementation "org.robolectric:robolectric:4.16.1"
     testImplementation "org.mockito:mockito-core:5.21.0"
 }

--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -104,3 +104,12 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.16.1"
     testImplementation "org.mockito:mockito-core:5.21.0"
 }
+
+// Robolectric's bundled ASM cannot instrument Java 26 class files.
+// Running tests in a JDK 17 JVM keeps bytecode at version 61, which
+// Robolectric handles correctly regardless of the system JDK.
+tasks.withType(Test).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/webtrit_callkeep_android/android/gradle.properties
+++ b/webtrit_callkeep_android/android/gradle.properties
@@ -1,10 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
-# Gradle must run on JDK 17. Gradle 8.14.x bundles ASM 9.7.1 which cannot
-# instrument class files compiled with Java 26; Groovy also emits Java 26
-# bytecode when the daemon runs on JDK 26, which Gradle's own instrumenter
-# then rejects at build-script compilation time.
-# Set org.gradle.java.home in ~/.gradle/gradle.properties to your local JDK 17
-# path, or export JAVA_HOME before running Gradle.
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 kotlin.code.style=official

--- a/webtrit_callkeep_android/android/gradle.properties
+++ b/webtrit_callkeep_android/android/gradle.properties
@@ -1,4 +1,10 @@
 android.useAndroidX=true
 android.enableJetifier=true
+# Gradle must run on JDK 17. Gradle 8.14.x bundles ASM 9.7.1 which cannot
+# instrument class files compiled with Java 26; Groovy also emits Java 26
+# bytecode when the daemon runs on JDK 26, which Gradle's own instrumenter
+# then rejects at build-script compilation time.
+# Set org.gradle.java.home in ~/.gradle/gradle.properties to your local JDK 17
+# path, or export JAVA_HOME before running Gradle.
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 kotlin.code.style=official

--- a/webtrit_callkeep_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/webtrit_callkeep_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 06 16:44:46 EET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/webtrit_callkeep_android/android/settings.gradle
+++ b/webtrit_callkeep_android/android/settings.gradle
@@ -1,2 +1,6 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'webtrit_callkeep_android'
 include ':lint'


### PR DESCRIPTION
## Overview

Two separate but related problems prevented Android unit tests from running under JDK 26:

**Problem 1 -- Gradle build-script compilation:**
Gradle 8.14.3 bundled ASM 9.7.1 (max Java 25). When the Gradle daemon ran on JDK 26, Groovy compiled build scripts to class file version 70 (Java 26), and Gradle's own instrumenter rejected them. Any change to \`build.gradle\` would produce \`BUG! exception in phase 'semantic analysis'\` before any tasks ran.

**Problem 2 -- Robolectric test instrumentation:**
Robolectric's own bundled ASM also cannot instrument Java 26 class files at test runtime (\`IllegalArgumentException: Unsupported class file major version 70\`).

**Fixes:**
- Upgrade Gradle wrapper \`8.14.3\` -> \`9.5.1\`. Gradle 9.5.1 ships ASM 9.9, which supports Java 26, fixing problem 1.
- Add Foojay resolver 1.0.0 to \`settings.gradle\` (first version compatible with Gradle 9.x) for JDK auto-provisioning.
- Pin test JVM to JDK 17 via Gradle Java Toolchain (\`tasks.withType(Test).configureEach { javaLauncher = ... }\`). Robolectric instruments Java 17 bytecode without issues.
- Add \`.github/workflows/android-unit-tests.yml\` CI workflow (JDK 17 pre-installed by \`actions/setup-java\`).
- Bump Robolectric \`4.16\` -> \`4.16.1\`.

**Result:** \`./gradlew testDebugUnitTest\` -- 198/198 passed on a JDK 26 host.