### PR TITLE
docs(android): document reportedIncoming guard in CallkeepCore

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -152,8 +152,25 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
+    /**
+     * Mark [callId] as having been reported by the host app via `reportNewIncomingCall`
+     * (the app/signaling path), as opposed to discovered by callkeep through the push/Telecom path.
+     *
+     * Purpose: de-duplicate the incoming-call notification to Flutter. When the app itself reported
+     * the call, Flutter already knows about it (`__onCallSignalingEventIncoming`). The
+     * `DidPushIncomingCall` broadcast that still arrives afterwards via the `:callkeep_core` IPC
+     * round-trip is then suppressed (see [consumeReportedIncoming]) so it does not add a second,
+     * push-path ActiveCall (line -1) alongside the existing app-path entry (line 0) for the same callId.
+     */
     fun markReportedIncoming(callId: String)
 
+    /**
+     * Returns true and clears the mark if [callId] was app-reported (see [markReportedIncoming]).
+     *
+     * Consume-on-read: the guard fires at most once per call, so the first `DidPushIncomingCall`
+     * for an app-reported call is suppressed and any subsequent delivery (e.g. an explicit
+     * re-emit to a newly attached delegate) is no longer affected.
+     */
     fun consumeReportedIncoming(callId: String): Boolean
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

Adds KDoc to `CallkeepCore.markReportedIncoming` / `consumeReportedIncoming`, which were declared without explanation. Documents what the guard is for: it de-duplicates the incoming-call notification to Flutter.

- `markReportedIncoming(callId)` — flags a call the host reported via `reportNewIncomingCall` (the app/signaling path), as opposed to one discovered by callkeep through the push/Telecom path.
- `consumeReportedIncoming(callId)` — consume-on-read; suppresses the duplicate push-path `DidPushIncomingCall` that arrives afterwards via the `:callkeep_core` IPC round-trip, so it does not add a second ActiveCall (line -1) alongside the existing app-path entry (line 0). Because it consumes on first read, the guard fires at most once and a later explicit re-emit to a newly attached delegate is unaffected.

Doc-only; no behavior change. The `ConnectionTracker` interface already carries equivalent KDoc; the `InProcessCallkeepCore` / `MainProcessConnectionTracker` overrides inherit it.

### Verification
- `flutter analyze` + `flutter test` + `./gradlew testDebugUnitTest` (pre-push) green.