### PR TITLE
fix(android): keep ringtone for a still-ringing call when another ends (WT-1073)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -271,6 +271,7 @@ class StandaloneCallService : Service() {
         Log.i(TAG, "handleIncomingCall: callId=${metadata.callId}")
         promoteToForeground()
         callMetadataMap[metadata.callId] = metadata
+        ringingIncomingCallIds.add(metadata.callId)
         answeredCallIds.remove(metadata.callId)
         if (answeredCallIds.isNotEmpty()) {
             Log.d(TAG, "handleIncomingCall: active call detected — playing call-waiting tone for callId=${metadata.callId}")
@@ -330,6 +331,7 @@ class StandaloneCallService : Service() {
 
         activateAudio()
         fireInitialAudioState(metadata.callId)
+        promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
     }
@@ -345,8 +347,22 @@ class StandaloneCallService : Service() {
 
         activateAudio()
         fireInitialAudioState(metadata.callId)
+        promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
+    }
+
+    /**
+     * After [answeredCallId] is answered the loud ringtone is stopped, but a second incoming call
+     * may still be ringing. Start the quiet call-waiting tone for it so it is not silently dropped,
+     * matching the start-path branch in [handleIncomingCall] that plays the call-waiting tone when
+     * a call is already active.
+     */
+    private fun promoteRemainingRingingToCallWaitingTone(answeredCallId: String) {
+        if (hasOtherRingingCall(ringingIncomingCallIds, answeredCallIds, answeredCallId)) {
+            Log.d(TAG, "promoteRemainingRingingToCallWaitingTone: another call still ringing")
+            ringtoneManager.startCallWaitingTone()
+        }
     }
 
     private fun handleDeclineCall(metadata: CallMetadata) {
@@ -370,9 +386,13 @@ class StandaloneCallService : Service() {
      * disconnect of one call silences every other call too. When a first incoming call times out
      * or is declined while a second incoming call is still ringing, the second call must keep
      * sounding, so the tones are left running until the last ringing call ends.
+     *
+     * Only incoming calls that have not been answered count as ringing: [ringingIncomingCallIds]
+     * excludes outgoing/dialing calls (which never play the ringtone) and [answeredCallIds]
+     * excludes calls that are already active.
      */
     private fun stopRingtoneUnlessOtherCallRinging(terminatingCallId: String) {
-        if (hasOtherRingingCall(callMetadataMap.keys, answeredCallIds, terminatingCallId)) {
+        if (hasOtherRingingCall(ringingIncomingCallIds, answeredCallIds, terminatingCallId)) {
             Log.d(TAG, "stopRingtoneUnlessOtherCallRinging: keeping tone, another call still ringing")
             return
         }
@@ -416,6 +436,7 @@ class StandaloneCallService : Service() {
             core.notifyConnectionEvent(CallLifecycleEvent.HungUp, meta.toBundle())
         }
         callMetadataMap.clear()
+        ringingIncomingCallIds.clear()
         answeredCallIds.clear()
         pendingAnswers.clear()
         deactivateAudio(force = true)
@@ -426,9 +447,11 @@ class StandaloneCallService : Service() {
     private fun handleCleanConnections() {
         Log.i(TAG, "handleCleanConnections: clearing state")
         callMetadataMap.clear()
+        ringingIncomingCallIds.clear()
         answeredCallIds.clear()
         pendingAnswers.clear()
         deactivateAudio(force = true)
+        ringtoneManager.stopRingtone()
         ringtoneManager.stopCallWaitingTone()
     }
 
@@ -543,6 +566,7 @@ class StandaloneCallService : Service() {
 
     private fun endCall(metadata: CallMetadata) {
         callMetadataMap.remove(metadata.callId)
+        ringingIncomingCallIds.remove(metadata.callId)
         answeredCallIds.remove(metadata.callId)
         pendingAnswers.remove(metadata.callId)
         if (callMetadataMap.isEmpty()) {
@@ -569,19 +593,25 @@ class StandaloneCallService : Service() {
         // Written on the main thread (onStartCommand); read from static dispatch methods
         // called on the main process thread, hence ConcurrentHashMap.
         internal val callMetadataMap: ConcurrentHashMap<String, CallMetadata> = ConcurrentHashMap()
+
+        // Incoming calls currently registered as ringing (added in handleIncomingCall, removed in
+        // endCall / cleared on teardown+clean). Distinct from callMetadataMap, which also holds
+        // outgoing/dialing calls that never play the ringtone, so the ringtone-stop guard must
+        // consult this set - not the full map - to decide whether another call is still ringing.
+        internal val ringingIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
         internal val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
         internal val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
         /**
          * `true` when a call other than [excludingCallId] is still ringing, i.e. registered in
-         * [callIds] but not present in [answeredCallIds]. Pure helper so the ringtone-stop guard
-         * is unit-testable without instantiating the service.
+         * [ringingCallIds] but not present in [answeredCallIds]. Pure helper so the ringtone-stop
+         * guard is unit-testable without instantiating the service.
          */
         internal fun hasOtherRingingCall(
-            callIds: Set<String>,
+            ringingCallIds: Set<String>,
             answeredCallIds: Set<String>,
             excludingCallId: String,
-        ): Boolean = callIds.any { it != excludingCallId && it !in answeredCallIds }
+        ): Boolean = ringingCallIds.any { it != excludingCallId && it !in answeredCallIds }
 
         /**
          * Starts an incoming call in standalone mode.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -351,18 +351,33 @@ class StandaloneCallService : Service() {
 
     private fun handleDeclineCall(metadata: CallMetadata) {
         Log.i(TAG, "handleDeclineCall: callId=${metadata.callId}")
-        ringtoneManager.stopRingtone()
-        ringtoneManager.stopCallWaitingTone()
+        stopRingtoneUnlessOtherCallRinging(metadata.callId)
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
     }
 
     private fun handleHungUpCall(metadata: CallMetadata) {
         Log.i(TAG, "handleHungUpCall: callId=${metadata.callId}")
-        ringtoneManager.stopRingtone()
-        ringtoneManager.stopCallWaitingTone()
+        stopRingtoneUnlessOtherCallRinging(metadata.callId)
         endCall(metadata)
         core.notifyConnectionEvent(CallLifecycleEvent.HungUp, metadata.toBundle())
+    }
+
+    /**
+     * Stop the shared ringtone / call-waiting tone only when no OTHER call is still ringing.
+     *
+     * The ringtone is a single shared instance (see [CallkeepAudioManager]); stopping it on the
+     * disconnect of one call silences every other call too. When a first incoming call times out
+     * or is declined while a second incoming call is still ringing, the second call must keep
+     * sounding, so the tones are left running until the last ringing call ends.
+     */
+    private fun stopRingtoneUnlessOtherCallRinging(terminatingCallId: String) {
+        if (hasOtherRingingCall(callMetadataMap.keys, answeredCallIds, terminatingCallId)) {
+            Log.d(TAG, "stopRingtoneUnlessOtherCallRinging: keeping tone, another call still ringing")
+            return
+        }
+        ringtoneManager.stopRingtone()
+        ringtoneManager.stopCallWaitingTone()
     }
 
     private fun handleUpdateCall(metadata: CallMetadata) {
@@ -556,6 +571,17 @@ class StandaloneCallService : Service() {
         internal val callMetadataMap: ConcurrentHashMap<String, CallMetadata> = ConcurrentHashMap()
         internal val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
         internal val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+        /**
+         * `true` when a call other than [excludingCallId] is still ringing, i.e. registered in
+         * [callIds] but not present in [answeredCallIds]. Pure helper so the ringtone-stop guard
+         * is unit-testable without instantiating the service.
+         */
+        internal fun hasOtherRingingCall(
+            callIds: Set<String>,
+            answeredCallIds: Set<String>,
+            excludingCallId: String,
+        ): Boolean = callIds.any { it != excludingCallId && it !in answeredCallIds }
 
         /**
          * Starts an incoming call in standalone mode.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -594,10 +594,12 @@ class StandaloneCallService : Service() {
         // called on the main process thread, hence ConcurrentHashMap.
         internal val callMetadataMap: ConcurrentHashMap<String, CallMetadata> = ConcurrentHashMap()
 
-        // Incoming calls currently registered as ringing (added in handleIncomingCall, removed in
-        // endCall / cleared on teardown+clean). Distinct from callMetadataMap, which also holds
-        // outgoing/dialing calls that never play the ringtone, so the ringtone-stop guard must
-        // consult this set - not the full map - to decide whether another call is still ringing.
+        // Incoming call ids, from registration until the call ends (added in handleIncomingCall,
+        // removed in endCall / cleared on teardown+clean). It is NOT pruned when a call is answered,
+        // so it may contain answered calls; "still ringing" is therefore membership here AND absence
+        // from answeredCallIds (see hasOtherRingingCall). Distinct from callMetadataMap, which also
+        // holds outgoing/dialing calls that never play the ringtone - hence the ringtone-stop guard
+        // consults this set, not the full map, to decide whether another call is still ringing.
         internal val ringingIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
         internal val answeredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
         internal val pendingAnswers: MutableSet<String> = ConcurrentHashMap.newKeySet()

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallServiceRingtoneGuardTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallServiceRingtoneGuardTest.kt
@@ -1,0 +1,75 @@
+package com.webtrit.callkeep.services.services.connection
+
+import android.os.Build
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [StandaloneCallService.hasOtherRingingCall], the guard that keeps the shared
+ * ringtone playing for a still-ringing call when another incoming call ends (WT-1073).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class StandaloneCallServiceRingtoneGuardTest {
+    @Test
+    fun `keeps ringtone when a second incoming call is still ringing`() {
+        // A and C both ringing (none answered); A is ending.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                callIds = setOf("A", "C"),
+                answeredCallIds = emptySet(),
+                excludingCallId = "A",
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `stops ringtone when the last ringing call ends`() {
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                callIds = setOf("A"),
+                answeredCallIds = emptySet(),
+                excludingCallId = "A",
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `the only other call being answered does not count as ringing`() {
+        // A is ending; C is already answered (active) -> nothing else ringing.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                callIds = setOf("A", "C"),
+                answeredCallIds = setOf("C"),
+                excludingCallId = "A",
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `another ringing call counts even when one other call is answered`() {
+        // A is ending; B answered, C still ringing -> keep the tone.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                callIds = setOf("A", "B", "C"),
+                answeredCallIds = setOf("B"),
+                excludingCallId = "A",
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `no other call when only the terminating call is present`() {
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                callIds = setOf("A"),
+                answeredCallIds = setOf("A"),
+                excludingCallId = "A",
+            )
+        assertFalse(result)
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallServiceRingtoneGuardTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallServiceRingtoneGuardTest.kt
@@ -9,18 +9,22 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Unit tests for [StandaloneCallService.hasOtherRingingCall], the guard that keeps the shared
- * ringtone playing for a still-ringing call when another incoming call ends (WT-1073).
+ * Unit tests for [StandaloneCallService.hasOtherRingingCall], the single decision used both by the
+ * ringtone-stop guard (keep the shared ringtone for a still-ringing call when another call ends,
+ * WT-1073) and by the answer-path call-waiting promotion.
+ *
+ * The predicate is fed [StandaloneCallService.ringingIncomingCallIds] (NOT the full call map): an
+ * outgoing/dialing call is absent from that set, so it never keeps the ringtone alive.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 class StandaloneCallServiceRingtoneGuardTest {
     @Test
     fun `keeps ringtone when a second incoming call is still ringing`() {
-        // A and C both ringing (none answered); A is ending.
+        // A and C both ringing incoming (none answered); A is ending.
         val result =
             StandaloneCallService.hasOtherRingingCall(
-                callIds = setOf("A", "C"),
+                ringingCallIds = setOf("A", "C"),
                 answeredCallIds = emptySet(),
                 excludingCallId = "A",
             )
@@ -31,7 +35,7 @@ class StandaloneCallServiceRingtoneGuardTest {
     fun `stops ringtone when the last ringing call ends`() {
         val result =
             StandaloneCallService.hasOtherRingingCall(
-                callIds = setOf("A"),
+                ringingCallIds = setOf("A"),
                 answeredCallIds = emptySet(),
                 excludingCallId = "A",
             )
@@ -43,7 +47,7 @@ class StandaloneCallServiceRingtoneGuardTest {
         // A is ending; C is already answered (active) -> nothing else ringing.
         val result =
             StandaloneCallService.hasOtherRingingCall(
-                callIds = setOf("A", "C"),
+                ringingCallIds = setOf("A", "C"),
                 answeredCallIds = setOf("C"),
                 excludingCallId = "A",
             )
@@ -55,7 +59,7 @@ class StandaloneCallServiceRingtoneGuardTest {
         // A is ending; B answered, C still ringing -> keep the tone.
         val result =
             StandaloneCallService.hasOtherRingingCall(
-                callIds = setOf("A", "B", "C"),
+                ringingCallIds = setOf("A", "B", "C"),
                 answeredCallIds = setOf("B"),
                 excludingCallId = "A",
             )
@@ -66,7 +70,44 @@ class StandaloneCallServiceRingtoneGuardTest {
     fun `no other call when only the terminating call is present`() {
         val result =
             StandaloneCallService.hasOtherRingingCall(
-                callIds = setOf("A"),
+                ringingCallIds = setOf("A"),
+                answeredCallIds = setOf("A"),
+                excludingCallId = "A",
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `outgoing dialing call is not in the ringing set and does not keep the ringtone`() {
+        // Incoming A is declined while outgoing B is dialing. B is tracked in callMetadataMap but
+        // NOT in ringingIncomingCallIds, so the guard sees no other ringing call and stops the tone.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                ringingCallIds = setOf("A"),
+                answeredCallIds = emptySet(),
+                excludingCallId = "A",
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `answer-path promotion fires when another incoming call is still ringing`() {
+        // A just answered (added to answeredCallIds); C still ringing -> promote C to call-waiting.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                ringingCallIds = setOf("A", "C"),
+                answeredCallIds = setOf("A"),
+                excludingCallId = "A",
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `answer-path promotion does not fire when no other call is ringing`() {
+        // A answered, nothing else ringing -> no call-waiting tone.
+        val result =
+            StandaloneCallService.hasOtherRingingCall(
+                ringingCallIds = setOf("A"),
                 answeredCallIds = setOf("A"),
                 excludingCallId = "A",
             )


### PR DESCRIPTION
## Overview

In standalone mode (app killed / background isolate, calls served by push via
`StandaloneCallService`) a single shared `Ringtone` instance serves all calls.
`handleDeclineCall` / `handleHungUpCall` stopped it unconditionally, so when a
first incoming call timed out or was declined while a second incoming call was
still ringing, the shared ringtone was stopped and the second call went silent
(its UI stayed on screen). Fixes WT-1073.

## Change

- Add a pure `hasOtherRingingCall(callIds, answeredCallIds, excludingCallId)`
  predicate: a call still in `callMetadataMap` and not yet answered counts as
  ringing.
- Gate the ringtone / call-waiting tone stop in the decline and hangup paths on
  that predicate via `stopRingtoneUnlessOtherCallRinging(...)`: the tone is now
  stopped only when the last ringing call ends.
- This mirrors the start-path guard added in WT-1388 (call-waiting tone vs
  ringtone); WT-1073 was the missed symmetric stop half.

## Scope

- Standalone path only. The system Telecom / foreground path cannot currently
  produce two simultaneously ringing calls (AOSP `MAXIMUM_RINGING_CALLS = 1`
  rejects the second ring; see WT-1462), so the Telecom-side guard is deferred
  to that work. Promoting a waiting tone back to a ringtone when the active call
  ends is tracked under WT-1414.

## Tests

- New `StandaloneCallServiceRingtoneGuardTest` covering the predicate: another
  call still ringing -> keep tone; last ringing call ends -> stop; answered
  calls do not count as ringing.
- `./gradlew testDebugUnitTest` green.

## Manual verification

Reproduced beforehand on the standalone path (app killed): A rings, C rings ~15s
later, A times out -> previously C went silent; with this change C keeps ringing.
