### PR TITLE
refactor(android): make onStateChanged the source of truth for shadow connection state

### DIFF
--- a/webtrit_callkeep_android/README.md
+++ b/webtrit_callkeep_android/README.md
@@ -77,7 +77,11 @@ The public API is covered by integration tests located in
 | `callkeep_delegate_edge_cases_test.dart`   | `setDelegate(null)` mid-call, delegate swap, `didPushIncomingCall`, audio session callbacks |
 | `callkeep_client_scenarios_test.dart`      | `answerCall` idempotency, ringback sound, async `performEndCall` contract                   |
 | `callkeep_reportendcall_reasons_test.dart` | All `CallkeepEndCallReason` values via `reportEndCall`                                      |
+| `callkeep_delivery_mode_test.dart`         | `getCallDeliveryMode` query (Android only) and the no-op behaviour on non-Android          |
 | `callkeep_stress_test.dart`                | Concurrent duplicate reports, rapid tearDown, spam scenarios                                |
+
+`all_tests.dart` is an aggregator entry point that runs every suite above in a single driver
+invocation (used for web `flutter drive` and full-suite device runs).
 
 Run on a connected device or emulator from the example app directory:
 
@@ -109,7 +113,7 @@ flutter pub run pigeon --input pigeons/callkeep.messages.dart
 # From this directory
 flutter pub get
 flutter analyze lib test
-dart format --line-length 80 --set-exit-if-changed lib test
+dart format --line-length 120 --set-exit-if-changed lib test
 ```
 
 ---

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallConnectionState.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallConnectionState.kt
@@ -1,0 +1,44 @@
+package com.webtrit.callkeep.models
+
+import android.telecom.Connection
+
+/**
+ * Local (callkeep-owned) representation of a call connection's lifecycle state.
+ *
+ * Kept independent of the Pigeon-generated `PCallkeepConnectionState`: domain/model code (e.g.
+ * [CallMetadata]) uses this type, and conversion to the Pigeon enum happens only at the core/IPC
+ * boundary (see MainProcessConnectionTracker). Mirrors the meaningful android.telecom.Connection states.
+ *
+ * Why not the raw `android.telecom.Connection.STATE_*` ints directly: they are untyped magic numbers,
+ * and the no-Telecom StandaloneCallService has no android.telecom.Connection — so a framework int
+ * cannot be the shared representation. This owned enum is backend-agnostic and type-safe; Telecom
+ * states map in via [fromTelecomState].
+ */
+enum class CallConnectionState {
+    INITIALIZING,
+    NEW,
+    RINGING,
+    DIALING,
+    ACTIVE,
+    HOLDING,
+    DISCONNECTED,
+    ;
+
+    companion object {
+        /**
+         * Map an android.telecom.Connection STATE_* int to the local enum; returns null for states
+         * not represented here (e.g. STATE_PULLING_CALL).
+         */
+        fun fromTelecomState(state: Int): CallConnectionState? =
+            when (state) {
+                Connection.STATE_INITIALIZING -> INITIALIZING
+                Connection.STATE_NEW -> NEW
+                Connection.STATE_RINGING -> RINGING
+                Connection.STATE_DIALING -> DIALING
+                Connection.STATE_ACTIVE -> ACTIVE
+                Connection.STATE_HOLDING -> HOLDING
+                Connection.STATE_DISCONNECTED -> DISCONNECTED
+                else -> null
+            }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/models/CallMetaData.kt
@@ -45,6 +45,11 @@ data class CallMetadata(
     val ringtonePath: String? = null,
     val createdTime: Long? = null,
     val acceptedTime: Long? = null,
+    // Transient transition payload: the authoritative connection state, carried by the
+    // ConnectionStateChanged event from PhoneConnection.onStateChanged (or StandaloneCallService)
+    // so the main process can mirror it. Local type by design (no Pigeon dependency in the model);
+    // converted to PCallkeepConnectionState only at the core boundary. Not part of the call identity.
+    val connectionState: CallConnectionState? = null,
 ) {
     val number: String? get() = handle?.number
 
@@ -79,6 +84,7 @@ data class CallMetadata(
             dualToneMultiFrequency?.let { putChar(CallDataConst.DTMF, it) }
             createdTime?.let { putLong(CALL_METADATA_CREATED_TIME, it) }
             acceptedTime?.let { putLong(CALL_METADATA_ACCEPTED_TIME, it) }
+            connectionState?.let { putString(CALL_METADATA_CONNECTION_STATE, it.name) }
         }
 
     /**
@@ -114,6 +120,7 @@ data class CallMetadata(
             ringtonePath = other.ringtonePath ?: ringtonePath,
             createdTime = other.createdTime ?: createdTime,
             acceptedTime = other.acceptedTime ?: acceptedTime,
+            connectionState = other.connectionState ?: connectionState,
         )
     }
 
@@ -122,6 +129,7 @@ data class CallMetadata(
         private const val CALL_METADATA_ACCEPTED_TIME = "CALL_METADATA_ACCEPTED_TIME"
         private const val CALL_RINGTONE_PATH = "CALL_RINGTONE_PATH"
         private const val CALL_METADATA_EXTRA_SPEAKER_ON_VIDEO = "EXTRA_SPEAKER_ON_VIDEO"
+        private const val CALL_METADATA_CONNECTION_STATE = "CALL_METADATA_CONNECTION_STATE"
         private const val DEFAULT_CHAR_VALUE = '\u0000'
 
         fun fromBundle(bundle: Bundle): CallMetadata =
@@ -153,6 +161,10 @@ data class CallMetadata(
                 ringtonePath = bundle.getStringOrNull(CALL_RINGTONE_PATH),
                 createdTime = bundle.getLongOrNull(CALL_METADATA_CREATED_TIME),
                 acceptedTime = bundle.getLongOrNull(CALL_METADATA_ACCEPTED_TIME),
+                connectionState =
+                    bundle
+                        .getStringOrNull(CALL_METADATA_CONNECTION_STATE)
+                        ?.let { name -> runCatching { CallConnectionState.valueOf(name) }.getOrNull() },
             )
         }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
@@ -31,6 +31,11 @@ enum class CallLifecycleEvent : ConnectionEvent {
     HungUp,
     OngoingCall,
     DidPushIncomingCall,
+    // Carries the authoritative connection state (CallMetadata.connectionState) so the main process
+    // can MIRROR it into the shadow state, instead of inferring a fixed state per event type. Emitted
+    // from PhoneConnection.onStateChanged (Telecom) / StandaloneCallService transitions. Live states
+    // only -- terminal DISCONNECTED stays on the cause-carrying HungUp/DeclineCall events.
+    ConnectionStateChanged,
     OutgoingFailure,
     IncomingFailure,
     ConnectionNotFound,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -116,11 +116,6 @@ interface CallkeepCore {
 
     fun markAnswered(callId: String)
 
-    fun markHeld(
-        callId: String,
-        onHold: Boolean,
-    )
-
     /**
      * Mirror the authoritative connection [state] for an already-tracked [callId] (source of truth =
      * the real android.telecom.Connection state via PhoneConnection.onStateChanged, or the

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -117,9 +117,11 @@ interface CallkeepCore {
     fun markAnswered(callId: String)
 
     /**
-     * Mirror the authoritative connection [state] for an already-tracked [callId] (source of truth =
-     * the real android.telecom.Connection state via PhoneConnection.onStateChanged, or the
-     * StandaloneCallService transitions). Idempotent; ignores terminal states.
+     * Mirror the authoritative connection [state] for [callId] (source of truth = the real
+     * android.telecom.Connection state via PhoneConnection.onStateChanged, or the StandaloneCallService
+     * transitions). Writes state UNCONDITIONALLY — it does NOT register the call and may be called
+     * before promote (state persists across addPending, which the cold-start adoption relies on).
+     * Ignores terminal DISCONNECTED (owned by [markTerminated]).
      */
     fun updateState(
         callId: String,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -10,6 +10,7 @@ import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.PIncomingCallErrorEnum
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.ConnectionEvent
 
@@ -118,6 +119,16 @@ interface CallkeepCore {
     fun markHeld(
         callId: String,
         onHold: Boolean,
+    )
+
+    /**
+     * Mirror the authoritative connection [state] for an already-tracked [callId] (source of truth =
+     * the real android.telecom.Connection state via PhoneConnection.onStateChanged, or the
+     * StandaloneCallService transitions). Idempotent; ignores terminal states.
+     */
+    fun updateState(
+        callId: String,
+        state: CallConnectionState,
     )
 
     fun markTerminated(callId: String)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -2,6 +2,7 @@ package com.webtrit.callkeep.services.core
 
 import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 
 /**
@@ -39,6 +40,17 @@ interface ConnectionTracker {
     fun markHeld(
         callId: String,
         onHold: Boolean,
+    )
+
+    /**
+     * Mirror the authoritative connection [state] for an already-tracked [callId]. Source of truth is
+     * the real android.telecom.Connection state (PhoneConnection.onStateChanged) / the StandaloneCallService
+     * transitions. Idempotent; never creates an entry, never touches guard sets; ignores terminal states
+     * (DISCONNECTED stays on [markTerminated] via the cause-carrying events).
+     */
+    fun updateState(
+        callId: String,
+        state: CallConnectionState,
     )
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -36,12 +36,6 @@ interface ConnectionTracker {
     /** Mark [callId] as answered and advance its state to STATE_ACTIVE. */
     fun markAnswered(callId: String)
 
-    /** Update the hold state for [callId] (STATE_HOLDING / STATE_ACTIVE). */
-    fun markHeld(
-        callId: String,
-        onHold: Boolean,
-    )
-
     /**
      * Mirror the authoritative connection [state] for an already-tracked [callId]. Source of truth is
      * the real android.telecom.Connection state (PhoneConnection.onStateChanged) / the StandaloneCallService

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -33,14 +33,19 @@ interface ConnectionTracker {
         state: PCallkeepConnectionState,
     )
 
-    /** Mark [callId] as answered and advance its state to STATE_ACTIVE. */
+    /**
+     * Mark [callId] as answered (lifecycle guard for isAnswered / checkIncomingDuplicate).
+     * Does NOT stamp the connection state — ACTIVE is mirrored via [updateState].
+     */
     fun markAnswered(callId: String)
 
     /**
-     * Mirror the authoritative connection [state] for an already-tracked [callId]. Source of truth is
-     * the real android.telecom.Connection state (PhoneConnection.onStateChanged) / the StandaloneCallService
-     * transitions. Idempotent; never creates an entry, never touches guard sets; ignores terminal states
-     * (DISCONNECTED stays on [markTerminated] via the cause-carrying events).
+     * Mirror the authoritative connection [state] for [callId]. Source of truth is the real
+     * android.telecom.Connection state (PhoneConnection.onStateChanged) / the StandaloneCallService
+     * transitions. Writes the state UNCONDITIONALLY (it does NOT register the call and is not gated on
+     * connections membership): state may be set before [promote] and is preserved across an [addPending]
+     * reset, which the cold-start "already answered" detection relies on. Touches no guard set. Ignores
+     * terminal DISCONNECTED — that is owned by [markTerminated] via the cause-carrying events.
      */
     fun updateState(
         callId: String,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -152,11 +152,6 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markAnswered(callId: String) = tracker.markAnswered(callId)
 
-    override fun markHeld(
-        callId: String,
-        onHold: Boolean,
-    ) = tracker.markHeld(callId, onHold)
-
     override fun updateState(
         callId: String,
         state: CallConnectionState,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -13,6 +13,7 @@ import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.PIncomingCallErrorEnum
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
@@ -155,6 +156,11 @@ class InProcessCallkeepCore internal constructor(
         callId: String,
         onHold: Boolean,
     ) = tracker.markHeld(callId, onHold)
+
+    override fun updateState(
+        callId: String,
+        state: CallConnectionState,
+    ) = tracker.updateState(callId, state)
 
     override fun markTerminated(callId: String) = tracker.markTerminated(callId)
 
@@ -346,6 +352,7 @@ class InProcessCallkeepCore internal constructor(
         internal val GLOBAL_LISTENER_EVENTS: List<ConnectionEvent> =
             listOf(
                 CallLifecycleEvent.DidPushIncomingCall,
+                CallLifecycleEvent.ConnectionStateChanged,
                 CallLifecycleEvent.DeclineCall,
                 CallLifecycleEvent.HungUp,
                 CallLifecycleEvent.ConnectionNotFound,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -130,47 +130,31 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     }
 
     /**
-     * Mark [callId] as answered and advance its state to [PCallkeepConnectionState.STATE_ACTIVE].
+     * Mark [callId] as answered (lifecycle guard for isAnswered/checkIncomingDuplicate).
+     *
+     * Does NOT stamp the connection state: the ACTIVE state is mirrored from the real connection via
+     * [updateState] (PhoneConnection.onStateChanged for Telecom; explicit ConnectionStateChanged from
+     * StandaloneCallService). The initial registration snapshot is still set by [promote].
      */
     override fun markAnswered(callId: String) {
         answeredCallIds.add(callId)
-        connectionStates[callId] = PCallkeepConnectionState.STATE_ACTIVE
-    }
-
-    /**
-     * Update the hold state for [callId].
-     * Advances its state to [PCallkeepConnectionState.STATE_HOLDING] when [onHold] is true,
-     * or back to [PCallkeepConnectionState.STATE_ACTIVE] when false.
-     * This keeps [getConnections] in sync with the Telecom hold state so that callers never
-     * see a stale ACTIVE state for a held call.
-     */
-    override fun markHeld(
-        callId: String,
-        onHold: Boolean,
-    ) {
-        connectionStates[callId] =
-            if (onHold) {
-                PCallkeepConnectionState.STATE_HOLDING
-            } else {
-                PCallkeepConnectionState.STATE_ACTIVE
-            }
     }
 
     /**
      * Mirror the authoritative connection [state] for [callId]. The source of truth is the real
      * android.telecom.Connection state, broadcast from PhoneConnection.onStateChanged (and emitted
-     * explicitly by the no-Telecom StandaloneCallService). Idempotent; only updates a call already
-     * tracked (registered via [promote]) — never creates an entry and never touches the lifecycle
-     * guard sets. Termination (STATE_DISCONNECTED) is owned by [markTerminated] on the cause-carrying
-     * events, not by this mirror.
+     * explicitly by the no-Telecom StandaloneCallService). Replaces the per-event state stamping that
+     * the removed markAnswered(ACTIVE)/markHeld did; like those it writes [connectionStates]
+     * unconditionally (it is NOT gated on [connections] membership), so the state survives an
+     * [addPending] reset and the cold-start "already answered" detection in reportNewIncomingCall keeps
+     * working. Touches no lifecycle guard set. Termination (STATE_DISCONNECTED) is owned by
+     * [markTerminated] on the cause-carrying events, not by this mirror.
      */
     override fun updateState(
         callId: String,
         state: CallConnectionState,
     ) {
-        if (connections.containsKey(callId)) {
-            connectionStates[callId] = state.toPCallkeepConnectionState()
-        }
+        connectionStates[callId] = state.toPCallkeepConnectionState()
     }
 
     // Conversion from the local model enum to the Pigeon enum lives here, at the core boundary,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -4,6 +4,7 @@ import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PCallkeepDisconnectCause
 import com.webtrit.callkeep.PCallkeepDisconnectCauseType
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import java.util.concurrent.ConcurrentHashMap
 
@@ -154,6 +155,36 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
                 PCallkeepConnectionState.STATE_ACTIVE
             }
     }
+
+    /**
+     * Mirror the authoritative connection [state] for [callId]. The source of truth is the real
+     * android.telecom.Connection state, broadcast from PhoneConnection.onStateChanged (and emitted
+     * explicitly by the no-Telecom StandaloneCallService). Idempotent; only updates a call already
+     * tracked (registered via [promote]) — never creates an entry and never touches the lifecycle
+     * guard sets. Termination (STATE_DISCONNECTED) is owned by [markTerminated] on the cause-carrying
+     * events, not by this mirror.
+     */
+    override fun updateState(
+        callId: String,
+        state: CallConnectionState,
+    ) {
+        if (connections.containsKey(callId)) {
+            connectionStates[callId] = state.toPCallkeepConnectionState()
+        }
+    }
+
+    // Conversion from the local model enum to the Pigeon enum lives here, at the core boundary,
+    // so model/domain code (CallMetadata) stays free of the generated PCallkeepConnectionState.
+    private fun CallConnectionState.toPCallkeepConnectionState(): PCallkeepConnectionState =
+        when (this) {
+            CallConnectionState.INITIALIZING -> PCallkeepConnectionState.STATE_INITIALIZING
+            CallConnectionState.NEW -> PCallkeepConnectionState.STATE_NEW
+            CallConnectionState.RINGING -> PCallkeepConnectionState.STATE_RINGING
+            CallConnectionState.DIALING -> PCallkeepConnectionState.STATE_DIALING
+            CallConnectionState.ACTIVE -> PCallkeepConnectionState.STATE_ACTIVE
+            CallConnectionState.HOLDING -> PCallkeepConnectionState.STATE_HOLDING
+            CallConnectionState.DISCONNECTED -> PCallkeepConnectionState.STATE_DISCONNECTED
+        }
 
     override fun updateMetadata(metadata: CallMetadata) {
         connections.computeIfPresent(metadata.callId) { _, existing ->

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -154,6 +154,10 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         callId: String,
         state: CallConnectionState,
     ) {
+        // Terminal state is owned by markTerminated (via the cause-carrying HungUp/DeclineCall events),
+        // not by this mirror — guard here so a future ConnectionStateChanged(DISCONNECTED) call site
+        // cannot accidentally override the termination path.
+        if (state == CallConnectionState.DISCONNECTED) return
         connectionStates[callId] = state.toPCallkeepConnectionState()
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -23,6 +23,7 @@ import com.webtrit.callkeep.managers.AudioManager
 import com.webtrit.callkeep.managers.NotificationManager
 import com.webtrit.callkeep.models.AudioDevice
 import com.webtrit.callkeep.models.AudioDeviceType
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
 import com.webtrit.callkeep.services.broadcaster.CallMediaEvent
@@ -251,6 +252,15 @@ class PhoneConnection internal constructor(
         if ((lastKnownState == STATE_DIALING || lastKnownState == STATE_RINGING) && state == STATE_ACTIVE) {
             onActiveConnection()
         }
+
+        // Mirror the authoritative Telecom state to the main process: the shadow state mirrors the
+        // real connection state instead of inferring a fixed value per lifecycle event. Live states
+        // only -- terminal DISCONNECTED stays on the cause-carrying termination events
+        // (onDisconnect -> HungUp/DeclineCall), which preserve the DisconnectCause.
+        CallConnectionState
+            .fromTelecomState(state)
+            ?.takeIf { it != CallConnectionState.DISCONNECTED }
+            ?.let { dispatcher(CallLifecycleEvent.ConnectionStateChanged, metadata.copy(connectionState = it)) }
 
         lastKnownState = state
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -19,6 +19,7 @@ import com.webtrit.callkeep.common.startForegroundServiceCompat
 import com.webtrit.callkeep.managers.NotificationChannelManager
 import com.webtrit.callkeep.models.AudioDevice
 import com.webtrit.callkeep.models.AudioDeviceType
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.notifications.StandaloneIncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
@@ -334,6 +335,12 @@ class StandaloneCallService : Service() {
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
+        // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
+        // mirrors it (replaces the removed markAnswered state-stamping).
+        core.notifyConnectionEvent(
+            CallLifecycleEvent.ConnectionStateChanged,
+            callMetadataMap[metadata.callId]!!.copy(connectionState = CallConnectionState.ACTIVE).toBundle(),
+        )
     }
 
     private fun handleAnswerCall(metadata: CallMetadata) {
@@ -350,6 +357,12 @@ class StandaloneCallService : Service() {
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
+        // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
+        // mirrors it (replaces the removed markAnswered state-stamping).
+        core.notifyConnectionEvent(
+            CallLifecycleEvent.ConnectionStateChanged,
+            callMetadataMap[metadata.callId]!!.copy(connectionState = CallConnectionState.ACTIVE).toBundle(),
+        )
     }
 
     /**
@@ -425,6 +438,12 @@ class StandaloneCallService : Service() {
         val updated = (callMetadataMap[metadata.callId] ?: metadata).copy(hasHold = onHold)
         callMetadataMap[metadata.callId] = updated
         core.notifyConnectionEvent(CallMediaEvent.ConnectionHolding, updated.toBundle())
+        // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
+        // mirrors it (replaces the removed markHeld state-stamping).
+        core.notifyConnectionEvent(
+            CallLifecycleEvent.ConnectionStateChanged,
+            updated.copy(connectionState = if (onHold) CallConnectionState.HOLDING else CallConnectionState.ACTIVE).toBundle(),
+        )
     }
 
     private fun handleTearDownConnections() {
@@ -518,10 +537,14 @@ class StandaloneCallService : Service() {
     }
 
     private fun handleSyncConnectionState() {
-        Log.i(TAG, "handleSyncConnectionState: re-emitting AnswerCall for answered calls")
+        Log.i(TAG, "handleSyncConnectionState: re-emitting AnswerCall + ACTIVE state for answered calls")
         answeredCallIds.forEach { callId ->
             val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
             core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, meta.toBundle())
+            core.notifyConnectionEvent(
+                CallLifecycleEvent.ConnectionStateChanged,
+                meta.copy(connectionState = CallConnectionState.ACTIVE).toBundle(),
+            )
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -440,9 +440,10 @@ class StandaloneCallService : Service() {
         core.notifyConnectionEvent(CallMediaEvent.ConnectionHolding, updated.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
         // mirrors it (replaces the removed markHeld state-stamping).
+        val holdState = if (onHold) CallConnectionState.HOLDING else CallConnectionState.ACTIVE
         core.notifyConnectionEvent(
             CallLifecycleEvent.ConnectionStateChanged,
-            updated.copy(connectionState = if (onHold) CallConnectionState.HOLDING else CallConnectionState.ACTIVE).toBundle(),
+            updated.copy(connectionState = holdState).toBundle(),
         )
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -594,9 +594,10 @@ class ForegroundService :
                         // a call that is still ringing and one that was already answered via the
                         // notification Answer button while the main process had no UI running.
                         //
-                        // connectionStates[callId] is set to STATE_ACTIVE by markAnswered() when
-                        // the AnswerCall broadcast arrives (fired from :callkeep_core after
-                        // onAnswer()), and is preserved across the addPending() call above.
+                        // connectionStates[callId] is mirrored to STATE_ACTIVE by the
+                        // ConnectionStateChanged event (PhoneConnection.onStateChanged ACTIVE, fired
+                        // from :callkeep_core after onAnswer()); updateState writes it unconditionally
+                        // so it is preserved across the addPending() call above.
                         val existingState = core.getState(callId)
                         if (existingState == PCallkeepConnectionState.STATE_ACTIVE) {
                             // Call answered before the main app started its UI. Adopt as active
@@ -1190,8 +1191,9 @@ class ForegroundService :
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
             val onHold = callMetaData.hasHold ?: false
-            // Keep tracker state in sync so getConnections() reflects HOLDING / ACTIVE correctly.
-            core.markHeld(callMetaData.callId, onHold)
+            // The HOLDING / ACTIVE shadow state is mirrored from the real connection via
+            // ConnectionStateChanged (onStateChanged for Telecom; explicit emit from StandaloneCallService),
+            // so this handler only relays the hold action to Flutter.
             flutterDelegateApi?.performSetHeld(callMetaData.callId, onHold) {}
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -29,6 +29,7 @@ import com.webtrit.callkeep.common.Platform
 import com.webtrit.callkeep.common.StorageDelegate
 import com.webtrit.callkeep.common.TelephonyUtils
 import com.webtrit.callkeep.managers.NotificationChannelManager
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import com.webtrit.callkeep.models.EmergencyNumberException
 import com.webtrit.callkeep.models.FailedCallInfo
@@ -133,6 +134,10 @@ class ForegroundService :
         when (event) {
             CallLifecycleEvent.DidPushIncomingCall -> {
                 handleCSReportDidPushIncomingCall(data)
+            }
+
+            CallLifecycleEvent.ConnectionStateChanged -> {
+                handleCSReportConnectionStateChanged(data)
             }
 
             CallLifecycleEvent.DeclineCall -> {
@@ -1042,6 +1047,22 @@ class ForegroundService :
                 callIdArg = metadata.callId,
                 errorArg = null,
             ) {}
+        }
+    }
+
+    /**
+     * Mirror the authoritative connection state carried by ConnectionStateChanged
+     * (PhoneConnection.onStateChanged in :callkeep_core, or StandaloneCallService) into the shadow
+     * state. Live states only; terminal DISCONNECTED is owned by the cause-carrying HungUp/DeclineCall
+     * path (handleCSReportDeclineCall -> markTerminated), so it is ignored here.
+     */
+    private fun handleCSReportConnectionStateChanged(extras: Bundle?) {
+        extras?.let {
+            val metadata = CallMetadata.fromBundle(it)
+            val state = metadata.connectionState ?: return@let
+            if (state == CallConnectionState.DISCONNECTED) return@let
+            logger.d("handleCSReportConnectionStateChanged: callId=${metadata.callId} state=$state")
+            core.updateState(metadata.callId, state)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -137,17 +137,21 @@ class MainProcessConnectionTrackerTest {
     }
 
     @Test
-    fun `updateState — no-op for an untracked call (does not create an entry)`() {
-        tracker.updateState("ghost", CallConnectionState.ACTIVE)
-        assertEquals(null, tracker.getState("ghost"))
-        assertFalse(tracker.exists("ghost"))
+    fun `updateState — writes state unconditionally (survives addPending reset, like the old stampers)`() {
+        // Not gated on connections membership: this is required so the cold-start "already answered"
+        // detection (reportNewIncomingCall) still sees STATE_ACTIVE after an addPending() that clears
+        // the answeredCallIds guard but not connectionStates.
+        tracker.updateState("call-1", CallConnectionState.ACTIVE)
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
+        // It mirrors state only; it does not register the call into connections.
+        assertFalse(tracker.exists("call-1"))
     }
 
     @Test
-    fun `updateState — no-op for a pending-only call (not yet promoted)`() {
+    fun `updateState — state set before promote is preserved (not a registration)`() {
         tracker.addPending("call-1")
         tracker.updateState("call-1", CallConnectionState.ACTIVE)
-        assertEquals(null, tracker.getState("call-1"))
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
     }
 
     // -------------------------------------------------------------------------
@@ -163,10 +167,12 @@ class MainProcessConnectionTrackerTest {
     }
 
     @Test
-    fun `markAnswered — getState advances to STATE_ACTIVE`() {
+    fun `markAnswered — does not stamp state (state is mirrored via updateState)`() {
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
         tracker.markAnswered("call-1")
-        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
+        // markAnswered is a lifecycle guard only now; the ACTIVE state arrives via updateState.
+        assertTrue(tracker.isAnswered("call-1"))
+        assertEquals(PCallkeepConnectionState.STATE_RINGING, tracker.getState("call-1"))
     }
 
     @Test
@@ -235,26 +241,8 @@ class MainProcessConnectionTrackerTest {
         assertFalse(tracker.consumeAnswer("call-1"))
     }
 
-    // -------------------------------------------------------------------------
-    // markHeld
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `markHeld true — getState returns STATE_HOLDING`() {
-        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
-        tracker.markAnswered("call-1")
-        tracker.markHeld("call-1", true)
-        assertEquals(PCallkeepConnectionState.STATE_HOLDING, tracker.getState("call-1"))
-    }
-
-    @Test
-    fun `markHeld false — getState returns STATE_ACTIVE`() {
-        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
-        tracker.markAnswered("call-1")
-        tracker.markHeld("call-1", true)
-        tracker.markHeld("call-1", false)
-        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
-    }
+    // (hold state is now mirrored via updateState(CallConnectionState.HOLDING/ACTIVE) — see the
+    // updateState tests above; the removed markHeld stamper no longer exists.)
 
     // -------------------------------------------------------------------------
     // getAll
@@ -455,6 +443,10 @@ class MainProcessConnectionTrackerTest {
 
         tracker.markAnswered(id)
         assertTrue(tracker.isAnswered(id))
+        // markAnswered is a guard only; the ACTIVE state arrives via the mirror (updateState),
+        // mirroring the real flow (onStateChanged ACTIVE / Standalone explicit emit).
+        assertEquals(PCallkeepConnectionState.STATE_RINGING, tracker.getState(id))
+        tracker.updateState(id, CallConnectionState.ACTIVE)
         assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState(id))
 
         tracker.markTerminated(id)

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -2,6 +2,7 @@ package com.webtrit.callkeep.services.core
 
 import android.os.Build
 import com.webtrit.callkeep.PCallkeepConnectionState
+import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -115,6 +116,38 @@ class MainProcessConnectionTrackerTest {
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
         assertTrue(tracker.exists("call-1"))
         assertFalse(tracker.isPending("call-1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // updateState (state mirror)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `updateState — mirrors local state into the pigeon state for a promoted call`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_RINGING)
+        tracker.updateState("call-1", CallConnectionState.ACTIVE)
+        assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
+    }
+
+    @Test
+    fun `updateState — maps HOLDING`() {
+        tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_ACTIVE)
+        tracker.updateState("call-1", CallConnectionState.HOLDING)
+        assertEquals(PCallkeepConnectionState.STATE_HOLDING, tracker.getState("call-1"))
+    }
+
+    @Test
+    fun `updateState — no-op for an untracked call (does not create an entry)`() {
+        tracker.updateState("ghost", CallConnectionState.ACTIVE)
+        assertEquals(null, tracker.getState("ghost"))
+        assertFalse(tracker.exists("ghost"))
+    }
+
+    @Test
+    fun `updateState — no-op for a pending-only call (not yet promoted)`() {
+        tracker.addPending("call-1")
+        tracker.updateState("call-1", CallConnectionState.ACTIVE)
+        assertEquals(null, tracker.getState("call-1"))
     }
 
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionTerminateTest.kt
@@ -34,8 +34,13 @@ class PhoneConnectionTerminateTest {
     private val context: Context = RuntimeEnvironment.getApplication()
 
     // Captured dispatcher events — order matters for multi-call assertions.
+    // ConnectionStateChanged is filtered out: these tests assert the termination event/cause
+    // (HungUp vs DeclineCall) and its idempotency; the orthogonal state-mirror events emitted by
+    // onStateChanged during setup/transitions are covered separately.
     private val dispatchedEvents = mutableListOf<ConnectionEvent>()
-    private val dispatcher: PerformDispatchHandle = { event, _ -> dispatchedEvents.add(event) }
+    private val dispatcher: PerformDispatchHandle = { event, _ ->
+        if (event != CallLifecycleEvent.ConnectionStateChanged) dispatchedEvents.add(event)
+    }
 
     // Count of onDisconnectCallback invocations.
     private var disconnectCallbackCount = 0

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -48,12 +48,13 @@ Triggered by an FCM message or a direct Dart call to `reportNewIncomingCall`.
         |   If not yet: ConnectionManager.reserveAnswer(callId)  (deferred)
         v
 11. PhoneConnectionService.onStartCommand(AnswerCall)
-        |   PhoneConnection.onAnswer()
-        |   STATE_ACTIVE
+        |   PhoneConnection.onAnswer() -> setActive() -> STATE_ACTIVE
+        |   broadcast: ConnectionStateChanged (connectionState = ACTIVE)
         |   broadcast: AnswerCall
         v
-12. ForegroundService receives AnswerCall broadcast
-        |   MainProcessConnectionTracker.markAnswered(callId)
+12. ForegroundService receives the broadcasts
+        |   ConnectionStateChanged -> updateState(callId, ACTIVE)  (mirror)
+        |   AnswerCall -> markAnswered(callId)  (guard)
         |   PDelegateFlutterApi.performAnswerCall(callId)
         v
 13. Dart delegate receives performAnswerCall()
@@ -137,10 +138,12 @@ Triggered when the user initiates a call from the app UI.
         |   CallkeepCore.startEstablishCall(callId)
         v
 9.  PhoneConnectionService: PhoneConnection.setActive() -> STATE_ACTIVE
+        |   broadcast: ConnectionStateChanged (connectionState = ACTIVE)
         |   broadcast: AnswerCall
         v
-10. ForegroundService receives AnswerCall broadcast
-        |   MainProcessConnectionTracker.markAnswered(callId)
+10. ForegroundService receives the broadcasts
+        |   ConnectionStateChanged -> updateState(callId, ACTIVE)  (mirror)
+        |   AnswerCall -> markAnswered(callId)  (guard)
         |   PDelegateFlutterApi.performConnected(callId)
         v
 11. Dart delegate receives performConnected()

--- a/webtrit_callkeep_android/docs/callkeep-core.md
+++ b/webtrit_callkeep_android/docs/callkeep-core.md
@@ -66,8 +66,9 @@ CallkeepCore.instance.removeConnectionEventListener(this)
 | `unregisterConnectionEvents(...)`     | Unregister a temporary receiver                          |
 
 **Global events** (routed to all `ConnectionEventListener` subscribers):
-`DidPushIncomingCall`, `DeclineCall`, `HungUp`, `ConnectionNotFound`, `AnswerCall`,
-`AudioDeviceSet`, `AudioDevicesUpdate`, `AudioMuting`, `ConnectionHolding`, `SentDTMF`.
+`DidPushIncomingCall`, `ConnectionStateChanged`, `DeclineCall`, `HungUp`, `ConnectionNotFound`,
+`AnswerCall`, `AudioDeviceSet`, `AudioDevicesUpdate`, `AudioMuting`, `ConnectionHolding`,
+`SentDTMF`.
 
 **Per-call dynamic receivers** (registered ad-hoc, not via listener):
 `OngoingCall`, `OutgoingFailure`, `IncomingFailure`, `TearDownComplete`.
@@ -81,8 +82,8 @@ reports events via `CallkeepCore`. They update `MainProcessConnectionTracker`.
 |------------------------------------|------------------------------------|---------------------------------|
 | `addPending(callId)`               | `NotifyPending` intent from CS     | Registers call as pending       |
 | `promote(callId, metadata, state)` | `DidPushIncomingCall` broadcast    | Full registration with metadata |
-| `markAnswered(callId)`             | `AnswerCall` broadcast             | Transitions to STATE_ACTIVE     |
-| `markHeld(callId, onHold)`         | `ConnectionHolding` broadcast      | Updates hold state              |
+| `markAnswered(callId)`             | `AnswerCall` broadcast             | Marks answered (guard only; no state stamp) |
+| `updateState(callId, state)`       | `ConnectionStateChanged` broadcast | Mirrors authoritative connection state (unconditional; ignores DISCONNECTED) |
 | `markTerminated(callId)`           | `HungUp` / `DeclineCall` broadcast | Moves to terminated set         |
 
 ## Command Dispatch API

--- a/webtrit_callkeep_android/docs/connection-tracker.md
+++ b/webtrit_callkeep_android/docs/connection-tracker.md
@@ -22,7 +22,7 @@ State is updated exclusively from broadcast events emitted by `PhoneConnectionSe
 | `connections`       | `ConcurrentHashMap<String, CallMetadata>`             | Non-terminated calls with full metadata                                 |
 | `connectionStates`  | `ConcurrentHashMap<String, PCallkeepConnectionState>` | Telecom state snapshot per call                                         |
 | `pendingCallIds`    | `MutableSet<String>`                                  | Calls sent to Telecom, `PhoneConnection` not yet created                |
-| `answeredCallIds`   | `MutableSet<String>`                                  | Calls that have reached STATE_ACTIVE                                    |
+| `answeredCallIds`   | `MutableSet<String>`                                  | Answer guard (calls the user answered); the ACTIVE state itself is mirrored via `updateState` |
 | `terminatedCallIds` | `MutableSet<String>`                                  | Ended calls (never removed, to detect stale events)                     |
 | `pendingAnswers`    | `MutableSet<String>`                                  | Deferred answers (user pressed answer before `PhoneConnection` existed) |
 
@@ -48,11 +48,12 @@ promote(callId, metadata, state)
     connectionStates[callId] = state
 
 markAnswered(callId)
-    answeredCallIds += callId
-    connectionStates[callId] = STATE_ACTIVE
+    answeredCallIds += callId          # guard only -- does NOT stamp connectionStates
 
-markHeld(callId, onHold)
-    connectionStates[callId] = STATE_HOLDING or STATE_ACTIVE
+updateState(callId, state)
+    connectionStates[callId] = state   # writes UNCONDITIONALLY (not gated on connections
+                                       # membership; callable before promote). DISCONNECTED
+                                       # is ignored -- terminal state is owned by markTerminated.
 
 markTerminated(callId)
     connections -= callId

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -80,8 +80,9 @@ registered `ConnectionEventListener`. `ForegroundService` does not register its 
 
 | Event                 | Handler                               | Main Action                                                              |
 |-----------------------|---------------------------------------|--------------------------------------------------------------------------|
-| `DidPushIncomingCall` | `handleCSReportDidPushIncomingCall()` | Promote call in tracker, call `performIncomingCall()` on Dart delegate   |
-| `AnswerCall`          | `handleCSReportAnswerCall()`          | `markAnswered()` in tracker, call `performAnswerCall()` on Dart delegate |
+| `DidPushIncomingCall`    | `handleCSReportDidPushIncomingCall()`    | Promote call in tracker, call `performIncomingCall()` on Dart delegate   |
+| `ConnectionStateChanged` | `handleCSReportConnectionStateChanged()` | `updateState()` -- mirror the authoritative connection state into the tracker |
+| `AnswerCall`             | `handleCSReportAnswerCall()`             | `markAnswered()` guard in tracker, call `performAnswerCall()` on Dart delegate |
 | `DeclineCall`         | `handleCSReportDeclineCall()`         | `markTerminated()`, call `performEndCall()`                              |
 | `HungUp`              | `handleCSReportDeclineCall()`         | Same as DeclineCall                                                      |
 | `ConnectionNotFound`  | `handleCSConnectionNotFound()`        | Synthesize HungUp — `performEndCall()`                                   |

--- a/webtrit_callkeep_android/docs/ipc-broadcasting.md
+++ b/webtrit_callkeep_android/docs/ipc-broadcasting.md
@@ -22,10 +22,11 @@ The event type is carried as a string extra inside the intent.
 
 | Event                 | Payload                         | Meaning                                          |
 |-----------------------|---------------------------------|--------------------------------------------------|
-| `DidPushIncomingCall` | `callId`, `CallMetadata` bundle | Incoming `PhoneConnection` created, UI shown     |
-| `AnswerCall`          | `callId`                        | Connection answered (STATE_ACTIVE)               |
-| `DeclineCall`         | `callId`                        | User rejected the call                           |
-| `HungUp`              | `callId`, disconnect cause      | Call disconnected from either side               |
+| `DidPushIncomingCall`    | `callId`, `CallMetadata` bundle              | Incoming `PhoneConnection` created, UI shown               |
+| `AnswerCall`             | `callId`                                     | Answer signal (guard); the ACTIVE state arrives separately via `ConnectionStateChanged` |
+| `ConnectionStateChanged` | `callId`, `CallMetadata` bundle (carries `connectionState`) | Authoritative live connection state to mirror into the shadow state (RINGING/DIALING/ACTIVE/HOLDING). Terminal DISCONNECTED is NOT sent here -- it stays on the cause-carrying `HungUp`/`DeclineCall`. |
+| `DeclineCall`            | `callId`                                     | User rejected the call                                     |
+| `HungUp`                 | `callId`, disconnect cause                   | Call disconnected from either side                         |
 | `OngoingCall`         | `callId`, `CallMetadata` bundle | Outgoing connection dialing                      |
 | `OutgoingFailure`     | `callId`, failure info          | Outgoing call could not be created               |
 | `IncomingFailure`     | `callId`, failure info          | Incoming call setup failed                       |

--- a/webtrit_callkeep_android/docs/models.md
+++ b/webtrit_callkeep_android/docs/models.md
@@ -26,6 +26,13 @@ The central data class describing a single call. Passed across process boundarie
 | `hasHold`          | `Boolean`           | Whether hold capability is available             |
 | `speakerOnVideo`   | `Boolean`           | Auto-route audio to speaker when video is active |
 | `ringtonePath`     | `String?`           | Custom ringtone file path (asset cache)          |
+| `connectionState`  | `CallConnectionState?` | Transient payload on `ConnectionStateChanged` events -- the live state the main process mirrors into its shadow state. Null on all other events. |
+
+`CallConnectionState` is a local domain enum (`models/CallConnectionState.kt`:
+INITIALIZING/NEW/RINGING/DIALING/ACTIVE/HOLDING/DISCONNECTED) with `fromTelecomState(Int)`. It is
+deliberately NOT the raw `android.telecom.Connection` state ints (untyped magic numbers, and the
+no-Telecom backend has no android `Connection`) nor the Pigeon-generated enum (Pigeon types stay
+out of the model layer; the Pigeon mapping happens only at the tracker boundary).
 
 ### Bundle Serialization
 

--- a/webtrit_callkeep_android/docs/phone-connection.md
+++ b/webtrit_callkeep_android/docs/phone-connection.md
@@ -67,6 +67,17 @@ Called by Telecom when the call ends (hang-up from either side).
 
 - Dispatches `SentDTMF` broadcast.
 
+### `onStateChanged(state)`
+
+Telecom-driven hook fired on every connection state transition.
+
+- Maps the raw Telecom `state` int via `CallConnectionState.fromTelecomState(state)`.
+- For live states (RINGING/DIALING/ACTIVE/HOLDING) dispatches `ConnectionStateChanged`,
+  carrying the state in `CallMetadata.connectionState` so the main process MIRRORS it into the
+  shadow state rather than inferring a fixed state per event type.
+- Terminal DISCONNECTED is skipped here -- it stays on the cause-carrying `HungUp` / `DeclineCall`
+  dispatched from `onDisconnect()` / `onReject()`.
+
 ### `onCallEndpointChanged(endpoint)` (API 34+) / legacy audio device change
 
 - Dispatches `AudioDeviceSet` broadcast with the new endpoint.


### PR DESCRIPTION
## Overview

Make `PhoneConnection.onStateChanged` the source of truth for the main-process shadow call-state, replacing the previous design that INFERRED a fixed state per cross-process lifecycle event (`DidPushIncomingCall`->RINGING, `OngoingCall`->DIALING, `AnswerCall`->ACTIVE, `ConnectionHolding`->HOLDING/ACTIVE). The real Telecom state was never broadcast; the shadow was reconstructed by hardcoding a value at each event handler. Now the real connection state is broadcast and mirrored, and the per-event inference is removed.

### Why mirror absolute state (not a transition interpreter)
The shadow singleton (`MainProcessConnectionTracker` via `CallkeepCore.instance`) is per-process, and `:callkeep_core` (where `PhoneConnection` runs) dies/restarts independently. Deriving actions from from->to transitions needs a reliable `from` + an ordered stream and is fragile across that split. Mirroring the ABSOLUTE state is idempotent and self-heals via the existing re-sync (`handleSyncConnectionState`/`onDelegateSet`). Termination keeps its own cause-carrying events (`HungUp`/`DeclineCall` preserve `DisconnectCause`) and is excluded from the mirror.

### Changes
- New local `models/CallConnectionState` enum (+`fromTelecomState`). The model stays free of the Pigeon-generated `PCallkeepConnectionState`; conversion happens only at the core boundary. A comment explains why not the raw `android.telecom.Connection.STATE_*` ints (untyped magic numbers; the no-Telecom backend has no android Connection).
- `CallMetadata.connectionState` (transient) + new `CallLifecycleEvent.ConnectionStateChanged`.
- `PhoneConnection.onStateChanged` emits `ConnectionStateChanged` for live states (RINGING/DIALING/ACTIVE/HOLDING).
- `ForegroundService` -> `core.updateState`; `MainProcessConnectionTracker.updateState` writes `connectionStates` unconditionally, so it survives an `addPending` reset and the cold-start `getState == STATE_ACTIVE` detection in `reportNewIncomingCall` keeps working (now fed by the mirror).
- Inference removed: `markAnswered` is a lifecycle guard only (no STATE_ACTIVE stamp); `markHeld` removed entirely (HOLDING/ACTIVE is mirrored; the Holding handler still relays `performSetHeld` to Flutter). `promote` keeps its initial registration snapshot; the mirror owns all subsequent transitions.
- No-Telecom parity: `StandaloneCallService` has no `onStateChanged`, so it emits `ConnectionStateChanged` explicitly at answer / hold / state re-sync.

### Verification
- `./gradlew testDebugUnitTest` + `flutter analyze` + `flutter test` green; tests updated for the new behavior (markHeld tests removed; markAnswered/lifecycle/updateState tests adjusted).
- Example integration suite on device (Xiaomi 25028RN03Y / Android 15, `all_tests.dart`): **155 passed / 6 skipped / 0 failed** — incl. state_machine (answer->hold->mute->unhold->end, two-call hold swap), background_services (cold-start / push / handoff / tearDown), connections, lifecycle, reportendcall_reasons.
- Draft: a targeted manual repro of the push->foreground handoff + caller-cancel remains advisable before merge.

### Relation to other PRs
Touches `PhoneConnection`/`PhoneConnectionService`/`ForegroundService`, the same area as the incoming-call adoption fix (#324, draft). Coordinate merge order / rebase.