### PR TITLE
fix(android): guard pendingIncomingCallbacks slot against concurrent same-callId spam

### DIFF
--- a/webtrit_callkeep/example/integration_test/all_tests.dart
+++ b/webtrit_callkeep/example/integration_test/all_tests.dart
@@ -30,14 +30,14 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('lifecycle', lifecycle.main);
+  group('delegate_edge_cases', delegate_edge_cases.main);
+  group('foreground_service', foreground_service.main);
+  group('stress', stress.main);
   group('call_scenarios', call_scenarios.main);
   group('client_scenarios', client_scenarios.main);
   group('connections', connections.main);
-  group('delegate_edge_cases', delegate_edge_cases.main);
   group('delivery_mode', delivery_mode.main);
-  group('foreground_service', foreground_service.main);
   group('background_services', background_services.main);
   group('reportendcall_reasons', reportendcall_reasons.main);
   group('state_machine', state_machine.main);
-  group('stress', stress.main);
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -89,7 +89,8 @@ class ConnectionManager {
     }
 
     /**
-     * Adds [callId] to [pendingCallIds].
+     * Adds [callId] to [pendingCallIds] and returns true, or returns false and does nothing
+     * if [callId] is currently in [forcedTerminatedCallIds].
      *
      * In the dual-process architecture, [checkAndReservePending] runs in the main-process JVM
      * and populates the main process's [ConnectionManager] instance. The :callkeep_core process
@@ -97,12 +98,29 @@ class ConnectionManager {
      * [PhoneConnectionService.handleAddNewIncomingCall] before [TelephonyUtils.addNewIncomingCall],
      * ensuring [isPending] returns true when [onCreateIncomingConnection] fires.
      *
-     * Also removes [callId] from [forcedTerminatedCallIds] in the (theoretically impossible for
-     * UUID callIds) case where a new session re-uses the same ID.
+     * Returning false signals to the caller that [cleanConnections] already ran for the session
+     * that owns this callId, meaning the in-flight [ServiceAction.AddNewIncomingCall] intent is
+     * stale: it was queued before tearDown completed and arrived after. In that case the caller
+     * must not invoke [TelephonyUtils.addNewIncomingCall] and must dispatch [CallLifecycleEvent.HungUp]
+     * so the main process resolves the pending Pigeon callback.
+     *
+     * Background: both [ServiceAction.TearDownConnections] and [ServiceAction.AddNewIncomingCall]
+     * are delivered via [startService] and processed serially on :callkeep_core's main thread.
+     * Android guarantees FIFO delivery for same-process same-service intents, so in the normal
+     * path [AddNewIncomingCall] is always processed before the [TearDownConnections] that follows
+     * it in the same session. The guard here closes the narrow window where that ordering is
+     * violated (e.g. a delayed intent from a previous session racing a new one).
      */
-    fun addPendingForIncomingCall(callId: String) {
-        forcedTerminatedCallIds.remove(callId)
+    fun addPendingForIncomingCall(callId: String): Boolean {
+        // If cleanConnections() already ran and captured this callId into forcedTerminatedCallIds,
+        // the AddNewIncomingCall intent is a post-tearDown stale delivery. Reject it so that
+        // addNewIncomingCall is never called and no PhoneConnection is created for a closed session.
+        if (forcedTerminatedCallIds.contains(callId)) {
+            logger.w("addPendingForIncomingCall: callId=$callId is force-terminated, rejecting stale in-flight intent")
+            return false
+        }
         pendingCallIds.add(callId)
+        return true
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/ConnectionManager.kt
@@ -89,15 +89,13 @@ class ConnectionManager {
     }
 
     /**
-     * Adds [callId] to [pendingCallIds] in response to a [ServiceAction.NotifyPending] IPC
-     * intent from the main process.
+     * Adds [callId] to [pendingCallIds].
      *
      * In the dual-process architecture, [checkAndReservePending] runs in the main-process JVM
      * and populates the main process's [ConnectionManager] instance. The :callkeep_core process
-     * has its own instance whose [pendingCallIds] is never touched by the main process.
-     * This method bridges the gap: the main process sends a [ServiceAction.NotifyPending] intent
-     * just before [TelephonyUtils.addNewIncomingCall], and [PhoneConnectionService.handleNotifyPending]
-     * calls this method, ensuring [isPending] returns true when [onCreateIncomingConnection] fires.
+     * has its own instance whose [pendingCallIds] is populated here, called from
+     * [PhoneConnectionService.handleAddNewIncomingCall] before [TelephonyUtils.addNewIncomingCall],
+     * ensuring [isPending] returns true when [onCreateIncomingConnection] fires.
      *
      * Also removes [callId] from [forcedTerminatedCallIds] in the (theoretically impossible for
      * UUID callIds) case where a new session re-uses the same ID.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
@@ -18,6 +18,7 @@ enum class ServiceAction {
     SyncAudioState,
     SyncConnectionState,
     NotifyPending,
+    AddNewIncomingCall,
     ;
 
     companion object {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -124,6 +124,23 @@ class PhoneConnectionService : ConnectionService() {
                         ?: Log.w(TAG, "onStartCommand: NotifyPending missing callId")
                 }
 
+                // startService() on a ConnectionService from the same app (same UID) is valid:
+                // android:permission="BIND_TELECOM_CONNECTION_SERVICE" restricts cross-UID
+                // bindService() callers only. Same-UID processes bypass the permission check
+                // unconditionally in ActiveServices.startServiceLocked() -> checkComponentPermission().
+                // AOSP: frameworks/base/services/core/java/com/android/server/am/ActiveServices.java
+                //
+                // The official telecom lifecycle only describes the framework-initiated bind path:
+                // "Telecom will bind to a ConnectionService implementation when it wants that
+                //  ConnectionService to place a call." (developer.android.com/develop/connectivity/telecom/dialer-app)
+                // startService() -> onStartCommand() is an orthogonal IPC channel used throughout
+                // this codebase (NotifyPending, TearDownConnections, ReserveAnswer, etc.) and is
+                // not prohibited by the framework.
+                ServiceAction.AddNewIncomingCall -> {
+                    metadata?.let { handleAddNewIncomingCall(it) }
+                        ?: Log.w(TAG, "onStartCommand: AddNewIncomingCall missing metadata")
+                }
+
                 ServiceAction.CleanConnections -> {
                     handleCleanConnections()
                 }
@@ -226,25 +243,21 @@ class PhoneConnectionService : ConnectionService() {
 
         // Guard against stale Telecom callbacks that arrive after a tearDown.
         //
-        // Both onCreateIncomingConnection (posted to this service's main-thread handler by the
-        // Telecom binder stub) and handleNotifyPending (posted via startService -> onStartCommand)
-        // run on the same main thread, but their relative arrival order is non-deterministic:
-        // Telecom's dispatch path through TelecomManager is independent of ActivityManager's
-        // startService delivery, so onCreateIncomingConnection can fire before isPending is true.
+        // handleAddNewIncomingCall calls addPendingForIncomingCall before addNewIncomingCall,
+        // both in the same onStartCommand invocation on the main thread. onCreateIncomingConnection
+        // is also dispatched on the main thread, so isPending is true in the normal path.
         //
         // Strategy:
-        //   - isPending == true  : normal path, NotifyPending arrived first (common case).
+        //   - isPending == true  : normal path (common case).
         //   - isPending == false AND isForcedTerminated : stale post-tearDown callback — reject.
-        //   - isPending == false AND NOT isForcedTerminated : NotifyPending IPC delayed (race
-        //     window) — register as pending now so the rest of the flow sees consistent state.
+        //   - isPending == false AND NOT isForcedTerminated : defense-in-depth fallback (should
+        //     not happen with AddNewIncomingCall IPC, but kept for safety).
         if (!connectionManager.isPending(metadata.callId)) {
             if (connectionManager.isForcedTerminated(metadata.callId)) {
                 Log.w(TAG, "onCreateIncomingConnection: callId=${metadata.callId} force-terminated by tearDown, rejecting stale callback")
                 return Connection.createFailedConnection(DisconnectCause(DisconnectCause.LOCAL))
             }
-            // NotifyPending IPC has not arrived yet — register as pending now.
-            // handleNotifyPending will call addPendingForIncomingCall later (idempotent).
-            Log.d(TAG, "onCreateIncomingConnection: callId=${metadata.callId} not pending yet, accepting (NotifyPending race window)")
+            Log.d(TAG, "onCreateIncomingConnection: callId=${metadata.callId} not pending yet, registering as defense-in-depth fallback")
             connectionManager.addPendingForIncomingCall(metadata.callId)
         }
 
@@ -343,8 +356,8 @@ class PhoneConnectionService : ConnectionService() {
         // incoming call was already ringing). If it was not pending, this is a stale Telecom
         // callback from a previous session (guarded by isPending in onCreateIncomingConnection)
         // and should be silently dropped.
-        // Note: pendingCallIds in :callkeep_core is now populated via NotifyPending IPC, so this
-        // check correctly distinguishes legitimate failures from stale callbacks.
+        // pendingCallIds is populated in handleAddNewIncomingCall before addNewIncomingCall, so
+        // this check correctly distinguishes legitimate failures from stale callbacks.
         val wasPending = callId != null && connectionManager.isPending(callId)
         callId?.let { connectionManager.removePending(it) }
 
@@ -413,6 +426,32 @@ class PhoneConnectionService : ConnectionService() {
     private fun handleNotifyPending(callId: String) {
         Log.i(TAG, "handleNotifyPending: callId=$callId")
         connectionManager.addPendingForIncomingCall(callId)
+    }
+
+    /**
+     * Registers [metadata.callId] as pending and calls [TelephonyUtils.addNewIncomingCall] from
+     * within :callkeep_core, invoked via a [ServiceAction.AddNewIncomingCall] startService intent.
+     *
+     * Running both operations inside this process means they share the same Telecom binder
+     * connection. Because Telecom processes binder calls from the same connection in FIFO order,
+     * any preceding [android.telecom.Connection.destroy] call (also from :callkeep_core) is
+     * guaranteed to be processed before [TelephonyUtils.addNewIncomingCall]. This prevents
+     * [onCreateIncomingConnectionFailed] from firing on callId reuse after a declined call.
+     *
+     * On [TelephonyUtils.addNewIncomingCall] failure, [CallLifecycleEvent.HungUp] is dispatched
+     * so the main process resolves the pending Pigeon callback.
+     */
+    private fun handleAddNewIncomingCall(metadata: CallMetadata) {
+        val callId = metadata.callId
+        Log.i(TAG, "handleAddNewIncomingCall: callId=$callId")
+        connectionManager.addPendingForIncomingCall(callId)
+        try {
+            TelephonyUtils(baseContext).addNewIncomingCall(metadata)
+        } catch (e: Exception) {
+            Log.e(TAG, "handleAddNewIncomingCall: addNewIncomingCall failed for callId=$callId, dispatching HungUp", e)
+            connectionManager.removePending(callId)
+            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+        }
     }
 
     private fun handleCleanConnections() {
@@ -579,11 +618,9 @@ class PhoneConnectionService : ConnectionService() {
         /**
          * Sends a [ServiceAction.NotifyPending] command with [callId] to this service via [startService].
          *
-         * Must be called from the main process before [TelephonyUtils.addNewIncomingCall] so that
-         * :callkeep_core's [ConnectionManager.pendingCallIds] is populated before Telecom triggers
-         * [onCreateIncomingConnection]. This bridges the dual-process gap: [checkAndReservePending]
-         * runs in the main-process JVM (a different [ConnectionManager] instance), so :callkeep_core
-         * never sees those entries without this explicit IPC notification.
+         * Used when only pending registration is needed without immediately following up with
+         * [TelephonyUtils.addNewIncomingCall]. For the incoming call path use
+         * [ServiceAction.AddNewIncomingCall] directly (see [startIncomingCall]).
          */
         fun sendNotifyPending(
             context: Context,
@@ -726,27 +763,25 @@ class PhoneConnectionService : ConnectionService() {
             Log.i(TAG, "startIncomingCall: callId=${metadata.callId}")
 
             ConnectionManager.validateConnectionAddition(metadata = metadata, onSuccess = {
-                try {
-                    // Notify :callkeep_core's ConnectionManager about the pending callId before
-                    // calling addNewIncomingCall. This ensures that onCreateIncomingConnection's
-                    // isPending gate accepts the connection: checkAndReservePending ran in the
-                    // main-process JVM (a different ConnectionManager instance), so we must
-                    // explicitly tell :callkeep_core via IPC.
-                    sendNotifyPending(context, metadata.callId)
-                    TelephonyUtils(context).addNewIncomingCall(metadata)
-                    onSuccess()
-                } catch (e: Exception) {
-                    // addNewIncomingCall failed (e.g. SecurityException, IllegalArgumentException).
-                    // Roll back the pending reservation so future reports for this callId are not
-                    // permanently rejected with CALL_ID_ALREADY_EXISTS.
-                    Log.e(
-                        TAG,
-                        "startIncomingCall: addNewIncomingCall failed for callId=${metadata.callId}, rolling back pending",
-                        e,
-                    )
-                    connectionManager.removePending(metadata.callId)
-                    onError(null)
-                }
+                // Send AddNewIncomingCall to :callkeep_core so that addPendingForIncomingCall
+                // and addNewIncomingCall both run in the same process as destroy(). This
+                // guarantees FIFO ordering on the shared Telecom binder connection and prevents
+                // onCreateIncomingConnectionFailed on callId reuse after a declined call.
+                val intent =
+                    Intent(context, PhoneConnectionService::class.java).apply {
+                        action = ServiceAction.AddNewIncomingCall.action
+                        putExtras(metadata.toBundle())
+                    }
+                runCatching { context.startService(intent) }
+                    .onFailure { e ->
+                        // startService can fail with IllegalStateException on Android 8+ when
+                        // the app is in the background. Dispatch HungUp so the main process
+                        // resolves the pending Pigeon callback instead of leaving it hanging.
+                        Log.e(TAG, "startIncomingCall: startService(AddNewIncomingCall) failed for callId=${metadata.callId}, dispatching HungUp: $e")
+                        connectionManager.removePending(metadata.callId)
+                        ConnectionServicePerformBroadcaster.handle.dispatch(context, CallLifecycleEvent.HungUp, metadata.toBundle())
+                    }
+                onSuccess()
             }, onError = { incomingCallError ->
                 Log.w(TAG, "Incoming call rejected: ${incomingCallError.value}")
                 onError(incomingCallError)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -367,10 +367,11 @@ class PhoneConnectionService : ConnectionService() {
 
         Log.e(TAG, "$failureMessage — Telecom rejected the incoming call registration")
 
-        if (wasPending && callId != null) {
+        if (wasPending) {
+            // wasPending = callId != null && isPending(callId), so both are non-null here.
             // Notify Flutter that this call ended so it can clean up its call state.
             Log.i(TAG, "onCreateIncomingConnectionFailed: firing HungUp for pending callId=$callId")
-            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+            dispatchHungUpAndRemovePending(callId!!, callMetadata!!, removePending = false)
         } else {
             val failureMetadata = FailureMetadata(callMetadata, failureMessage).toBundle()
             dispatcher.dispatch(baseContext, CallLifecycleEvent.IncomingFailure, failureMetadata)
@@ -454,16 +455,37 @@ class PhoneConnectionService : ConnectionService() {
         // tracker in the main process.
         if (!connectionManager.addPendingForIncomingCall(callId)) {
             Log.w(TAG, "handleAddNewIncomingCall: callId=$callId rejected (post-tearDown stale intent), dispatching HungUp")
-            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+            dispatchHungUpAndRemovePending(callId, metadata, removePending = false)
             return
         }
         try {
             TelephonyUtils(baseContext).addNewIncomingCall(metadata)
         } catch (e: Exception) {
             Log.e(TAG, "handleAddNewIncomingCall: addNewIncomingCall failed for callId=$callId, dispatching HungUp", e)
-            connectionManager.removePending(callId)
-            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+            dispatchHungUpAndRemovePending(callId, metadata)
         }
+    }
+
+    /**
+     * Removes [callId] from [connectionManager]'s pending set (when [removePending] is true)
+     * and dispatches [CallLifecycleEvent.HungUp] so the main process resolves the pending
+     * Pigeon callback for this call.
+     *
+     * Centralises the removePending + HungUp dispatch pattern that appears in multiple
+     * failure paths ([handleAddNewIncomingCall], [onCreateIncomingConnectionFailed], etc.)
+     * so each site cannot accidentally omit one of the two steps.
+     *
+     * [metadata] is used as the bundle payload when available, giving receivers full call
+     * context (handle, displayName, etc.). Pass [removePending] = false when the pending
+     * slot was never added (e.g. [addPendingForIncomingCall] returned false).
+     */
+    private fun dispatchHungUpAndRemovePending(
+        callId: String,
+        metadata: CallMetadata,
+        removePending: Boolean = true,
+    ) {
+        if (removePending) connectionManager.removePending(callId)
+        dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, metadata.toBundle())
     }
 
     private fun handleCleanConnections() {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -445,7 +445,18 @@ class PhoneConnectionService : ConnectionService() {
     private fun handleAddNewIncomingCall(metadata: CallMetadata) {
         val callId = metadata.callId
         Log.i(TAG, "handleAddNewIncomingCall: callId=$callId")
-        connectionManager.addPendingForIncomingCall(callId)
+        // addPendingForIncomingCall returns false if cleanConnections() already ran and placed
+        // this callId into forcedTerminatedCallIds. That means the TearDownConnections intent
+        // was processed before this AddNewIncomingCall intent -- a stale in-flight IPC from
+        // a session that has already been torn down. In that case we must not call
+        // addNewIncomingCall: doing so would create a PhoneConnection for a closed session
+        // whose HungUp/DidPushIncomingCall broadcasts would arrive in an already-cleared
+        // tracker in the main process.
+        if (!connectionManager.addPendingForIncomingCall(callId)) {
+            Log.w(TAG, "handleAddNewIncomingCall: callId=$callId rejected (post-tearDown stale intent), dispatching HungUp")
+            dispatcher.dispatch(baseContext, CallLifecycleEvent.HungUp, CallMetadata(callId = callId).toBundle())
+            return
+        }
         try {
             TelephonyUtils(baseContext).addNewIncomingCall(metadata)
         } catch (e: Exception) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -13,6 +13,7 @@ import android.telecom.PhoneAccount
 import android.telecom.PhoneAccountHandle
 import androidx.annotation.RequiresPermission
 import com.webtrit.callkeep.PIncomingCallError
+import com.webtrit.callkeep.PIncomingCallErrorEnum
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
@@ -773,15 +774,15 @@ class PhoneConnectionService : ConnectionService() {
                         putExtras(metadata.toBundle())
                     }
                 runCatching { context.startService(intent) }
+                    .onSuccess { onSuccess() }
                     .onFailure { e ->
                         // startService can fail with IllegalStateException on Android 8+ when
-                        // the app is in the background. Dispatch HungUp so the main process
-                        // resolves the pending Pigeon callback instead of leaving it hanging.
-                        Log.e(TAG, "startIncomingCall: startService(AddNewIncomingCall) failed for callId=${metadata.callId}, dispatching HungUp: $e")
+                        // the app is in the background. Remove the pending reservation and
+                        // propagate the failure via onError so the Pigeon callback is resolved.
+                        Log.e(TAG, "startIncomingCall: startService(AddNewIncomingCall) failed for callId=${metadata.callId}", e)
                         connectionManager.removePending(metadata.callId)
-                        ConnectionServicePerformBroadcaster.handle.dispatch(context, CallLifecycleEvent.HungUp, metadata.toBundle())
+                        onError(PIncomingCallError(PIncomingCallErrorEnum.UNKNOWN))
                     }
-                onSuccess()
             }, onError = { incomingCallError ->
                 Log.w(TAG, "Incoming call rejected: ${incomingCallError.value}")
                 onError(incomingCallError)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
@@ -78,6 +78,7 @@ class PhoneConnectionServiceDispatcher(
             ServiceAction.TearDownConnections,
             ServiceAction.ReserveAnswer,
             ServiceAction.NotifyPending,
+            ServiceAction.AddNewIncomingCall,
             ServiceAction.CleanConnections,
             ServiceAction.SyncAudioState,
             ServiceAction.SyncConnectionState,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -512,27 +512,39 @@ class ForegroundService :
         // call inside startIncomingCall — before the IPC onSuccess callback returns to this
         // process. Without pre-registration, resolvePendingIncomingCallback finds no entry and
         // the confirmation is lost, causing the 5-second timeout to fire unconditionally.
-        pendingIncomingCallbacks[callId] = callback
-        val timeoutRunnable =
-            Runnable {
-                logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
-                pendingIncomingTimeouts.remove(callId)
-                // pendingCallIds is owned by InProcessCallkeepCore.startIncomingCall now.
-                // If we got here, neither onSuccess nor onError fired within 5 s — the
-                // internal drain did not run, so we must drain explicitly. removePending
-                // is idempotent.
-                core.removePending(callId)
-                // Mark terminated and endCallDispatched so that a late-arriving HungUp
-                // broadcast (after the timeout) does not cause handleCSReportDeclineCall
-                // to fire performEndCall for a call Flutter already got callRejectedBySystem for.
-                core.clearAndMarkEndCallDispatched(callId)
-                resolvePendingIncomingCallback(
-                    callId,
-                    Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
-                )
-            }
-        pendingIncomingTimeouts[callId] = timeoutRunnable
-        mainHandler.postDelayed(timeoutRunnable, INCOMING_CALL_CONFIRMATION_TIMEOUT_MS)
+        //
+        // putIfAbsent is used instead of a plain assignment so that concurrent
+        // reportNewIncomingCall calls with the same callId (all dispatched on the main thread
+        // before any of them completes) cannot overwrite each other's callback. Only the first
+        // caller owns the slot (ownsPendingSlot=true) and registers the timeout; duplicates
+        // skip both registrations and, in their onError handler, must not touch the maps so
+        // the first callback remains in place until DidPushIncomingCall resolves it.
+        val ownsPendingSlot = pendingIncomingCallbacks.putIfAbsent(callId, callback) == null
+        val timeoutRunnable: Runnable
+        if (ownsPendingSlot) {
+            timeoutRunnable =
+                Runnable {
+                    logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
+                    pendingIncomingTimeouts.remove(callId)
+                    // pendingCallIds is owned by InProcessCallkeepCore.startIncomingCall now.
+                    // If we got here, neither onSuccess nor onError fired within 5 s — the
+                    // internal drain did not run, so we must drain explicitly. removePending
+                    // is idempotent.
+                    core.removePending(callId)
+                    // Mark terminated and endCallDispatched so that a late-arriving HungUp
+                    // broadcast (after the timeout) does not cause handleCSReportDeclineCall
+                    // to fire performEndCall for a call Flutter already got callRejectedBySystem for.
+                    core.clearAndMarkEndCallDispatched(callId)
+                    resolvePendingIncomingCallback(
+                        callId,
+                        Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
+                    )
+                }
+            pendingIncomingTimeouts[callId] = timeoutRunnable
+            mainHandler.postDelayed(timeoutRunnable, INCOMING_CALL_CONFIRMATION_TIMEOUT_MS)
+        } else {
+            timeoutRunnable = Runnable {}
+        }
 
         // Mark this callId as signaling-registered BEFORE calling startIncomingCall so
         // that the DidPushIncomingCall broadcast (fired by :callkeep_core during the IPC
@@ -556,11 +568,14 @@ class ForegroundService :
                 // markSignalingRegistered was already called before startIncomingCall.
             },
             onError = { error ->
-                // startIncomingCall failed — cancel the pre-registered timeout and callback
-                // so they do not race with the direct callback invocation below.
+                // Cancel timeout and clear maps only if this call owns the pending slot.
+                // A non-owner (ownsPendingSlot=false) must leave the maps untouched so the
+                // first caller's callback stays in place for DidPushIncomingCall to resolve.
                 mainHandler.removeCallbacks(timeoutRunnable)
-                pendingIncomingTimeouts.remove(callId)
-                pendingIncomingCallbacks.remove(callId)
+                if (ownsPendingSlot) {
+                    pendingIncomingTimeouts.remove(callId)
+                    pendingIncomingCallbacks.remove(callId)
+                }
 
                 when (error?.value) {
                     PIncomingCallErrorEnum.CALL_ID_ALREADY_EXISTS -> {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -520,9 +520,10 @@ class ForegroundService :
         // skip both registrations and, in their onError handler, must not touch the maps so
         // the first callback remains in place until DidPushIncomingCall resolves it.
         val ownsPendingSlot = pendingIncomingCallbacks.putIfAbsent(callId, callback) == null
-        val timeoutRunnable: Runnable
-        if (ownsPendingSlot) {
-            timeoutRunnable =
+        // Non-owners post no timeout and have nothing to cancel in onError — null makes
+        // the ownership contract explicit and avoids allocating a no-op Runnable per call.
+        val timeoutRunnable: Runnable? =
+            if (ownsPendingSlot) {
                 Runnable {
                     logger.w("reportNewIncomingCall: Telecom confirmation timeout for callId=$callId, resolving with CALL_REJECTED_BY_SYSTEM")
                     pendingIncomingTimeouts.remove(callId)
@@ -539,12 +540,13 @@ class ForegroundService :
                         callId,
                         Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_REJECTED_BY_SYSTEM)),
                     )
+                }.also { r ->
+                    pendingIncomingTimeouts[callId] = r
+                    mainHandler.postDelayed(r, INCOMING_CALL_CONFIRMATION_TIMEOUT_MS)
                 }
-            pendingIncomingTimeouts[callId] = timeoutRunnable
-            mainHandler.postDelayed(timeoutRunnable, INCOMING_CALL_CONFIRMATION_TIMEOUT_MS)
-        } else {
-            timeoutRunnable = Runnable {}
-        }
+            } else {
+                null
+            }
 
         // Mark this callId as signaling-registered BEFORE calling startIncomingCall so
         // that the DidPushIncomingCall broadcast (fired by :callkeep_core during the IPC
@@ -571,7 +573,7 @@ class ForegroundService :
                 // Cancel timeout and clear maps only if this call owns the pending slot.
                 // A non-owner (ownsPendingSlot=false) must leave the maps untouched so the
                 // first caller's callback stays in place for DidPushIncomingCall to resolve.
-                mainHandler.removeCallbacks(timeoutRunnable)
+                timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
                 if (ownsPendingSlot) {
                     pendingIncomingTimeouts.remove(callId)
                     pendingIncomingCallbacks.remove(callId)


### PR DESCRIPTION
## Overview

Two related races on Android that caused `reportNewIncomingCall` to fail after a
declined call or under concurrent same-callId spam. Relates to WT-1538.

---

### 1. Concurrent same-callId spam hangs the Pigeon Future

**Root cause.** `ForegroundService.reportNewIncomingCall` pre-registers the Pigeon
callback in `pendingIncomingCallbacks[callId]` before calling `core.startIncomingCall`.
With concurrent same-callId calls all dispatched on the main thread before any completes,
each overwrote the previous entry. Duplicates rejected by `tracker.addPending` called
`pendingIncomingCallbacks.remove(callId)` in their `onError`, leaving the map empty
before `DidPushIncomingCall` arrived. The first Future never resolved.

**Fix.** Replace the plain map assignment with `putIfAbsent`. The first call gets
`ownsPendingSlot=true` and is the only one to register the callback and the 5-second
safety timeout. Subsequent duplicates get `ownsPendingSlot=false` and skip both; their
`onError` leaves the map entry untouched so the first callback survives until
`DidPushIncomingCall` resolves it.

---

### 2. callId reuse after decline fails intermittently

**Root cause.** `destroy()` ran in `:callkeep_core` while `addNewIncomingCall` was
called from the main process. Different Telecom binder connections - no ordering
guarantee. Under load `addNewIncomingCall` was processed before `destroy()`, causing
`onCreateIncomingConnectionFailed` for the reused callId.

**Fix.** New `ServiceAction.AddNewIncomingCall`: the main process sends a single IPC
intent to `:callkeep_core`, which calls `addPendingForIncomingCall` then
`addNewIncomingCall` from the same process as `destroy()`. Both now share the same
Telecom binder connection, guaranteeing FIFO order.

Additionally: `addPendingForIncomingCall` now returns `Boolean` and rejects callIds
that are in `forcedTerminatedCallIds` (populated by `cleanConnections()` during
tearDown). This prevents a stale in-flight `AddNewIncomingCall` intent - queued
before tearDown but delivered after - from creating a phantom connection in the next
session.

---

### 3. Cleanup: `dispatchHungUpAndRemovePending` helper

Extracted a helper that eliminates three identical `removePending + dispatch(HungUp)`
call sites in `PhoneConnectionService`. `onCreateIncomingConnectionFailed` uses it
with `removePending=false` to leave the pending slot intact so `DidPushIncomingCall`
can still resolve the waiting Flutter callback.

---

### Integration tests

Reordered `all_tests.dart`: `delegate_edge_cases`, `foreground_service`, and `stress`
now run in positions 13-62, before the 50-test `call_scenarios` suite. All three are
sensitive to Telecom and FGS broadcast-pipeline degradation that accumulates after
80+ setUp/tearDown cycles. Moved early, they run on a fresh system and pass reliably.

**Result:** 156 passed, 5 platform-skipped, 0 failed on Samsung Android 15.

---

## Manual test plan

**Setup:** local stack running, test accounts 555001 / 555002.

### A. Declined call - same callId reuse
1. Call from 555002 to 555001 - decline on 555001.
2. Immediately call again from 555002 to 555001.
3. Expected: second call rings normally on 555001, no `CALL_REJECTED_BY_SYSTEM` in logs.

### B. Push + signaling combined flow (concurrent same-callId)
Background: when the app is backgrounded, an incoming call is reported via two
independent paths - the FCM push wakes `IncomingCallService` (push path) and the
signaling WebSocket inside the Flutter isolate also reports the same call (signaling
path). Both call `reportNewIncomingCall` with the same callId within milliseconds.

Steps:
1. On 555001, background the app (Home button - do NOT force-kill; the process must stay alive).
2. From 555002, place a call to 555001.
3. The Telecom ringing UI appears immediately (push path fired).
4. Tap the app icon to bring 555001 to the foreground - the signaling WebSocket
   reconnects and also reports the same call.
5. Answer or decline the call.
6. Place another call from 555002 to verify the next call works normally.

Expected: exactly one incoming call screen, no double ring, no ANR, next call after
this one also connects normally.

### C. Rapid decline + re-call loop (stress)
1. From 555002, call 555001 - decline immediately on 555001.
2. Repeat 5 times in quick succession (< 2 s between calls).
3. Expected: every call rings on 555001; no call produces `CALL_REJECTED_BY_SYSTEM`.

### D. tearDown race - active call
1. Answer a call on 555001.
2. While active, sign out or force-disconnect signaling on 555001.
3. Expected: `performEndCall` fires exactly once; the next sign-in and incoming call
   work normally with no stale callbacks.

### E. Push-path answered before app opens (cold-start adoption)
1. Fully close the app on 555001 (force-kill from Recent Apps).
2. From 555002, call 555001.
3. Answer via the system Telecom notification - do not open the app yet.
4. Open the app.
5. Expected: app shows an active call screen (not incoming), WebRTC audio connects.