### PR TITLE
refactor(android): emit DidPushIncomingCall at connection creation, not on show-UI

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -122,10 +122,15 @@ class PhoneConnection internal constructor(
     /**
      * Invoked by the system when the incoming call interface should be displayed.
      *
-     * If there is already an active or held call, play a soft call-waiting tone through
-     * the voice call stream instead of the full ringtone. The ringtone uses TYPE_RINGTONE
-     * which routes through the earpiece at full ringtone volume during an active call,
-     * and can cause pain if the user has the phone pressed to their ear (WT-1388).
+     * Presentation only: post the incoming-call notification and start the ringtone (or a soft
+     * call-waiting tone when another call is already active/held — the full TYPE_RINGTONE routes
+     * through the earpiece at full volume during a call and can hurt with the phone to the ear,
+     * WT-1388).
+     *
+     * The control-plane notification to the main process (DidPushIncomingCall) is NOT emitted
+     * here. It is dispatched deterministically from [PhoneConnectionService.onCreateIncomingConnection]
+     * when the connection is created, so it does not depend on this system UI callback's timing
+     * (which the framework schedules separately and which is skipped for an immediately-answered call).
      */
     override fun onShowIncomingCallUi() {
         logger.d("Showing incoming call UI for callId: $callId")
@@ -136,7 +141,6 @@ class PhoneConnection internal constructor(
         } else {
             audioManager.startRingtone(metadata.ringtonePath)
         }
-        dispatcher(CallLifecycleEvent.DidPushIncomingCall, metadata)
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -334,6 +334,17 @@ class PhoneConnectionService : ConnectionService() {
                 Log.i(TAG, "onCreateIncomingConnection: applying deferred answer for callId=${metadata.callId}")
                 connection.onAnswer()
             }
+        } else {
+            // Notify the main process that an incoming call is registered, deterministically at
+            // creation time. Previously this was emitted later from PhoneConnection.onShowIncomingCallUi
+            // (a system UI callback the framework schedules separately), which made delivery to
+            // Flutter and the reportNewIncomingCall callback resolution depend on UI-show timing.
+            //
+            // Only the not-yet-answered branch emits it: a call with a consumed deferred answer is
+            // being answered immediately (no incoming UI), so it is surfaced to Flutter via the
+            // answer flow instead — matching the previous behaviour where onShowIncomingCallUi
+            // (and therefore DidPushIncomingCall) did not fire for an immediately-answered call.
+            performEventHandle(CallLifecycleEvent.DidPushIncomingCall, metadata)
         }
 
         phoneConnectionServiceDispatcher.dispatchLifecycle(


### PR DESCRIPTION
## Overview

Move where the Telecom path emits `DidPushIncomingCall` from the system UI callback `PhoneConnection.onShowIncomingCallUi` to the deterministic connection-creation point `PhoneConnectionService.onCreateIncomingConnection`. Behaviour-preserving in intent; changes only *when/where* the event is emitted.

### Why
`DidPushIncomingCall` is a control-plane event: its handler (`handleCSReportDidPushIncomingCall`) promotes the call to RINGING, resolves the pending `reportNewIncomingCall` Pigeon callback, applies the app-reported suppression, and notifies Flutter (`didPushIncomingCall`). Emitting it from `onShowIncomingCallUi` tied all of that to a **system UI callback the framework schedules separately from — and after — `onCreateIncomingConnection`**, with OEM-dependent timing. Consequences:

- The two backends emit the same event at **different lifecycle points**: the Standalone (no-Telecom) path already emits it deterministically in `handleIncomingCall`, and its own comment claims parity with `onCreateIncomingConnection` — which was not actually true for the Telecom path.
- Resolution of the pending `reportNewIncomingCall` callback (and the Flutter notification) was delayed to UI-show time, leaning on the 5 s confirmation timeout as a fallback.
- Presentation (ringtone/call-waiting) and control-plane (notify/resolve/promote) were entangled in one UI callback.

### Change
- `PhoneConnection.onShowIncomingCallUi` — presentation only now (notification + ringtone/call-waiting tone). DidPush dispatch removed.
- `PhoneConnectionService.onCreateIncomingConnection` — dispatches `DidPushIncomingCall` deterministically when the connection is created, alongside the `ConnectionCreated` lifecycle event. Emitted **only in the not-yet-answered branch**: a call whose deferred answer was consumed is answered immediately (no incoming UI) and reaches Flutter via the answer flow — matching the prior behaviour where `onShowIncomingCallUi` (and thus DidPush) did not fire for an immediately-answered call.

Telecom and Standalone paths now emit at the same lifecycle point.

### Risk / verification
Behavioural change limited to emit timing/site; no public API change. `./gradlew testDebugUnitTest` + `flutter analyze` + `flutter test` (pre-push) green. **Draft** until device-verified:
- normal incoming rings; call-waiting tone when another call is active/held;
- immediate-answer (notification button, cold start) still works and does not double-surface;
- push->foreground handoff (interacts with PR #324) still surfaces the call exactly once;
- the `reportNewIncomingCall` callback resolves at creation (no 5 s timeout fallback in the happy path).

### Relation to other PRs
Touches `PhoneConnection` / `PhoneConnectionService`, same files as the incoming-call adoption fix (#324, draft). Independent change; whichever merges second needs a trivial rebase.