### PR TITLE
test(android): add fast-fail timeout to concurrent spam integration test

### DIFF
--- a/webtrit_callkeep/example/android/gradle.properties
+++ b/webtrit_callkeep/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -282,8 +282,7 @@ void main() {
           'concurrent spam: Future.wait timed out after 8s -- '
           'one or more reportNewIncomingCall futures never resolved. '
           'Root cause: pendingIncomingCallbacks[callId] is overwritten then cleared '
-          'by a concurrent duplicate onError handler before DidPushIncomingCall arrives '
-          '(see tasks/callkeep-itest-spam-race/report.md).',
+          'by a concurrent duplicate onError handler before DidPushIncomingCall arrives.',
         );
       }
 

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -273,7 +273,19 @@ void main() {
         4,
         (_) => callkeep.reportNewIncomingCall(id, kTestHandle1, displayName: 'Call'),
       );
-      final results = await Future.wait(futures);
+
+      late final List<CallkeepIncomingCallError?> results;
+      try {
+        results = await Future.wait(futures).timeout(const Duration(seconds: 8));
+      } on TimeoutException {
+        fail(
+          'concurrent spam: Future.wait timed out after 8s -- '
+          'one or more reportNewIncomingCall futures never resolved. '
+          'Root cause: pendingIncomingCallbacks[callId] is overwritten then cleared '
+          'by a concurrent duplicate onError handler before DidPushIncomingCall arrives '
+          '(see tasks/callkeep-itest-spam-race/report.md).',
+        );
+      }
 
       final successes = results.where((e) => e == null).length;
       expect(successes, 1, reason: 'exactly one concurrent report must succeed');

--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -267,6 +267,14 @@ void main() {
       expect(endedIds.length, expectedIds.length);
     });
 
+    // Verifies that firing reportNewIncomingCall with the same callId four times
+    // concurrently (via Future.wait, no await between launches) results in exactly
+    // one success and three callIdAlreadyExists errors.
+    //
+    // The invariant: ForegroundService must guard pendingIncomingCallbacks so that
+    // only the first registrant owns the map slot. Duplicate onError handlers must
+    // not remove an entry they did not create, which would orphan the first call's
+    // Pigeon callback and cause Future.wait to hang indefinitely.
     testWidgets('spam same ID concurrently - exactly one succeeds', (WidgetTester _) async {
       final id = nextTestId();
       final futures = List.generate(


### PR DESCRIPTION
## Overview

Adds an 8-second `Future.wait` timeout to the concurrent same-callId spam test
so it fails fast with a descriptive message instead of hanging indefinitely
(previously 16+ minutes until the flutter test runner global timeout).

The test documents a known race condition in `ForegroundService.reportNewIncomingCall`
where concurrent duplicate calls clear `pendingIncomingCallbacks[callId]` before
`DidPushIncomingCall` arrives, leaving `cb[0]` permanently unresolved.

## What changed

- `integration_test/callkeep_stress_test.dart`: wrap `Future.wait(futures)` with
  `.timeout(8s)` + `catch (TimeoutException)` that calls `fail(...)` with a message
  pointing to the root cause. The strict `expect(successes, 1)` expectation is
  preserved -- it will pass once the Kotlin fix lands.

- `android/gradle.properties`: `android.builtInKotlin=false` + `android.newDsl=false`
  auto-added by Flutter migrator during the test run (suppresses KGP build warnings).

## Test result (Pixel 9, API 36)

Before: test hung for 16+ minutes, eventually reported "did not complete".
After:  test fails at `00:08` with:
> concurrent spam: Future.wait timed out after 8s -- one or more
> reportNewIncomingCall futures never resolved. Root cause:
> pendingIncomingCallbacks[callId] is overwritten then cleared by a
> concurrent duplicate onError handler before DidPushIncomingCall arrives
> (see tasks/callkeep-itest-spam-race/report.md).

## Related

WT-TBD (local task: callkeep-itest-spam-race) -- Kotlin fix is tracked separately
and will land on this branch as a follow-up commit.