### PR TITLE
refactor(android): rename signaling-registered guard to reported-incoming

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_stress_test.dart
@@ -716,7 +716,7 @@ void main() {
   // (line 0 / incomingFromOffer), showing two identical ringing entries in the UI.
   //
   // Fix: ForegroundService.reportNewIncomingCall adds the callId to
-  // signalingRegisteredCallIds; handleCSReportDidPushIncomingCall suppresses
+  // reportedIncomingCallIds; handleCSReportDidPushIncomingCall suppresses
   // didPushIncomingCall for those callIds.
   // -------------------------------------------------------------------------
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -152,9 +152,9 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
-    fun markSignalingRegistered(callId: String)
+    fun markReportedIncoming(callId: String)
 
-    fun consumeSignalingRegistered(callId: String): Boolean
+    fun consumeReportedIncoming(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -101,18 +101,18 @@ interface ConnectionTracker {
     fun markEndCallDispatched(callId: String): Boolean
 
     /**
-     * Mark [callId] as registered via ForegroundService.reportNewIncomingCall
-     * (the foreground signaling path). Suppresses the DidPushIncomingCall broadcast
+     * Mark [callId] as having been reported by the host app via
+     * ForegroundService.reportNewIncomingCall. Suppresses the DidPushIncomingCall broadcast
      * that follows via the :callkeep_core IPC round-trip, preventing a duplicate
      * push-path ActiveCall entry in the app's call state.
      */
-    fun markSignalingRegistered(callId: String)
+    fun markReportedIncoming(callId: String)
 
     /**
-     * Returns true and removes the mark if [callId] was signaling-registered.
+     * Returns true and removes the mark if [callId] was app-reported (see [markReportedIncoming]).
      * Consuming on first read ensures the guard fires at most once per call.
      */
-    fun consumeSignalingRegistered(callId: String): Boolean
+    fun consumeReportedIncoming(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Read operations

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -185,9 +185,9 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndCallDispatched(callId: String): Boolean = tracker.markEndCallDispatched(callId)
 
-    override fun markSignalingRegistered(callId: String) = tracker.markSignalingRegistered(callId)
+    override fun markReportedIncoming(callId: String) = tracker.markReportedIncoming(callId)
 
-    override fun consumeSignalingRegistered(callId: String): Boolean = tracker.consumeSignalingRegistered(callId)
+    override fun consumeReportedIncoming(callId: String): Boolean = tracker.consumeReportedIncoming(callId)
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -59,7 +59,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // (foreground signaling path). Suppresses the DidPushIncomingCall broadcast that
     // follows via the :callkeep_core IPC round-trip, preventing a duplicate push-path
     // ActiveCall entry alongside the signaling-path entry.
-    private val signalingRegisteredCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    private val reportedIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // last known Pigeon connection state per callId, kept for getConnections() queries
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
@@ -92,11 +92,11 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // signalingRegisteredCallIds is intentionally NOT cleared here. addPending is called
-        // both by the initial registration site (before markSignalingRegistered) and again
-        // inside InProcessCallkeepCore.startIncomingCall (after markSignalingRegistered). Clearing
+        // reportedIncomingCallIds is intentionally NOT cleared here. addPending is called
+        // both by the initial registration site (before markReportedIncoming) and again
+        // inside InProcessCallkeepCore.startIncomingCall (after markReportedIncoming). Clearing
         // it here would erase the guard on the second call and let DidPushIncomingCall through.
-        // The guard is cleared by consumeSignalingRegistered (normal flow) or markTerminated
+        // The guard is cleared by consumeReportedIncoming (normal flow) or markTerminated
         // (call-end cleanup, covers callId reuse).
         return pendingCallIds.add(callId)
     }
@@ -119,8 +119,8 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // signalingRegisteredCallIds is intentionally NOT cleared here. promote() is called
-        // inside handleCSReportDidPushIncomingCall, immediately before consumeSignalingRegistered
+        // reportedIncomingCallIds is intentionally NOT cleared here. promote() is called
+        // inside handleCSReportDidPushIncomingCall, immediately before consumeReportedIncoming
         // checks the guard. Clearing it here would defeat the suppression and let
         // didPushIncomingCall reach Flutter for signaling-path calls.
         connections[callId] = metadata
@@ -170,7 +170,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         answeredCallIds.remove(callId)
         pendingCallIds.remove(callId)
         pendingAnswers.remove(callId)
-        signalingRegisteredCallIds.remove(callId)
+        reportedIncomingCallIds.remove(callId)
         connectionStates[callId] = PCallkeepConnectionState.STATE_DISCONNECTED
     }
 
@@ -295,7 +295,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         connectionStates.clear()
         directNotifiedCallIds.clear()
         endCallDispatchedCallIds.clear()
-        signalingRegisteredCallIds.clear()
+        reportedIncomingCallIds.clear()
     }
 
     // -------------------------------------------------------------------------
@@ -310,11 +310,11 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
 
     override fun markEndCallDispatched(callId: String): Boolean = endCallDispatchedCallIds.add(callId)
 
-    override fun markSignalingRegistered(callId: String) {
-        signalingRegisteredCallIds.add(callId)
+    override fun markReportedIncoming(callId: String) {
+        reportedIncomingCallIds.add(callId)
     }
 
-    override fun consumeSignalingRegistered(callId: String): Boolean = signalingRegisteredCallIds.remove(callId)
+    override fun consumeReportedIncoming(callId: String): Boolean = reportedIncomingCallIds.remove(callId)
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -492,7 +492,7 @@ class ForegroundService :
                 // this callback returns but before _CallPerformEvent.answered is processed.
                 core.promote(callId, metadata, PCallkeepConnectionState.STATE_ACTIVE)
                 core.markAnswered(callId)
-                core.markSignalingRegistered(callId)
+                core.markReportedIncoming(callId)
                 flutterDelegateApi?.performAnswerCall(callId) {}
                 logger.i("reportNewIncomingCall: adopted already-answered call callId=$callId, fired performAnswerCall")
             } else {
@@ -553,7 +553,7 @@ class ForegroundService :
         // round-trip) is suppressed even if it arrives before the onSuccess callback runs.
         // Flutter learns about this call from __onCallSignalingEventIncoming, so the
         // duplicate push-path didPushIncomingCall must not reach it.
-        core.markSignalingRegistered(callId)
+        core.markReportedIncoming(callId)
 
         // Note: core.startIncomingCall can throw synchronously (e.g. uninitialized
         // ContextHolder). The exception bypasses our onError handler and propagates to
@@ -567,7 +567,7 @@ class ForegroundService :
             onSuccess = {
                 logger.d("reportNewIncomingCall: startIncomingCall success callId=$callId")
                 // pendingIncomingCallbacks and timeout are already registered above.
-                // markSignalingRegistered was already called before startIncomingCall.
+                // markReportedIncoming was already called before startIncomingCall.
             },
             onError = { error ->
                 // Cancel timeout and clear maps only if this call owns the pending slot.
@@ -636,7 +636,7 @@ class ForegroundService :
                         // Roll back the signaling-registered guard. The pending entry has already
                         // been drained by InProcessCallkeepCore.startIncomingCall before invoking
                         // this onError callback, so no core.removePending(callId) is needed here.
-                        core.consumeSignalingRegistered(callId)
+                        core.consumeReportedIncoming(callId)
                         callback(Result.success(error))
                     }
                 }
@@ -664,7 +664,7 @@ class ForegroundService :
         // directNotifiedCallIds so the stale async HungUp broadcast is suppressed
         // in handleCSReportDeclineCall.
         // core.clear() at the end of tearDown handles all per-session state including
-        // callback guards (directNotified, endCallDispatched, signalingRegistered).
+        // callback guards (directNotified, endCallDispatched, reportedIncoming).
 
         // Step 1: Collect active call IDs from the core shadow state (promoted connections).
         val activeCallIds = core.getAll().map { it.callId }
@@ -1021,9 +1021,9 @@ class ForegroundService :
             // arrives AFTER the reportNewIncomingCall Pigeon response (IPC round-trip latency),
             // so without this guard the push-path handler always runs after the signaling
             // handler and creates a second ActiveCall for the same callId.
-            if (core.consumeSignalingRegistered(metadata.callId)) {
+            if (core.consumeReportedIncoming(metadata.callId)) {
                 logger.d(
-                    "handleCSReportDidPushIncomingCall: suppressing didPushIncomingCall for signaling-registered call ${metadata.callId}",
+                    "handleCSReportDidPushIncomingCall: suppressing didPushIncomingCall for app-reported call ${metadata.callId}",
                 )
                 return@let
             }
@@ -1051,9 +1051,9 @@ class ForegroundService :
             val callMetaData = CallMetadata.fromBundle(it)
             val callId = callMetaData.callId
 
-            // consumeSignalingRegistered cleans up any pending signaling guard for this
+            // consumeReportedIncoming cleans up any pending signaling guard for this
             // callId (edge case: call terminates before DidPushIncomingCall arrives).
-            core.consumeSignalingRegistered(callId)
+            core.consumeReportedIncoming(callId)
 
             // Suppress stale async HungUp/Decline broadcasts for calls that were already
             // directly notified via performEndCall in tearDown(). Without this guard, the

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -534,20 +534,20 @@ class MainProcessConnectionTrackerTest {
         //   1. markAnswered()           <- SyncConnectionState (cold-start)
         //   2. promote(STATE_ACTIVE)    <- fix step 1
         //   3. markAnswered()           <- fix step 2 (re-mark after promote clears it)
-        //   4. markSignalingRegistered()  <- fix step 3
+        //   4. markReportedIncoming()  <- fix step 3
         tracker.markAnswered("call-1") // cold-start
         assertTrue(tracker.isAnswered("call-1"))
 
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_ACTIVE) // fix 1
         tracker.markAnswered("call-1") // fix 2
-        tracker.markSignalingRegistered("call-1") // fix 3
+        tracker.markReportedIncoming("call-1") // fix 3
 
         assertTrue(tracker.exists("call-1"))
         assertTrue(tracker.isAnswered("call-1"))
         assertFalse(tracker.isPending("call-1"))
         assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
         // DidPushIncomingCall broadcast must be suppressed after adoption
-        assertTrue(tracker.consumeSignalingRegistered("call-1"))
+        assertTrue(tracker.consumeReportedIncoming("call-1"))
     }
 
     @Test


### PR DESCRIPTION
## Overview

Pure rename, no behavior change. `callkeep` is a generic ConnectionService/CallKit plugin and has no concept of "signaling" — that belongs to the host app. The guard that suppresses a duplicate push-path `didPushIncomingCall` actually means *"this incoming call was reported by the host via `reportNewIncomingCall`"* (as opposed to discovered via the push/Telecom path). The old `signaling*` naming leaked the app's vocabulary into the plugin; this renames it to what callkeep itself knows.

### Changes
- `markSignalingRegistered` -> `markReportedIncoming`
- `consumeSignalingRegistered` -> `consumeReportedIncoming`
- `signalingRegisteredCallIds` -> `reportedIncomingCallIds`
- suppression log line and related doc comments updated accordingly.

Touches `ConnectionTracker`, `CallkeepCore`, `InProcessCallkeepCore`, `MainProcessConnectionTracker`, `ForegroundService`, `MainProcessConnectionTrackerTest`, and a stale comment in the example stress test. The `signaling` mentions that remain are descriptive references to the host app's signaling layer, which are accurate.

### Verification
- `./gradlew testDebugUnitTest` green; `flutter analyze` + `flutter test` (pre-push) green.

### Note
Touches `ForegroundService` in the same area as the incoming-call adoption fix (PR #324). They are independent; whichever merges second may need a trivial rebase.