### PR TITLE
chore(ci): run Firebase integration tests on merge and release only

### DIFF
--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - release/*
     paths:
       - "webtrit_callkeep/**"
       - "webtrit_callkeep_android/**"

--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -2,7 +2,7 @@ name: Integration Tests (Firebase Test Lab)
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - develop
     paths:
@@ -10,13 +10,14 @@ on:
       - "webtrit_callkeep_android/**"
       - "webtrit_callkeep_platform_interface/**"
       - ".github/workflows/integration-tests-firebase.yml"
+    tags:
+      - "*.*.*"
 
 jobs:
   # ── Job 1: discover test files + build all APKs in one runner ────────────────
   setup:
     name: Build all APKs
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
 
     outputs:
       tests: ${{ steps.discover.outputs.tests }}

--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -11,8 +11,6 @@ on:
       - "webtrit_callkeep_android/**"
       - "webtrit_callkeep_platform_interface/**"
       - ".github/workflows/integration-tests-firebase.yml"
-    tags:
-      - "*.*.*"
 
 jobs:
   # ── Job 1: discover test files + build all APKs in one runner ────────────────


### PR DESCRIPTION
## Overview

Firebase Test Lab integration tests were running on every PR to develop, which
is expensive and slows down code review. They now trigger only after code
actually lands, based on the release flow:

```
develop -> release/X.Y.Z -> PR to main -> merge -> auto-tag X.Y.Z
```

**Trigger changes:**

| Event | Before | After |
|-------|--------|-------|
| PR opened / updated | runs | skipped |
| Push to develop (PR merged) | skipped | runs |
| Push to release/* (release candidate) | skipped | runs |
| `workflow_dispatch` | runs | runs |

Tag push is intentionally excluded: tags are created by `auto-tag-version.yaml`
after merge to main, which is too late to block a bad release. The
`release/*` branch trigger covers the release candidate before the main merge.

Also removed the fork-PR guard on the `setup` job - it was only relevant for
the now-removed `pull_request` trigger.