### PR TITLE
fix: parse service intents into typed commands to avoid metadata crash

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -176,7 +176,16 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
-        val metadata = CallMetadata.fromBundle(request.extras)
+        // request.extras originates from our own placeOutgoingCall(metadata.toBundle()), so a
+        // missing callId here is a "should never happen" invariant violation (e.g. Binder
+        // truncation / framework edge case). Fail this one connection gracefully instead of
+        // letting CallMetadata.fromBundle throw an uncaught IllegalArgumentException that would
+        // crash the whole :callkeep_core process.
+        val metadata =
+            CallMetadata.fromBundleOrNull(request.extras) ?: run {
+                Log.e(TAG, "onCreateOutgoingConnection: missing callId in request extras, rejecting")
+                return Connection.createFailedConnection(DisconnectCause(DisconnectCause.ERROR))
+            }
 
         // Check if a connection with the same call ID already exists.
         // If so, reject the new connection request to prevent conflicts.
@@ -239,7 +248,15 @@ class PhoneConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle,
         request: ConnectionRequest,
     ): Connection {
-        val metadata = CallMetadata.fromBundle(request.extras)
+        // request.extras originates from our own addNewIncomingCall(metadata.toBundle()), so a
+        // missing callId here is a "should never happen" invariant violation. Reject this one
+        // connection instead of letting CallMetadata.fromBundle throw an uncaught
+        // IllegalArgumentException that would crash the whole :callkeep_core process.
+        val metadata =
+            CallMetadata.fromBundleOrNull(request.extras) ?: run {
+                Log.e(TAG, "onCreateIncomingConnection: missing callId in request extras, rejecting")
+                return Connection.createFailedConnection(DisconnectCause(DisconnectCause.ERROR))
+            }
         Log.i(TAG, "onCreateIncomingConnection: entry callId=${metadata.callId} account=$connectionManagerPhoneAccount")
 
         // Guard against stale Telecom callbacks that arrive after a tearDown.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -98,31 +98,32 @@ class PhoneConnectionService : ConnectionService() {
         flags: Int,
         startId: Int,
     ): Int {
-        val action =
-            intent?.action?.let { ServiceAction.from(it) } ?: run {
-                Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
+        // Parse the intent into a typed command once, BEFORE the try, but without touching the
+        // call metadata for commands that do not need it. This avoids the crash where
+        // CallMetadata.fromBundle was eagerly invoked on empty Binder-delivered extras for the
+        // no-extras lifecycle commands and threw an uncaught IllegalArgumentException.
+        val command =
+            intent?.let { PhoneServiceCommand.from(it) } ?: run {
+                Log.w(TAG, "onStartCommand: unknown, missing, or incomplete action '${intent?.action}', ignoring")
                 return START_NOT_STICKY
             }
-        val metadata = intent.extras?.let { CallMetadata.fromBundle(it) }
 
         try {
-            when (action) {
+            when (command) {
                 // IPC commands from the main process — handled directly, not routed through the
                 // call-connection dispatcher. Using startService (instead of broadcasts) guarantees
                 // delivery even if the service is starting up: the intent is queued and processed
                 // after onCreate() completes, so these handlers are always reachable.
-                ServiceAction.TearDownConnections -> {
+                is PhoneServiceCommand.TearDown -> {
                     handleTearDownConnections()
                 }
 
-                ServiceAction.ReserveAnswer -> {
-                    metadata?.callId?.let { handleReserveAnswer(it) }
-                        ?: Log.w(TAG, "onStartCommand: ReserveAnswer missing callId")
+                is PhoneServiceCommand.Reserve -> {
+                    handleReserveAnswer(command.callId)
                 }
 
-                ServiceAction.NotifyPending -> {
-                    metadata?.callId?.let { handleNotifyPending(it) }
-                        ?: Log.w(TAG, "onStartCommand: NotifyPending missing callId")
+                is PhoneServiceCommand.Pending -> {
+                    handleNotifyPending(command.callId)
                 }
 
                 // startService() on a ConnectionService from the same app (same UID) is valid:
@@ -137,25 +138,24 @@ class PhoneConnectionService : ConnectionService() {
                 // startService() -> onStartCommand() is an orthogonal IPC channel used throughout
                 // this codebase (NotifyPending, TearDownConnections, ReserveAnswer, etc.) and is
                 // not prohibited by the framework.
-                ServiceAction.AddNewIncomingCall -> {
-                    metadata?.let { handleAddNewIncomingCall(it) }
-                        ?: Log.w(TAG, "onStartCommand: AddNewIncomingCall missing metadata")
+                is PhoneServiceCommand.AddIncoming -> {
+                    handleAddNewIncomingCall(command.metadata)
                 }
 
-                ServiceAction.CleanConnections -> {
+                is PhoneServiceCommand.Clean -> {
                     handleCleanConnections()
                 }
 
-                ServiceAction.SyncAudioState -> {
+                is PhoneServiceCommand.SyncAudio -> {
                     handleSyncAudioState()
                 }
 
-                ServiceAction.SyncConnectionState -> {
+                is PhoneServiceCommand.SyncConnection -> {
                     handleSyncConnectionState()
                 }
 
-                else -> {
-                    phoneConnectionServiceDispatcher.dispatch(action, metadata)
+                is PhoneServiceCommand.CallOp -> {
+                    phoneConnectionServiceDispatcher.dispatch(command.action, command.metadata)
                 }
             }
         } catch (e: Exception) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -104,7 +104,13 @@ class PhoneConnectionService : ConnectionService() {
         // no-extras lifecycle commands and threw an uncaught IllegalArgumentException.
         val command =
             intent?.let { PhoneServiceCommand.from(it) } ?: run {
-                Log.w(TAG, "onStartCommand: unknown, missing, or incomplete action '${intent?.action}', ignoring")
+                // Distinguish an unrecognised action from a known action whose required
+                // callId/metadata is missing, so the log points at the actual failure.
+                if (intent?.action?.let { ServiceAction.from(it) } != null) {
+                    Log.w(TAG, "onStartCommand: action '${intent.action}' missing required callId/metadata, ignoring")
+                } else {
+                    Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
+                }
                 return START_NOT_STICKY
             }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
@@ -1,0 +1,93 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Intent
+import com.webtrit.callkeep.common.CallDataConst
+import com.webtrit.callkeep.models.CallMetadata
+
+/**
+ * Typed representation of a command delivered to [PhoneConnectionService.onStartCommand].
+ *
+ * Parsing the [Intent] (action lookup + [CallMetadata] extraction) is performed once in [from]
+ * instead of eagerly at the top of `onStartCommand`. This removes the crash where
+ * `CallMetadata.fromBundle` was invoked on the bare intent extras BEFORE the surrounding
+ * try/catch: Binder IPC can deliver a non-null but empty [android.os.Bundle] for the no-extras
+ * lifecycle commands ([ServiceAction.TearDownConnections], [ServiceAction.CleanConnections],
+ * [ServiceAction.SyncAudioState], [ServiceAction.SyncConnectionState]), and the missing-`callId`
+ * `IllegalArgumentException` then propagated uncaught out of `onStartCommand`.
+ *
+ * With this factory each command type owns exactly the data it needs:
+ *  - lifecycle commands carry nothing and never touch the extras;
+ *  - [Reserve] / [Pending] carry a non-null `callId`;
+ *  - [AddIncoming] carries non-null [CallMetadata];
+ *  - [CallOp] carries the raw [ServiceAction] plus nullable metadata for the dispatcher path.
+ */
+sealed class PhoneServiceCommand {
+    data object TearDown : PhoneServiceCommand()
+
+    data object Clean : PhoneServiceCommand()
+
+    data object SyncAudio : PhoneServiceCommand()
+
+    data object SyncConnection : PhoneServiceCommand()
+
+    data class Reserve(
+        val callId: String,
+    ) : PhoneServiceCommand()
+
+    data class Pending(
+        val callId: String,
+    ) : PhoneServiceCommand()
+
+    data class AddIncoming(
+        val metadata: CallMetadata,
+    ) : PhoneServiceCommand()
+
+    data class CallOp(
+        val action: ServiceAction,
+        val metadata: CallMetadata?,
+    ) : PhoneServiceCommand()
+
+    companion object {
+        /**
+         * Builds a [PhoneServiceCommand] from [intent], or returns `null` when the action is
+         * unknown/missing or a command that requires a `callId`/metadata is missing it. A `null`
+         * result is non-fatal: the caller logs and ignores the intent.
+         */
+        fun from(intent: Intent): PhoneServiceCommand? {
+            val action = ServiceAction.from(intent.action) ?: return null
+            return when (action) {
+                ServiceAction.TearDownConnections -> {
+                    TearDown
+                }
+
+                ServiceAction.CleanConnections -> {
+                    Clean
+                }
+
+                ServiceAction.SyncAudioState -> {
+                    SyncAudio
+                }
+
+                ServiceAction.SyncConnectionState -> {
+                    SyncConnection
+                }
+
+                ServiceAction.ReserveAnswer -> {
+                    intent.extras?.getString(CallDataConst.CALL_ID)?.let { Reserve(it) }
+                }
+
+                ServiceAction.NotifyPending -> {
+                    intent.extras?.getString(CallDataConst.CALL_ID)?.let { Pending(it) }
+                }
+
+                ServiceAction.AddNewIncomingCall -> {
+                    intent.extras?.let { CallMetadata.fromBundleOrNull(it) }?.let { AddIncoming(it) }
+                }
+
+                else -> {
+                    CallOp(action, intent.extras?.let { CallMetadata.fromBundleOrNull(it) })
+                }
+            }
+        }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -108,40 +108,31 @@ class StandaloneCallService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
-        val action =
-            intent?.action?.let { StandaloneServiceAction.from(it) } ?: run {
-                Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
+        // Parse the intent into a typed command once. Lifecycle commands carry no metadata, so
+        // CallMetadata parsing never runs for them — closing the same eager-parse crash fixed on
+        // the Telecom path (empty Binder-delivered Bundle -> uncaught IllegalArgumentException).
+        val command =
+            intent?.let { StandaloneServiceCommand.from(it) } ?: run {
+                Log.w(TAG, "onStartCommand: unknown, missing, or incomplete action '${intent?.action}', ignoring")
                 return START_NOT_STICKY
             }
-        val metadata = intent.extras?.let { CallMetadata.fromBundle(it) }
 
         // Satisfy the 5-second startForeground() window for call-setup actions, which
         // are the only ones started via startForegroundService(). All other actions
         // arrive via startService() and must NOT call startForeground() here — doing so
         // from a non-foreground-service start crashes the process on some OEM devices.
-        if (action == StandaloneServiceAction.IncomingCall || action == StandaloneServiceAction.OutgoingCall) {
+        if (command.isCallSetup) {
             promoteToForeground()
         }
 
         try {
-            when (action) {
-                StandaloneServiceAction.IncomingCall -> metadata?.let { handleIncomingCall(it) }
-                StandaloneServiceAction.OutgoingCall -> metadata?.let { handleOutgoingCall(it) }
-                StandaloneServiceAction.EstablishCall -> metadata?.let { handleEstablishCall(it) }
-                StandaloneServiceAction.AnswerCall -> metadata?.let { handleAnswerCall(it) }
-                StandaloneServiceAction.DeclineCall -> metadata?.let { handleDeclineCall(it) }
-                StandaloneServiceAction.HungUpCall -> metadata?.let { handleHungUpCall(it) }
-                StandaloneServiceAction.UpdateCall -> metadata?.let { handleUpdateCall(it) }
-                StandaloneServiceAction.SendDtmf -> metadata?.let { handleSendDtmf(it) }
-                StandaloneServiceAction.Holding -> metadata?.let { handleHolding(it) }
-                StandaloneServiceAction.TearDownConnections -> handleTearDownConnections()
-                StandaloneServiceAction.CleanConnections -> handleCleanConnections()
-                StandaloneServiceAction.ReserveAnswer -> metadata?.callId?.let { handleReserveAnswer(it) }
-                StandaloneServiceAction.Muting -> metadata?.let { handleMuting(it) }
-                StandaloneServiceAction.Speaker -> metadata?.let { handleSpeaker(it) }
-                StandaloneServiceAction.AudioDeviceSet -> metadata?.let { handleAudioDeviceSet(it) }
-                StandaloneServiceAction.SyncAudioState -> handleSyncAudioState()
-                StandaloneServiceAction.SyncConnectionState -> handleSyncConnectionState()
+            when (command) {
+                is StandaloneServiceCommand.TearDown -> handleTearDownConnections()
+                is StandaloneServiceCommand.Clean -> handleCleanConnections()
+                is StandaloneServiceCommand.SyncAudio -> handleSyncAudioState()
+                is StandaloneServiceCommand.SyncConnection -> handleSyncConnectionState()
+                is StandaloneServiceCommand.Reserve -> handleReserveAnswer(command.callId)
+                is StandaloneServiceCommand.Call -> dispatchCall(command.action, command.metadata)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Exception with action: ${intent?.action}", e)
@@ -172,6 +163,51 @@ class StandaloneCallService : Service() {
     // -------------------------------------------------------------------------
     // Command handlers
     // -------------------------------------------------------------------------
+
+    /**
+     * Routes a [StandaloneServiceCommand.Call] to its handler. [metadata] is guaranteed non-null
+     * by [StandaloneServiceCommand.from], so the per-action `metadata?.let` guards that previously
+     * silently dropped call actions on a malformed bundle are no longer needed.
+     */
+    private fun dispatchCall(
+        action: StandaloneServiceAction,
+        metadata: CallMetadata,
+    ) {
+        when (action) {
+            StandaloneServiceAction.IncomingCall -> handleIncomingCall(metadata)
+
+            StandaloneServiceAction.OutgoingCall -> handleOutgoingCall(metadata)
+
+            StandaloneServiceAction.EstablishCall -> handleEstablishCall(metadata)
+
+            StandaloneServiceAction.AnswerCall -> handleAnswerCall(metadata)
+
+            StandaloneServiceAction.DeclineCall -> handleDeclineCall(metadata)
+
+            StandaloneServiceAction.HungUpCall -> handleHungUpCall(metadata)
+
+            StandaloneServiceAction.UpdateCall -> handleUpdateCall(metadata)
+
+            StandaloneServiceAction.SendDtmf -> handleSendDtmf(metadata)
+
+            StandaloneServiceAction.Holding -> handleHolding(metadata)
+
+            StandaloneServiceAction.Muting -> handleMuting(metadata)
+
+            StandaloneServiceAction.Speaker -> handleSpeaker(metadata)
+
+            StandaloneServiceAction.AudioDeviceSet -> handleAudioDeviceSet(metadata)
+
+            // Lifecycle and ReserveAnswer actions are modelled as dedicated command types and never
+            // wrapped in Call, so they cannot reach this branch.
+            StandaloneServiceAction.TearDownConnections,
+            StandaloneServiceAction.CleanConnections,
+            StandaloneServiceAction.ReserveAnswer,
+            StandaloneServiceAction.SyncAudioState,
+            StandaloneServiceAction.SyncConnectionState,
+            -> Log.w(TAG, "dispatchCall: unexpected non-call action $action, ignoring")
+        }
+    }
 
     /**
      * Promotes the service to a foreground service.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -108,22 +108,32 @@ class StandaloneCallService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
+        val action = intent?.action?.let { StandaloneServiceAction.from(it) }
+
+        // Satisfy the 5-second startForeground() window for call-setup actions, which are the only
+        // ones started via startForegroundService(). This MUST be decided from the raw action (not
+        // the parsed command) and run BEFORE the command-parse bail-out below: if the call-setup
+        // intent arrives with empty/truncated Binder extras, command parsing fails and an early
+        // return without startForeground() would crash the process with
+        // ForegroundServiceDidNotStartInTimeException ~5s later. All other actions arrive via
+        // startService() and must NOT call startForeground() here — doing so from a
+        // non-foreground-service start crashes the process on some OEM devices.
+        if (action?.isCallSetup == true) {
+            promoteToForeground()
+        }
+
         // Parse the intent into a typed command once. Lifecycle commands carry no metadata, so
         // CallMetadata parsing never runs for them — closing the same eager-parse crash fixed on
         // the Telecom path (empty Binder-delivered Bundle -> uncaught IllegalArgumentException).
         val command =
             intent?.let { StandaloneServiceCommand.from(it) } ?: run {
                 Log.w(TAG, "onStartCommand: unknown, missing, or incomplete action '${intent?.action}', ignoring")
+                // Release the service if nothing keeps it alive — including the placeholder
+                // foreground we may have just promoted for a call-setup action whose extras did
+                // not parse — so it does not linger as a zombie (foreground) service.
+                stopIfIdle()
                 return START_NOT_STICKY
             }
-
-        // Satisfy the 5-second startForeground() window for call-setup actions, which
-        // are the only ones started via startForegroundService(). All other actions
-        // arrive via startService() and must NOT call startForeground() here — doing so
-        // from a non-foreground-service start crashes the process on some OEM devices.
-        if (command.isCallSetup) {
-            promoteToForeground()
-        }
 
         try {
             when (command) {
@@ -141,11 +151,20 @@ class StandaloneCallService : Service() {
         // If no calls are active or pending after processing, there is nothing to keep alive.
         // This handles the case where a lifecycle-only command (SyncConnectionState,
         // SyncAudioState, CleanConnections) starts the service when no call is in progress.
+        stopIfIdle()
+
+        return START_NOT_STICKY
+    }
+
+    /**
+     * Stops the service when no call is active or pending. Reached both after normal command
+     * processing and on the command-parse bail-out path, so a call-setup intent that promoted to
+     * foreground but failed to parse does not leave a zombie (foreground) service running.
+     */
+    private fun stopIfIdle() {
         if (callMetadataMap.isEmpty() && pendingAnswers.isEmpty()) {
             stopSelf()
         }
-
-        return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -657,6 +676,15 @@ enum class StandaloneServiceAction {
     ;
 
     val action: String get() = "callkeep_standalone_$name"
+
+    /**
+     * Call-setup actions are the only ones started via [android.content.Context.startForegroundService]
+     * (see [StandaloneCallService.startIncomingCall] / [StandaloneCallService.startOutgoingCall]) and
+     * therefore impose the 5-second [android.app.Service.startForeground] window. Single source of
+     * truth used by [StandaloneCallService.onStartCommand] to promote to foreground from the raw
+     * action, independently of whether the command metadata parses.
+     */
+    val isCallSetup: Boolean get() = this == IncomingCall || this == OutgoingCall
 
     companion object {
         fun from(action: String?): StandaloneServiceAction? = entries.find { it.action == action }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -127,7 +127,13 @@ class StandaloneCallService : Service() {
         // the Telecom path (empty Binder-delivered Bundle -> uncaught IllegalArgumentException).
         val command =
             intent?.let { StandaloneServiceCommand.from(it) } ?: run {
-                Log.w(TAG, "onStartCommand: unknown, missing, or incomplete action '${intent?.action}', ignoring")
+                // Distinguish an unrecognised action from a known action whose required
+                // callId/metadata is missing, so the log points at the actual failure.
+                if (action != null) {
+                    Log.w(TAG, "onStartCommand: action '$action' missing required callId/metadata, ignoring")
+                } else {
+                    Log.w(TAG, "onStartCommand: unknown or missing action '${intent?.action}', ignoring")
+                }
                 // Release the service if nothing keeps it alive — including the placeholder
                 // foreground we may have just promoted for a call-setup action whose extras did
                 // not parse — so it does not linger as a zombie (foreground) service.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
@@ -1,0 +1,81 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Intent
+import com.webtrit.callkeep.common.CallDataConst
+import com.webtrit.callkeep.models.CallMetadata
+
+/**
+ * Typed representation of a command delivered to [StandaloneCallService.onStartCommand].
+ *
+ * Mirrors [PhoneServiceCommand] for the non-Telecom path. Parsing is done once in [from] so the
+ * [CallMetadata] extraction never runs for the no-extras lifecycle commands
+ * ([StandaloneServiceAction.TearDownConnections], [StandaloneServiceAction.CleanConnections],
+ * [StandaloneServiceAction.SyncAudioState], [StandaloneServiceAction.SyncConnectionState]). This
+ * closes the same latent crash as on the Telecom path: a Binder-delivered empty
+ * [android.os.Bundle] would otherwise reach `CallMetadata.fromBundle` and throw an uncaught
+ * `IllegalArgumentException`.
+ *
+ * Every call action carries non-null [CallMetadata]; [Reserve] carries a non-null `callId`.
+ */
+sealed class StandaloneServiceCommand {
+    /** True for actions delivered via `startForegroundService`, which must promote to foreground. */
+    open val isCallSetup: Boolean get() = false
+
+    data object TearDown : StandaloneServiceCommand()
+
+    data object Clean : StandaloneServiceCommand()
+
+    data object SyncAudio : StandaloneServiceCommand()
+
+    data object SyncConnection : StandaloneServiceCommand()
+
+    data class Reserve(
+        val callId: String,
+    ) : StandaloneServiceCommand()
+
+    data class Call(
+        val action: StandaloneServiceAction,
+        val metadata: CallMetadata,
+    ) : StandaloneServiceCommand() {
+        override val isCallSetup: Boolean
+            get() =
+                action == StandaloneServiceAction.IncomingCall ||
+                    action == StandaloneServiceAction.OutgoingCall
+    }
+
+    companion object {
+        /**
+         * Builds a [StandaloneServiceCommand] from [intent], or returns `null` when the action is
+         * unknown/missing or a command that requires a `callId`/metadata is missing it. A `null`
+         * result is non-fatal: the caller logs and ignores the intent.
+         */
+        fun from(intent: Intent): StandaloneServiceCommand? {
+            val action = StandaloneServiceAction.from(intent.action) ?: return null
+            return when (action) {
+                StandaloneServiceAction.TearDownConnections -> {
+                    TearDown
+                }
+
+                StandaloneServiceAction.CleanConnections -> {
+                    Clean
+                }
+
+                StandaloneServiceAction.SyncAudioState -> {
+                    SyncAudio
+                }
+
+                StandaloneServiceAction.SyncConnectionState -> {
+                    SyncConnection
+                }
+
+                StandaloneServiceAction.ReserveAnswer -> {
+                    intent.extras?.getString(CallDataConst.CALL_ID)?.let { Reserve(it) }
+                }
+
+                else -> {
+                    intent.extras?.let { CallMetadata.fromBundleOrNull(it) }?.let { Call(action, it) }
+                }
+            }
+        }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
@@ -18,9 +18,6 @@ import com.webtrit.callkeep.models.CallMetadata
  * Every call action carries non-null [CallMetadata]; [Reserve] carries a non-null `callId`.
  */
 sealed class StandaloneServiceCommand {
-    /** True for actions delivered via `startForegroundService`, which must promote to foreground. */
-    open val isCallSetup: Boolean get() = false
-
     data object TearDown : StandaloneServiceCommand()
 
     data object Clean : StandaloneServiceCommand()
@@ -36,12 +33,7 @@ sealed class StandaloneServiceCommand {
     data class Call(
         val action: StandaloneServiceAction,
         val metadata: CallMetadata,
-    ) : StandaloneServiceCommand() {
-        override val isCallSetup: Boolean
-            get() =
-                action == StandaloneServiceAction.IncomingCall ||
-                    action == StandaloneServiceAction.OutgoingCall
-    }
+    ) : StandaloneServiceCommand()
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
@@ -1,0 +1,122 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import com.webtrit.callkeep.common.CallDataConst
+import com.webtrit.callkeep.models.CallMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [PhoneServiceCommand.from] and [StandaloneServiceCommand.from].
+ *
+ * The central regression guard: a no-extras lifecycle action delivered with a non-null but empty
+ * [Bundle] (as Binder IPC can produce) must parse into a lifecycle command, NOT throw
+ * IllegalArgumentException from CallMetadata parsing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class ServiceCommandTest {
+    private fun intent(
+        action: String,
+        extras: Bundle?,
+    ): Intent =
+        Intent().apply {
+            this.action = action
+            if (extras != null) putExtras(extras)
+        }
+
+    // ----------------------------------------------------------------------- Phone
+
+    @Test
+    fun phone_lifecycleAction_withEmptyBundle_doesNotCrashAndReturnsLifecycleCommand() {
+        val command = PhoneServiceCommand.from(intent(ServiceAction.TearDownConnections.action, Bundle()))
+        assertEquals(PhoneServiceCommand.TearDown, command)
+    }
+
+    @Test
+    fun phone_lifecycleAction_withNullExtras_returnsLifecycleCommand() {
+        assertEquals(PhoneServiceCommand.Clean, PhoneServiceCommand.from(intent(ServiceAction.CleanConnections.action, null)))
+        assertEquals(PhoneServiceCommand.SyncAudio, PhoneServiceCommand.from(intent(ServiceAction.SyncAudioState.action, null)))
+        assertEquals(
+            PhoneServiceCommand.SyncConnection,
+            PhoneServiceCommand.from(intent(ServiceAction.SyncConnectionState.action, null)),
+        )
+    }
+
+    @Test
+    fun phone_reserveAnswer_withCallId_returnsReserve() {
+        val extras = Bundle().apply { putString(CallDataConst.CALL_ID, "call-1") }
+        assertEquals(PhoneServiceCommand.Reserve("call-1"), PhoneServiceCommand.from(intent(ServiceAction.ReserveAnswer.action, extras)))
+    }
+
+    @Test
+    fun phone_reserveAnswer_withoutCallId_returnsNull() {
+        assertNull(PhoneServiceCommand.from(intent(ServiceAction.ReserveAnswer.action, Bundle())))
+    }
+
+    @Test
+    fun phone_addNewIncomingCall_withMetadata_returnsAddIncoming() {
+        val extras = CallMetadata(callId = "call-2").toBundle()
+        val command = PhoneServiceCommand.from(intent(ServiceAction.AddNewIncomingCall.action, extras))
+        assertTrue(command is PhoneServiceCommand.AddIncoming)
+        assertEquals("call-2", (command as PhoneServiceCommand.AddIncoming).metadata.callId)
+    }
+
+    @Test
+    fun phone_callOp_withoutExtras_returnsCallOpWithNullMetadata() {
+        val command = PhoneServiceCommand.from(intent(ServiceAction.AnswerCall.action, null))
+        assertTrue(command is PhoneServiceCommand.CallOp)
+        command as PhoneServiceCommand.CallOp
+        assertEquals(ServiceAction.AnswerCall, command.action)
+        assertNull(command.metadata)
+    }
+
+    @Test
+    fun phone_unknownAction_returnsNull() {
+        assertNull(PhoneServiceCommand.from(intent("callkeep_not_an_action", null)))
+    }
+
+    // ----------------------------------------------------------------------- Standalone
+
+    @Test
+    fun standalone_lifecycleAction_withEmptyBundle_doesNotCrashAndReturnsLifecycleCommand() {
+        val command = StandaloneServiceCommand.from(intent(StandaloneServiceAction.TearDownConnections.action, Bundle()))
+        assertEquals(StandaloneServiceCommand.TearDown, command)
+    }
+
+    @Test
+    fun standalone_callSetupAction_withMetadata_returnsCallMarkedAsSetup() {
+        val extras = CallMetadata(callId = "call-3").toBundle()
+        val command = StandaloneServiceCommand.from(intent(StandaloneServiceAction.IncomingCall.action, extras))
+        assertTrue(command is StandaloneServiceCommand.Call)
+        command as StandaloneServiceCommand.Call
+        assertEquals(StandaloneServiceAction.IncomingCall, command.action)
+        assertTrue(command.isCallSetup)
+    }
+
+    @Test
+    fun standalone_callAction_withoutMetadata_returnsNull() {
+        assertNull(StandaloneServiceCommand.from(intent(StandaloneServiceAction.AnswerCall.action, Bundle())))
+    }
+
+    @Test
+    fun standalone_reserveAnswer_withCallId_returnsReserve() {
+        val extras = Bundle().apply { putString(CallDataConst.CALL_ID, "call-4") }
+        assertEquals(
+            StandaloneServiceCommand.Reserve("call-4"),
+            StandaloneServiceCommand.from(intent(StandaloneServiceAction.ReserveAnswer.action, extras)),
+        )
+    }
+
+    @Test
+    fun standalone_unknownAction_returnsNull() {
+        assertNull(StandaloneServiceCommand.from(intent("not_a_standalone_action", null)))
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
@@ -98,12 +98,22 @@ class ServiceCommandTest {
         assertTrue(command is StandaloneServiceCommand.Call)
         command as StandaloneServiceCommand.Call
         assertEquals(StandaloneServiceAction.IncomingCall, command.action)
-        assertTrue(command.isCallSetup)
     }
 
     @Test
     fun standalone_callAction_withoutMetadata_returnsNull() {
         assertNull(StandaloneServiceCommand.from(intent(StandaloneServiceAction.AnswerCall.action, Bundle())))
+    }
+
+    @Test
+    fun standalone_isCallSetup_trueOnlyForIncomingAndOutgoing() {
+        // onStartCommand promotes to foreground based on this predicate computed from the raw
+        // action — independently of whether the command metadata parses — so a call-setup intent
+        // with empty extras still satisfies the startForeground() window.
+        val setup = setOf(StandaloneServiceAction.IncomingCall, StandaloneServiceAction.OutgoingCall)
+        StandaloneServiceAction.entries.forEach { action ->
+            assertEquals(action in setup, action.isCallSetup)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Overview

`PhoneConnectionService` and `StandaloneCallService` both parsed call metadata via `CallMetadata.fromBundle` at the top of `onStartCommand`, **before** the surrounding `try/catch`. Binder IPC can deliver a non-null but empty `Bundle` for the no-extras lifecycle commands (`TearDownConnections`, `CleanConnections`, `SyncAudioState`, `SyncConnectionState`), so the missing-`callId` `IllegalArgumentException` propagated uncaught out of `onStartCommand` and crashed the `:callkeep_core` process (confirmed in Play Vitals: IAE from `CallMetaData.kt:121` via `PhoneConnectionService.kt:103`).

## Change

Introduce `PhoneServiceCommand` / `StandaloneServiceCommand` sealed types with a `from(intent)` factory that parses action + metadata once:

- lifecycle commands carry no metadata and never touch the extras;
- `Reserve` / `Pending` carry a non-null `callId`;
- `AddIncoming` / `Call` carry non-null `CallMetadata`;
- everything else maps to `CallOp(action, metadata?)` for the dispatcher path.

`onStartCommand` now switches over the typed command. Metadata parsing only runs for actions that need it, and a parse miss is non-fatal (logged + ignored) instead of crashing.

This **supersedes #301**, which only switched `PhoneConnectionService` to `fromBundleOrNull` and left `StandaloneCallService:116` with the identical latent crash on non-Telecom devices.

## Tests

New `ServiceCommandTest` covers the regression directly: a no-extras lifecycle action delivered with an empty `Bundle` parses into a lifecycle command instead of throwing, plus the `callId`/metadata-required and unknown-action paths for both services. `./gradlew testDebugUnitTest` green.

WT-1142