### PR TITLE
ci: bump Flutter to 3.44.1 and exclude generated files from format gate

### DIFF
--- a/.github/workflows/flutter_package.yml
+++ b/.github/workflows/flutter_package.yml
@@ -105,7 +105,17 @@ jobs:
         run: ${{inputs.setup}}
 
       - name: ✨ Check Formatting
-        run: dart format --line-length ${{inputs.format_line_length}} --set-exit-if-changed ${{inputs.format_directories}}
+        run: |
+          # Exclude generated sources from the format gate, mirroring the local lefthook hook.
+          # dart format has no exclude flag and ignores analysis_options formatter.exclude, so
+          # build the file list explicitly and skip dirs that do not exist in a given package.
+          dirs=""
+          for d in ${{inputs.format_directories}}; do [ -d "$d" ] && dirs="$dirs $d"; done
+          files=$(find $dirs -name '*.dart' \
+            ! -name '*.g.dart' ! -name '*.freezed.dart' ! -name '*.gr.dart' ! -name '*.pigeon.dart')
+          if [ -n "$files" ]; then
+            dart format --line-length ${{inputs.format_line_length}} --set-exit-if-changed $files
+          fi
 
       - name: 🕵️ Analyze
         run: flutter analyze ${{inputs.analyze_directories}}

--- a/.github/workflows/integration-tests-firebase.yml
+++ b/.github/workflows/integration-tests-firebase.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.32.0"
+          flutter-version: "3.44.1"
           channel: stable
 
       - name: Install Flutter dependencies

--- a/.github/workflows/webtrit_callkeep_android.yaml
+++ b/.github/workflows/webtrit_callkeep_android.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       run_tests: false
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_android
       format_line_length: "120"
 

--- a/.github/workflows/webtrit_callkeep_ios.yaml
+++ b/.github/workflows/webtrit_callkeep_ios.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       run_tests: false
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_ios
       format_line_length: "120"
 

--- a/.github/workflows/webtrit_callkeep_linux.yaml
+++ b/.github/workflows/webtrit_callkeep_linux.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_linux
       format_line_length: "120"
 

--- a/.github/workflows/webtrit_callkeep_macos.yaml
+++ b/.github/workflows/webtrit_callkeep_macos.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_macos
       format_line_length: "120"
 

--- a/.github/workflows/webtrit_callkeep_platform_interface.yaml
+++ b/.github/workflows/webtrit_callkeep_platform_interface.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       run_tests: false
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_platform_interface
       format_line_length: "120"
       format_directories: "lib"

--- a/.github/workflows/webtrit_callkeep_web.yaml
+++ b/.github/workflows/webtrit_callkeep_web.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/flutter_package.yml
     with:
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_web
       format_line_length: "120"
       format_directories: "lib"

--- a/.github/workflows/webtrit_callkeep_windows.yaml
+++ b/.github/workflows/webtrit_callkeep_windows.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.32.0
+      flutter_version: 3.44.1
       working_directory: webtrit_callkeep_windows
       format_line_length: "120"
 


### PR DESCRIPTION
## Overview

CI workflows pinned Flutter `3.32.0` (Dart 3.8.0), but `webtrit_callkeep_android` and `webtrit_callkeep_ios` now depend on `pigeon: ^27.0.0`, which requires Dart `>=3.9.0`. As a result `flutter pub get` fails at dependency resolution and the package `build` check goes red on every PR (e.g. it was red on #319 with `version solving failed`).

## Change

- Bump the pinned Flutter version `3.32.0 -> 3.44.1` (Dart 3.12.1) across all package workflows (`android`, `ios`, `platform_interface`, `web`, `linux`, `macos`, `windows`) and the Firebase integration workflow.
- Fix the reusable `flutter_package.yml` format step to exclude generated sources (`*.g.dart`, `*.freezed.dart`, `*.gr.dart`, `*.pigeon.dart`), mirroring the local `lefthook` hook. Bumping Flutter alone exposed this: the old step ran `dart format` over the committed `*.pigeon.dart` files and the newer formatter rewraps them. `dart format` has no exclude flag and ignores `analysis_options` `formatter.exclude`, so the file list is built explicitly (also skipping dirs that do not exist in a given package).

## Verification

Mirrored the CI steps locally on Flutter 3.44.1 / Dart 3.12.1:
- `flutter pub get` resolves for android + ios (previously failed).
- `dart format` over `lib test` excluding generated files: PASS for android + ios.
- `flutter analyze lib test`: clean for android + ios + platform_interface.

`linux`/`macos`/`windows` use the external VeryGood reusable workflow (run tests + coverage) and have no pigeon dependency; the version bump is low-risk there but is validated by this PR's own CI run.