### PR TITLE
fix(android): adopt ringing incoming call on Flutter delegate attach

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
@@ -46,7 +46,7 @@ enum class CallLifecycleEvent : ConnectionEvent {
     // this is NOT gated by the signaling-registered suppression: the new delegate has no record
     // of the call and must be seeded before it processes signaling events. Emitted by
     // PhoneConnectionService.handleReplayConnectionStates for connections in STATE_RINGING.
-    ReEmitIncomingCall,
+    ReplayIncomingCall,
     OutgoingFailure,
     IncomingFailure,
     ConnectionNotFound,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
@@ -40,6 +40,13 @@ enum class CallLifecycleEvent : ConnectionEvent {
     // from PhoneConnection.onStateChanged (Telecom) / StandaloneCallService transitions. Live states
     // only -- terminal DISCONNECTED stays on the cause-carrying HungUp/DeclineCall events.
     ConnectionStateChanged,
+
+    // Re-delivery of a still-ringing incoming call to a freshly-attached Flutter delegate
+    // (e.g. after a push->foreground isolate handoff or hot restart). Unlike DidPushIncomingCall,
+    // this is NOT gated by the signaling-registered suppression: the new delegate has no record
+    // of the call and must be seeded before it processes signaling events. Emitted by
+    // PhoneConnectionService.handleReplayConnectionStates for connections in STATE_RINGING.
+    ReEmitIncomingCall,
     OutgoingFailure,
     IncomingFailure,
     ConnectionNotFound,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
@@ -42,7 +42,7 @@ enum class CallLifecycleEvent : ConnectionEvent {
     ConnectionStateChanged,
 
     // Re-delivery of a still-ringing incoming call to a freshly-attached Flutter delegate
-    // (e.g. after a push->foreground isolate handoff or hot restart). Unlike DidPushIncomingCall,
+    // (e.g. after a push->foreground isolate handoff or hot restart). Unlike IncomingConnectionReported,
     // this is NOT gated by the signaling-registered suppression: the new delegate has no record
     // of the call and must be seeded before it processes signaling events. Emitted by
     // PhoneConnectionService.handleReplayConnectionStates for connections in STATE_RINGING.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -160,27 +160,6 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
-    /**
-     * Mark [callId] as having been reported by the host app via `reportNewIncomingCall`
-     * (the app/signaling path), as opposed to discovered by callkeep through the push/Telecom path.
-     *
-     * Purpose: de-duplicate the incoming-call notification to Flutter. When the app itself reported
-     * the call, Flutter already knows about it (`__onCallSignalingEventIncoming`). The
-     * `IncomingConnectionReported` broadcast that still arrives afterwards via the `:callkeep_core` IPC
-     * round-trip is then suppressed (see [consumeReportedIncoming]) so it does not add a second,
-     * push-path ActiveCall (line -1) alongside the existing app-path entry (line 0) for the same callId.
-     */
-    fun markReportedIncoming(callId: String)
-
-    /**
-     * Returns true and clears the mark if [callId] was app-reported (see [markReportedIncoming]).
-     *
-     * Consume-on-read: the guard fires at most once per call, so the first `IncomingConnectionReported`
-     * for an app-reported call is suppressed and any subsequent delivery (e.g. an explicit
-     * re-emit to a newly attached delegate) is no longer affected.
-     */
-    fun consumeReportedIncoming(callId: String): Boolean
-
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -111,20 +111,6 @@ interface ConnectionTracker {
      */
     fun markEndCallDispatched(callId: String): Boolean
 
-    /**
-     * Mark [callId] as having been reported by the host app via
-     * ForegroundService.reportNewIncomingCall. Suppresses the IncomingConnectionReported broadcast
-     * that follows via the :callkeep_core IPC round-trip, preventing a duplicate
-     * push-path ActiveCall entry in the app's call state.
-     */
-    fun markReportedIncoming(callId: String)
-
-    /**
-     * Returns true and removes the mark if [callId] was app-reported (see [markReportedIncoming]).
-     * Consuming on first read ensures the guard fires at most once per call.
-     */
-    fun consumeReportedIncoming(callId: String): Boolean
-
     // -------------------------------------------------------------------------
     // Read operations
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -347,7 +347,7 @@ class InProcessCallkeepCore internal constructor(
         internal val GLOBAL_LISTENER_EVENTS: List<ConnectionEvent> =
             listOf(
                 CallLifecycleEvent.IncomingConnectionReported,
-                CallLifecycleEvent.ReEmitIncomingCall,
+                CallLifecycleEvent.ReplayIncomingCall,
                 CallLifecycleEvent.ConnectionStateChanged,
                 CallLifecycleEvent.DeclineCall,
                 CallLifecycleEvent.HungUp,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -347,6 +347,7 @@ class InProcessCallkeepCore internal constructor(
         internal val GLOBAL_LISTENER_EVENTS: List<ConnectionEvent> =
             listOf(
                 CallLifecycleEvent.IncomingConnectionReported,
+                CallLifecycleEvent.ReEmitIncomingCall,
                 CallLifecycleEvent.ConnectionStateChanged,
                 CallLifecycleEvent.DeclineCall,
                 CallLifecycleEvent.HungUp,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -186,10 +186,6 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndCallDispatched(callId: String): Boolean = tracker.markEndCallDispatched(callId)
 
-    override fun markReportedIncoming(callId: String) = tracker.markReportedIncoming(callId)
-
-    override fun consumeReportedIncoming(callId: String): Boolean = tracker.consumeReportedIncoming(callId)
-
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -56,12 +56,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // performEndCall for a Telecom-terminated call. Prevents duplicate performEndCall.
     private val endCallDispatchedCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
-    // callIds successfully registered via ForegroundService.reportNewIncomingCall
-    // (foreground signaling path). Suppresses the IncomingConnectionReported broadcast that
-    // follows via the :callkeep_core IPC round-trip, preventing a duplicate push-path
-    // ActiveCall entry alongside the signaling-path entry.
-    private val reportedIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     // last known Pigeon connection state per callId, kept for getConnections() queries
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
 
@@ -93,12 +87,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // reportedIncomingCallIds is intentionally NOT cleared here. addPending is called
-        // both by the initial registration site (before markReportedIncoming) and again
-        // inside InProcessCallkeepCore.startIncomingCall (after markReportedIncoming). Clearing
-        // it here would erase the guard on the second call and let IncomingConnectionReported through.
-        // The guard is cleared by consumeReportedIncoming (normal flow) or markTerminated
-        // (call-end cleanup, covers callId reuse).
         return pendingCallIds.add(callId)
     }
 
@@ -120,10 +108,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // reportedIncomingCallIds is intentionally NOT cleared here. promote() is called
-        // inside handleCSIncomingConnectionReported, immediately before consumeReportedIncoming
-        // checks the guard. Clearing it here would defeat the suppression and let
-        // didPushIncomingCall reach Flutter for signaling-path calls.
         connections[callId] = metadata
         pendingCallIds.remove(callId)
         connectionStates[callId] = state
@@ -189,7 +173,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         answeredCallIds.remove(callId)
         pendingCallIds.remove(callId)
         pendingAnswers.remove(callId)
-        reportedIncomingCallIds.remove(callId)
         connectionStates[callId] = PCallkeepConnectionState.STATE_DISCONNECTED
     }
 
@@ -314,7 +297,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         connectionStates.clear()
         directNotifiedCallIds.clear()
         endCallDispatchedCallIds.clear()
-        reportedIncomingCallIds.clear()
     }
 
     // -------------------------------------------------------------------------
@@ -328,12 +310,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     override fun consumeDirectNotified(callId: String): Boolean = directNotifiedCallIds.remove(callId)
 
     override fun markEndCallDispatched(callId: String): Boolean = endCallDispatchedCallIds.add(callId)
-
-    override fun markReportedIncoming(callId: String) {
-        reportedIncomingCallIds.add(callId)
-    }
-
-    override fun consumeReportedIncoming(callId: String): Boolean = reportedIncomingCallIds.remove(callId)
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -93,6 +93,14 @@ class PhoneConnection internal constructor(
     var hasAnswered: Boolean = false
         private set
 
+    /**
+     * The current call metadata backing this connection. Exposed so [PhoneConnectionService] can
+     * re-deliver a still-ringing incoming call (with its handle/displayName/video) to a freshly
+     * attached Flutter delegate — see [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReEmitIncomingCall].
+     */
+    val currentMetadata: CallMetadata
+        get() = metadata
+
     init {
         audioModeIsVoip = true
         connectionProperties = PROPERTY_SELF_MANAGED

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -96,7 +96,7 @@ class PhoneConnection internal constructor(
     /**
      * The current call metadata backing this connection. Exposed so [PhoneConnectionService] can
      * re-deliver a still-ringing incoming call (with its handle/displayName/video) to a freshly
-     * attached Flutter delegate — see [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReEmitIncomingCall].
+     * attached Flutter delegate — see [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReplayIncomingCall].
      */
     val currentMetadata: CallMetadata
         get() = metadata

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -484,10 +484,18 @@ class PhoneConnectionService : ConnectionService() {
     }
 
     private fun handleReplayConnectionStates() {
-        Log.i(TAG, "handleReplayConnectionStates: re-emitting lifecycle state for answered connections")
+        Log.i(TAG, "handleReplayConnectionStates: re-emitting lifecycle state for answered and ringing connections")
         connectionManager.getConnections().forEach { connection ->
             if (connection.hasAnswered) {
                 performEventHandle(CallLifecycleEvent.AnswerCall, CallMetadata(callId = connection.callId))
+            } else if (connection.state == android.telecom.Connection.STATE_RINGING) {
+                // A still-ringing incoming call whose owning Flutter delegate is freshly attached
+                // (push->foreground isolate handoff or hot restart). The delegate that originally
+                // received DidPushIncomingCall is gone, so the new one has no record of this call.
+                // Re-deliver the full metadata so the main process seeds its call state BEFORE it
+                // processes signaling events (handshake/hangup). Without this the call lives only as
+                // a native connection and an incoming hangup is dropped (no matching ActiveCall).
+                performEventHandle(CallLifecycleEvent.ReEmitIncomingCall, connection.currentMetadata)
             }
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -18,6 +18,7 @@ import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
 import com.webtrit.callkeep.common.TelephonyUtils
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.EmergencyNumberException
 import com.webtrit.callkeep.models.FailureMetadata
@@ -484,18 +485,33 @@ class PhoneConnectionService : ConnectionService() {
     }
 
     private fun handleReplayConnectionStates() {
-        Log.i(TAG, "handleReplayConnectionStates: re-emitting lifecycle state for answered and ringing connections")
+        Log.i(TAG, "handleReplayConnectionStates: re-emitting lifecycle + connection state for active connections")
         connectionManager.getConnections().forEach { connection ->
-            if (connection.hasAnswered) {
-                performEventHandle(CallLifecycleEvent.AnswerCall, CallMetadata(callId = connection.callId))
-            } else if (connection.state == android.telecom.Connection.STATE_RINGING) {
-                // A still-ringing incoming call whose owning Flutter delegate is freshly attached
-                // (push->foreground isolate handoff or hot restart). The delegate that originally
-                // received DidPushIncomingCall is gone, so the new one has no record of this call.
-                // Re-deliver the full metadata so the main process seeds its call state BEFORE it
-                // processes signaling events (handshake/hangup). Without this the call lives only as
-                // a native connection and an incoming hangup is dropped (no matching ActiveCall).
-                performEventHandle(CallLifecycleEvent.ReEmitIncomingCall, connection.currentMetadata)
+            // Mirror the live Telecom state back into the main-process shadow tracker. On a cold
+            // start the original onStateChanged fired before this process existed, so the state
+            // (e.g. ACTIVE for a call answered via the notification button) is restored only here --
+            // and reportNewIncomingCall's already-answered adoption reads getState() == STATE_ACTIVE.
+            // markAnswered() is a guard only since the state-mirror refactor, so AnswerCall below no
+            // longer repopulates connectionStates; this does. Live states only (DISCONNECTED stays
+            // on the cause-carrying termination events).
+            CallConnectionState
+                .fromTelecomState(connection.state)
+                ?.takeIf { it != CallConnectionState.DISCONNECTED }
+                ?.let { performEventHandle(CallLifecycleEvent.ConnectionStateChanged, connection.currentMetadata.copy(connectionState = it)) }
+
+            // Re-deliver the call-setup event so a freshly attached delegate adopts/shows the call.
+            when {
+                connection.hasAnswered ->
+                    performEventHandle(CallLifecycleEvent.AnswerCall, CallMetadata(callId = connection.callId))
+
+                connection.state == Connection.STATE_RINGING ->
+                    // A still-ringing incoming call whose owning Flutter delegate is freshly attached
+                    // (push->foreground isolate handoff or hot restart). The delegate that originally
+                    // received IncomingConnectionReported is gone, so the new one has no record of this call.
+                    // Re-deliver the full metadata so the main process seeds its call state BEFORE it
+                    // processes signaling events (handshake/hangup). Without this the call lives only
+                    // as a native connection and an incoming hangup is dropped (no matching ActiveCall).
+                    performEventHandle(CallLifecycleEvent.ReEmitIncomingCall, connection.currentMetadata)
             }
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -511,7 +511,7 @@ class PhoneConnectionService : ConnectionService() {
                     // Re-deliver the full metadata so the main process seeds its call state BEFORE it
                     // processes signaling events (handshake/hangup). Without this the call lives only
                     // as a native connection and an incoming hangup is dropped (no matching ActiveCall).
-                    performEventHandle(CallLifecycleEvent.ReEmitIncomingCall, connection.currentMetadata)
+                    performEventHandle(CallLifecycleEvent.ReplayIncomingCall, connection.currentMetadata)
             }
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1086,9 +1086,9 @@ class ForegroundService :
      *
      * Triggered by [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReEmitIncomingCall]
      * from [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.handleReplayConnectionStates]
-     * on delegate attach. Unlike [handleCSReportDidPushIncomingCall] this deliberately does NOT
+     * on delegate attach. Unlike [handleCSIncomingConnectionReported] this deliberately does NOT
      * consult the signaling-registered suppression: the call IS signaling-registered, but the
-     * delegate that received the original DidPushIncomingCall is gone (push->foreground isolate
+     * delegate that received the original IncomingConnectionReported is gone (push->foreground isolate
      * handoff or hot restart), so the new delegate must still be seeded. A duplicate is harmless --
      * the Flutter side deduplicates by callId (CallBloc._onCallPushEventIncoming) and enriches the
      * existing entry with the signaling offer when it arrives.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -140,8 +140,8 @@ class ForegroundService :
                 handleCSReportConnectionStateChanged(data)
             }
 
-            CallLifecycleEvent.ReEmitIncomingCall -> {
-                handleCSReEmitIncomingCall(data)
+            CallLifecycleEvent.ReplayIncomingCall -> {
+                handleCSReplayIncomingCall(data)
             }
 
             CallLifecycleEvent.DeclineCall -> {
@@ -1084,7 +1084,7 @@ class ForegroundService :
     /**
      * Re-deliver a still-ringing incoming call to the (freshly attached) Flutter delegate.
      *
-     * Triggered by [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReEmitIncomingCall]
+     * Triggered by [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReplayIncomingCall]
      * from [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.handleReplayConnectionStates]
      * on delegate attach. Unlike [handleCSIncomingConnectionReported] this deliberately does NOT
      * consult the signaling-registered suppression: the call IS signaling-registered, but the
@@ -1093,16 +1093,16 @@ class ForegroundService :
      * the Flutter side deduplicates by callId (CallBloc._onCallPushEventIncoming) and enriches the
      * existing entry with the signaling offer when it arrives.
      */
-    private fun handleCSReEmitIncomingCall(extras: Bundle?) {
-        logger.d("handleCSReEmitIncomingCall")
+    private fun handleCSReplayIncomingCall(extras: Bundle?) {
+        logger.d("handleCSReplayIncomingCall")
         extras?.let {
             val metadata = CallMetadata.fromBundle(it)
             val handle = metadata.handle
             if (handle == null) {
-                logger.w("handleCSReEmitIncomingCall: missing handle for callId=${metadata.callId}; skipping")
+                logger.w("handleCSReplayIncomingCall: missing handle for callId=${metadata.callId}; skipping")
                 return@let
             }
-            logger.i("handleCSReEmitIncomingCall: re-delivering ringing incoming callId=${metadata.callId} to delegate")
+            logger.i("handleCSReplayIncomingCall: re-delivering ringing incoming callId=${metadata.callId} to delegate")
             flutterDelegateApi?.didPushIncomingCall(
                 handleArg = handle.toPHandle(),
                 displayNameArg = metadata.displayName,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -140,6 +140,10 @@ class ForegroundService :
                 handleCSReportConnectionStateChanged(data)
             }
 
+            CallLifecycleEvent.ReEmitIncomingCall -> {
+                handleCSReEmitIncomingCall(data)
+            }
+
             CallLifecycleEvent.DeclineCall -> {
                 handleCSReportDeclineCall(data)
             }
@@ -1074,6 +1078,38 @@ class ForegroundService :
             if (state == CallConnectionState.DISCONNECTED) return@let
             logger.d("handleCSReportConnectionStateChanged: callId=${metadata.callId} state=$state")
             core.updateState(metadata.callId, state)
+        }
+    }
+
+    /**
+     * Re-deliver a still-ringing incoming call to the (freshly attached) Flutter delegate.
+     *
+     * Triggered by [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReEmitIncomingCall]
+     * from [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.handleReplayConnectionStates]
+     * on delegate attach. Unlike [handleCSReportDidPushIncomingCall] this deliberately does NOT
+     * consult the signaling-registered suppression: the call IS signaling-registered, but the
+     * delegate that received the original DidPushIncomingCall is gone (push->foreground isolate
+     * handoff or hot restart), so the new delegate must still be seeded. A duplicate is harmless --
+     * the Flutter side deduplicates by callId (CallBloc._onCallPushEventIncoming) and enriches the
+     * existing entry with the signaling offer when it arrives.
+     */
+    private fun handleCSReEmitIncomingCall(extras: Bundle?) {
+        logger.d("handleCSReEmitIncomingCall")
+        extras?.let {
+            val metadata = CallMetadata.fromBundle(it)
+            val handle = metadata.handle
+            if (handle == null) {
+                logger.w("handleCSReEmitIncomingCall: missing handle for callId=${metadata.callId}; skipping")
+                return@let
+            }
+            logger.i("handleCSReEmitIncomingCall: re-delivering ringing incoming callId=${metadata.callId} to delegate")
+            flutterDelegateApi?.didPushIncomingCall(
+                handleArg = handle.toPHandle(),
+                displayNameArg = metadata.displayName,
+                videoArg = metadata.hasVideo ?: false,
+                callIdArg = metadata.callId,
+                errorArg = null,
+            ) {}
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -498,7 +498,6 @@ class ForegroundService :
                 // this callback returns but before _CallPerformEvent.answered is processed.
                 core.promote(callId, metadata, PCallkeepConnectionState.STATE_ACTIVE)
                 core.markAnswered(callId)
-                core.markReportedIncoming(callId)
                 flutterDelegateApi?.performAnswerCall(callId) {}
                 logger.i("reportNewIncomingCall: adopted already-answered call callId=$callId, fired performAnswerCall")
             } else {
@@ -554,13 +553,6 @@ class ForegroundService :
                 null
             }
 
-        // Mark this callId as signaling-registered BEFORE calling startIncomingCall so
-        // that the IncomingConnectionReported broadcast (fired by :callkeep_core during the IPC
-        // round-trip) is suppressed even if it arrives before the onSuccess callback runs.
-        // Flutter learns about this call from __onCallSignalingEventIncoming, so the
-        // duplicate push-path didPushIncomingCall must not reach it.
-        core.markReportedIncoming(callId)
-
         // Note: core.startIncomingCall can throw synchronously (e.g. uninitialized
         // ContextHolder). The exception bypasses our onError handler and propagates to
         // Pigeon as channel-error. The 5 s timeoutRunnable above is our safety-net for
@@ -573,7 +565,6 @@ class ForegroundService :
             onSuccess = {
                 logger.d("reportNewIncomingCall: startIncomingCall success callId=$callId")
                 // pendingIncomingCallbacks and timeout are already registered above.
-                // markReportedIncoming was already called before startIncomingCall.
             },
             onError = { error ->
                 // Cancel timeout and clear maps only if this call owns the pending slot.
@@ -640,10 +631,9 @@ class ForegroundService :
 
                     else -> {
                         logger.e("reportNewIncomingCall: startIncomingCall failed callId=$callId, error=$error")
-                        // Roll back the signaling-registered guard. The pending entry has already
-                        // been drained by InProcessCallkeepCore.startIncomingCall before invoking
-                        // this onError callback, so no core.removePending(callId) is needed here.
-                        core.consumeReportedIncoming(callId)
+                        // The pending entry has already been drained by
+                        // InProcessCallkeepCore.startIncomingCall before invoking this onError
+                        // callback, so no core.removePending(callId) is needed here.
                         callback(Result.success(error))
                     }
                 }
@@ -671,7 +661,7 @@ class ForegroundService :
         // directNotifiedCallIds so the stale async HungUp broadcast is suppressed
         // in handleCSReportDeclineCall.
         // core.clear() at the end of tearDown handles all per-session state including
-        // callback guards (directNotified, endCallDispatched, reportedIncoming).
+        // callback guards (directNotified, endCallDispatched).
 
         // Step 1: Collect active call IDs from the core shadow state (promoted connections).
         val activeCallIds = core.getAll().map { it.callId }
@@ -1011,11 +1001,14 @@ class ForegroundService :
         logger.d("handleCSIncomingConnectionReported")
         extras?.let {
             val metadata = CallMetadata.fromBundle(it)
-            // The IncomingConnectionReported event is two concerns: register the connection in the
-            // main-process shadow state, then notify the Flutter delegate. They stay in this single
-            // handler (one cross-process broadcast) so registration is atomic with delivery.
+            // Register-only: record the connection in the main-process shadow state. The foreground
+            // delegate is deliberately NOT notified here. A foreground incoming always reaches the
+            // Flutter delegate by another route: its own signaling (__onCallSignalingEventIncoming)
+            // for calls that arrive while the app is running, or the ReplayIncomingCall replay on
+            // delegate attach for a push->foreground handoff (the connection existed before this
+            // process did). Background incoming is shown by IncomingCallService directly. So there is
+            // no live push-path delivery to make from this event.
             registerIncomingConnection(metadata)
-            deliverIncomingToDelegate(metadata)
         }
     }
 
@@ -1032,30 +1025,21 @@ class ForegroundService :
     }
 
     /**
-     * Notify the Flutter delegate of a reported incoming call via the public `didPushIncomingCall`
-     * callback. This is the only place the public push-incoming notification name is used; the
-     * cross-process event itself is [CallLifecycleEvent.IncomingConnectionReported].
+     * Notify the Flutter delegate of an incoming call via the public `didPushIncomingCall` callback.
+     * The single delivery point to the foreground delegate, used by the connection-state replay
+     * ([handleCSReplayIncomingCall]) to seed a freshly attached delegate. Delivery is unconditional:
+     * the Dart CallBloc deduplicates by callId, so re-delivering a call the app already knows about
+     * (e.g. from signaling) does not create a second ActiveCall.
      */
     private fun deliverIncomingToDelegate(metadata: CallMetadata) {
-        // If this call was registered via reportNewIncomingCall (the foreground signaling path),
-        // Flutter already knows about it through __onCallSignalingEventIncoming. Suppress
-        // didPushIncomingCall to prevent a duplicate push-path entry (line -1) from being added to
-        // state.activeCalls alongside the existing signaling entry (line 0). In the :callkeep_core
-        // separate-process architecture, this broadcast arrives AFTER the reportNewIncomingCall
-        // Pigeon response (IPC round-trip latency), so without this guard the push-path handler
-        // always runs after the signaling handler and creates a second ActiveCall for the same callId.
-        if (core.consumeReportedIncoming(metadata.callId)) {
-            logger.d("deliverIncomingToDelegate: suppressing didPushIncomingCall for app-reported call ${metadata.callId}")
-            return
-        }
-
         val handle = metadata.handle
         if (handle == null) {
             // Cannot build a PHandle without a number; skip rather than crash on a
-            // malformed/handle-less broadcast (the call is already promoted above).
+            // malformed/handle-less broadcast (the call is already promoted in the tracker).
             logger.w("deliverIncomingToDelegate: missing handle for callId=${metadata.callId}; skipping didPushIncomingCall")
             return
         }
+        logger.i("deliverIncomingToDelegate: delivering incoming callId=${metadata.callId} to delegate")
         flutterDelegateApi?.didPushIncomingCall(
             handleArg = handle.toPHandle(),
             displayNameArg = metadata.displayName,
@@ -1082,35 +1066,18 @@ class ForegroundService :
     }
 
     /**
-     * Re-deliver a still-ringing incoming call to the (freshly attached) Flutter delegate.
-     *
-     * Triggered by [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReplayIncomingCall]
-     * from [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.handleReplayConnectionStates]
-     * on delegate attach. Unlike [handleCSIncomingConnectionReported] this deliberately does NOT
-     * consult the signaling-registered suppression: the call IS signaling-registered, but the
-     * delegate that received the original IncomingConnectionReported is gone (push->foreground isolate
-     * handoff or hot restart), so the new delegate must still be seeded. A duplicate is harmless --
-     * the Flutter side deduplicates by callId (CallBloc._onCallPushEventIncoming) and enriches the
-     * existing entry with the signaling offer when it arrives.
+     * Deliver a still-ringing incoming call to the (freshly attached) Flutter delegate. This is the
+     * sole foreground delivery of an incoming call: triggered by
+     * [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.ReplayIncomingCall] from
+     * [com.webtrit.callkeep.services.services.connection.PhoneConnectionService.handleReplayConnectionStates]
+     * on delegate attach (e.g. a push->foreground isolate handoff or hot restart). The delegate that
+     * received the original report is gone, so the new one must be seeded. A duplicate is harmless --
+     * the Flutter CallBloc deduplicates by callId and enriches the existing entry with the signaling
+     * offer when it arrives.
      */
     private fun handleCSReplayIncomingCall(extras: Bundle?) {
         logger.d("handleCSReplayIncomingCall")
-        extras?.let {
-            val metadata = CallMetadata.fromBundle(it)
-            val handle = metadata.handle
-            if (handle == null) {
-                logger.w("handleCSReplayIncomingCall: missing handle for callId=${metadata.callId}; skipping")
-                return@let
-            }
-            logger.i("handleCSReplayIncomingCall: re-delivering ringing incoming callId=${metadata.callId} to delegate")
-            flutterDelegateApi?.didPushIncomingCall(
-                handleArg = handle.toPHandle(),
-                displayNameArg = metadata.displayName,
-                videoArg = metadata.hasVideo ?: false,
-                callIdArg = metadata.callId,
-                errorArg = null,
-            ) {}
-        }
+        extras?.let { deliverIncomingToDelegate(CallMetadata.fromBundle(it)) }
     }
 
     private fun handleCSReportDeclineCall(extras: Bundle?) {
@@ -1118,10 +1085,6 @@ class ForegroundService :
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
             val callId = callMetaData.callId
-
-            // consumeReportedIncoming cleans up any pending signaling guard for this
-            // callId (edge case: call terminates before IncomingConnectionReported arrives).
-            core.consumeReportedIncoming(callId)
 
             // Suppress stale async HungUp/Decline broadcasts for calls that were already
             // directly notified via performEndCall in tearDown(). Without this guard, the

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -559,20 +559,16 @@ class MainProcessConnectionTrackerTest {
         //   1. markAnswered()           <- ReplayConnectionStates (cold-start)
         //   2. promote(STATE_ACTIVE)    <- fix step 1
         //   3. markAnswered()           <- fix step 2 (re-mark after promote clears it)
-        //   4. markReportedIncoming()  <- fix step 3
         tracker.markAnswered("call-1") // cold-start
         assertTrue(tracker.isAnswered("call-1"))
 
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_ACTIVE) // fix 1
         tracker.markAnswered("call-1") // fix 2
-        tracker.markReportedIncoming("call-1") // fix 3
 
         assertTrue(tracker.exists("call-1"))
         assertTrue(tracker.isAnswered("call-1"))
         assertFalse(tracker.isPending("call-1"))
         assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
-        // IncomingConnectionReported broadcast must be suppressed after adoption
-        assertTrue(tracker.consumeReportedIncoming("call-1"))
     }
 
     @Test

--- a/webtrit_callkeep_android/docs/background-services.md
+++ b/webtrit_callkeep_android/docs/background-services.md
@@ -17,9 +17,7 @@ Flutter app is backgrounded or killed.
 
 ### Responsibility
 
-Spawned when an FCM push notification (or the dormant SMS trigger — not tested / not actively
-developed, see [incoming-call-handling.md](incoming-call-handling.md)) announces an incoming call.
-It:
+Spawned when an FCM push notification (or SMS trigger) announces an incoming call. It:
 
 1. Starts a short-lived Flutter background isolate.
 2. Shows the incoming-call notification / system UI.
@@ -29,9 +27,9 @@ It:
 ### Lifecycle
 
 - Started via:
-    - `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall()` (from Dart or a
+  - `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall()` (from Dart or a
       background message handler).
-    - `NotificationManager.showIncomingCallNotification()` (from FCM handler code).
+  - `NotificationManager.showIncomingCallNotification()` (from FCM handler code).
 - `onCreate()` — calls `startForeground()` with a placeholder notification immediately to avoid
   Android's 10-second ANR window for foreground service start; subscribes to `CallkeepCore`
   events via `CallkeepCore.instance.addConnectionEventListener(this)`.

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -30,11 +30,12 @@ Triggered by an FCM message or a direct Dart call to `reportNewIncomingCall`.
         |   broadcast: IncomingConnectionReported
         v
 7.  ForegroundService.connectionServicePerformReceiver
-        |   CallkeepCore.promote(callId, meta, state)
-        |
-        |   PDelegateFlutterApi.performIncomingCall(callId, meta)
+        |   CallkeepCore.promote(callId, meta, state)   (register-only)
         v
-8.  Dart delegate receives performIncomingCall()
+8.  Delegate notification (NOT from the event above):
+        |   - call arrived while app running -> Flutter signaling __onCallSignalingEventIncoming
+        |   - push->foreground handoff -> ReplayIncomingCall on delegate attach
+        |     -> PDelegateFlutterApi.didPushIncomingCall(callId, meta)
 ```
 
 **Answer path (user taps answer in notification or UI):**

--- a/webtrit_callkeep_android/docs/connection-tracker.md
+++ b/webtrit_callkeep_android/docs/connection-tracker.md
@@ -28,13 +28,17 @@ State is updated exclusively from broadcast events emitted by `PhoneConnectionSe
 
 ## Callback Guards
 
-Three additional sets prevent duplicate Dart notifications for the same call:
+These sets prevent duplicate Dart notifications for the same call:
 
-| Guard                        | Purpose                                                                                                                                                                  |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `directNotifiedCallIds`      | Calls notified directly during `tearDown()`. Suppresses a subsequent `HungUp` broadcast for the same call.                                                               |
-| `endCallDispatchedCallIds`   | Calls for which `performEndCall()` has already been sent to Dart. Prevents a second dispatch.                                                                            |
-| `signalingRegisteredCallIds` | Calls for which `reportNewIncomingCall()` succeeded. Suppresses the corresponding `IncomingConnectionReported` broadcast (which would result in a duplicate Dart notification). |
+| Guard                        | Purpose                                                                                                    |
+|------------------------------|------------------------------------------------------------------------------------------------------------|
+| `directNotifiedCallIds`      | Calls notified directly during `tearDown()`. Suppresses a subsequent `HungUp` broadcast for the same call. |
+| `endCallDispatchedCallIds`   | Calls for which `performEndCall()` has already been sent to Dart. Prevents a second dispatch.              |
+
+(The `IncomingConnectionReported` event is register-only and does not notify the Flutter delegate,
+so no app-reported suppression guard is needed. The foreground delegate is notified of an incoming
+call by its own signaling, or by `ReplayIncomingCall` on delegate attach; the Dart `CallBloc`
+deduplicates by callId.)
 
 ## State Transitions
 

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -93,7 +93,8 @@ registered `ConnectionEventListener`. `ForegroundService` does not register its 
 
 | Event                 | Handler                               | Main Action                                                              |
 |-----------------------|---------------------------------------|--------------------------------------------------------------------------|
-| `IncomingConnectionReported`    | `handleCSIncomingConnectionReported()`    | `registerIncomingConnection()` (promote + wakelock + resolve pending Pigeon callback) then `deliverIncomingToDelegate()` (`didPushIncomingCall`) |
+| `IncomingConnectionReported` | `handleCSIncomingConnectionReported()` | Register the call in the tracker (promote + wakelock + resolve pending callback). Register-only -- no delegate notification |
+| `ReplayIncomingCall`     | `handleCSReplayIncomingCall()`        | Deliver the incoming call to a freshly attached delegate via `didPushIncomingCall` (sole foreground delivery) |
 | `ConnectionStateChanged` | `handleCSReportConnectionStateChanged()` | `updateState()` -- mirror the authoritative connection state into the tracker |
 | `AnswerCall`             | `handleCSReportAnswerCall()`             | `markAnswered()` guard in tracker, call `performAnswerCall()` on Dart delegate |
 | `DeclineCall`         | `handleCSReportDeclineCall()`         | `markTerminated()`, call `performEndCall()`                              |

--- a/webtrit_callkeep_android/docs/incoming-call-handling.md
+++ b/webtrit_callkeep_android/docs/incoming-call-handling.md
@@ -14,8 +14,7 @@ Color: blue = callkeep, orange = host app, grey = external (Telecom / system UI)
 
 ## Who owns the background work
 
-After a call is reported and `IncomingCallService` starts,
-`IncomingCallHandler.maybeInitBackgroundHandling`
+After a call is reported and `IncomingCallService` starts, `IncomingCallHandler.maybeInitBackgroundHandling`
 decides whether callkeep spawns its own background isolate:
 
 ```mermaid
@@ -66,37 +65,3 @@ sequenceDiagram
         PCS->>SYS: dismiss incoming UI
     end
 ```
-
-## Delivery to the Flutter delegate
-
-Surfacing the incoming call in a Flutter delegate (`didPushIncomingCall`) happens through different
-channels depending on where the call materialises and which engine is attached. There are two
-`ConnectionEventListener`s: `ForegroundService` (main process, **bound to the Activity** — the
-foreground delegate) and `IncomingCallService` (background isolate); see
-[foreground-service.md](foreground-service.md) and [background-services.md](background-services.md).
-
-| Context                                                               | How the delegate learns of the incoming call                                                                                                      | Live `IncomingConnectionReported` -> `didPushIncomingCall`                                                                                       |
-|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| Foreground signaling (`reportNewIncomingCall`)                        | The app's own signaling creates the call in Dart (`__onCallSignalingEventIncoming`)                                                               | **suppressed** — `reportNewIncomingCall` set the `reportedIncoming` guard, so the broadcast is not re-delivered (would duplicate the ActiveCall) |
-| Push -> foreground handoff (call exists before the Activity comes up) | `onDelegateSet` -> `replayConnectionStates` -> `ReplayIncomingCall` -> `didPushIncomingCall` re-delivers on attach                                | not the delivery — it fired before `ForegroundService` was alive                                                                                 |
-| Background, app dead                                                  | `IncomingCallService` shows the call directly via `IncomingCallHandler` on its own isolate delegate; its event listener only acts on `AnswerCall` | not used by `IncomingCallService`                                                                                                                |
-| SMS trigger (`IncomingCallSmsTriggerReceiver` -> `startIncomingCall`) | No signaling and the delegate is already attached (Activity up), so the live `didPushIncomingCall` is the only delivery                           | the delivery — but the SMS path is dormant (see below)                                                                                           |
-
-**Invariant.** `ForegroundService` is the foreground `ConnectionEventListener` and is bound to the
-Activity lifecycle (`bindForegroundService` on attach, `unbind + stop` on detach). Its live
-`IncomingConnectionReported` -> `didPushIncomingCall` delivery is therefore **foreground-only**.
-With the SMS trigger not in use, every real foreground incoming reaches the delegate via either its
-own signaling (live delivery suppressed) or the `onDelegateSet` replay (handoff) — so the live
-delivery has **no remaining live consumer**; it is kept only as the contract for the dormant SMS
-path. Background incoming is delivered by `IncomingCallService` directly, not by this event. The
-`IncomingConnectionReported` event itself is still load-bearing for its **registration** side
-(promote into the shadow tracker + resolve the pending `reportNewIncomingCall` Pigeon callback),
-which is independent of the delegate delivery.
-
-## SMS-triggered incoming (dormant / likely deprecated)
-
-The SMS-based incoming-call trigger (`IncomingCallSmsTriggerReceiver` +
-`SmsReceptionConfigBootstrapApi.initializeSmsReception`, message prefix `<#> WEBTRIT:`) is
-**currently not tested and not actively developed — treat it as dormant / likely deprecated**. It
-is the only path that relies on the live `IncomingConnectionReported` -> `didPushIncomingCall`
-delivery while the app is foreground. Do not assume it is exercised; verify before depending on it.

--- a/webtrit_callkeep_android/docs/ipc-broadcasting.md
+++ b/webtrit_callkeep_android/docs/ipc-broadcasting.md
@@ -22,7 +22,8 @@ The event type is carried as a string extra inside the intent.
 
 | Event                 | Payload                         | Meaning                                          |
 |-----------------------|---------------------------------|--------------------------------------------------|
-| `IncomingConnectionReported`    | `callId`, `CallMetadata` bundle              | Incoming `PhoneConnection` created, UI shown               |
+| `IncomingConnectionReported`    | `callId`, `CallMetadata` bundle              | Incoming `PhoneConnection` created -> register in the shadow state (register-only; the delegate is notified via signaling or `ReplayIncomingCall`) |
+| `ReplayIncomingCall`     | `callId`, `CallMetadata` bundle              | Re-deliver a still-ringing incoming call to a freshly attached delegate (sole foreground delivery; from the connection-state replay on delegate attach) |
 | `AnswerCall`             | `callId`                                     | Answer signal (guard); the ACTIVE state arrives separately via `ConnectionStateChanged` |
 | `ConnectionStateChanged` | `callId`, `CallMetadata` bundle (carries `connectionState`) | Authoritative live connection state to mirror into the shadow state (RINGING/DIALING/ACTIVE/HOLDING). Terminal DISCONNECTED is NOT sent here -- it stays on the cause-carrying `HungUp`/`DeclineCall`. |
 | `DeclineCall`            | `callId`                                     | User rejected the call                                     |

--- a/webtrit_callkeep_android/docs/pigeon-apis.md
+++ b/webtrit_callkeep_android/docs/pigeon-apis.md
@@ -121,8 +121,6 @@ Implemented by: `BackgroundPushNotificationIsolateBootstrapApi`
 ### `SmsReceptionConfigBootstrapApi`
 
 Configures the optional SMS-based incoming call trigger (`IncomingCallSmsTriggerReceiver`).
-**Dormant / likely deprecated**: not tested and not actively developed; see
-[incoming-call-handling.md](incoming-call-handling.md) (SMS-triggered incoming).
 
 ---
 

--- a/webtrit_callkeep_android/docs/plugin.md
+++ b/webtrit_callkeep_android/docs/plugin.md
@@ -21,8 +21,7 @@ Called once when the Flutter engine attaches:
   storage so services can access them without a Flutter engine).
 - Registers bootstrap APIs for background isolates:
   - `BackgroundPushNotificationIsolateBootstrapApi` (push-triggered incoming call service)
-  - `SmsReceptionConfigBootstrapApi` (optional SMS fallback — dormant / likely deprecated, see
-    [incoming-call-handling.md](incoming-call-handling.md))
+  - `SmsReceptionConfigBootstrapApi` (optional SMS fallback)
 - Registers `PHostDiagnosticsApi`, `PHostPermissionsApi`, `PHostActivityControlApi`,
   `PHostConnectionsApi`, `PHostSoundApi`.
 


### PR DESCRIPTION
## Overview

Fixes a push->foreground handoff race where an incoming call the caller cancels "right at connection" is mishandled by the freshly-attached Flutter delegate: the user either keeps hearing the native ringtone with no UI, or sees a **ghost incoming** that never clears after the caller hung up.

### Root cause
The whole call stack relies on one invariant: *the live incoming call is present in CallBloc state before any signaling event is processed* (the `incomingFromPush` fast-path, the HandshakeProcessor `!activeCallIds.contains` guard, the normal hangup handler all assume it). During a push->foreground isolate handoff that invariant breaks:

- the call exists only as a native `STATE_RINGING` connection (kept alive across the handoff);
- the `DidPushIncomingCall` that would seed CallBloc was delivered to the now-disposed push isolate, or suppressed for the signaling-registered call;
- so the new Activity CallBloc never learns about it. An incoming `487` hangup then finds **no `ActiveCall`** and is dropped (`__onMutationSignalingHangup` returns on `call == null`). The native ringtone is orphaned; and if the (stalled, ~4 s) handshake later creates the call, it resurrects an already-cancelled call -> ghost incoming.

Confirmed across three device logs (sound-only variant, sound+UI ghost variant, and a control where cancelling *after* the call entered state works cleanly).

### Fix
callkeep already re-delivers state to a freshly-attached Flutter delegate via `ForegroundService.onDelegateSet -> PhoneConnectionService.handleSyncConnectionState`, but only for **answered** connections (`AnswerCall`). This extends it to also re-deliver **STATE_RINGING** incoming connections, via a new `ReEmitIncomingCall` lifecycle event routed straight to `didPushIncomingCall` — deliberately bypassing the signaling-registered suppression, because the new delegate has no record of the call.

This reuses the existing Flutter push-seed path end to end (deduplicated by callId in `CallBloc._onCallPushEventIncoming`), so the call enters state before signaling events: the hangup is handled normally and the handshake no longer resurrects it. No Dart changes.

Additive only (new enum value + handler); the existing `DidPushIncomingCall` suppression path and its tests are untouched.

### Changes
- `ConnectionServicePerformBroadcaster`: new `CallLifecycleEvent.ReEmitIncomingCall`.
- `InProcessCallkeepCore`: register it in `GLOBAL_LISTENER_EVENTS`.
- `PhoneConnection`: expose `currentMetadata`.
- `PhoneConnectionService.handleSyncConnectionState`: re-emit `ReEmitIncomingCall` for `STATE_RINGING` connections.
- `ForegroundService`: handle it -> `didPushIncomingCall` (no suppression).

### Verification
- `./gradlew testDebugUnitTest` green; `flutter analyze` + `flutter test` (pre-push) green.
- NOT yet device-verified -> opened as **draft**. Manual repro to confirm: tap incoming-call push, wait for signaling to attach, cancel from the caller at that moment; expect the call to clear (no orphaned ringtone, no ghost incoming).

### Follow-ups
- Add a native unit test for the ringing re-emit branch in `handleSyncConnectionState`.
- Confirm iOS parity / that the scenario does not reproduce on iOS (CallKit presents natively); this fix is Android-only.