### PR TITLE
refactor(android): rename SyncConnectionState to ReplayConnectionStates

### DIFF
--- a/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
+++ b/webtrit_callkeep/example/integration_test/callkeep_foreground_service_test.dart
@@ -468,7 +468,7 @@ void main() {
   // =========================================================================
   // cold-start adoption — CALL_ID_ALREADY_EXISTS_AND_ANSWERED branch
   //
-  // Regression for the cold-start race where SyncConnectionState fires
+  // Regression for the cold-start race where ReplayConnectionStates fires
   // handleCSReportAnswerCall during ForegroundService.onCreate, marking the
   // call as answered in the main-process tracker BEFORE reportNewIncomingCall
   // arrives from the signaling layer (CallBloc.__onCallSignalingEventIncoming).
@@ -506,7 +506,7 @@ void main() {
       await waitFor(firstAnswerLatch.future, label: 'performAnswerCall (first)');
 
       // Simulate the signaling layer re-reporting the already-answered call
-      // (cold-start: reportNewIncomingCall arrives after SyncConnectionState
+      // (cold-start: reportNewIncomingCall arrives after ReplayConnectionStates
       // already marked the call answered). The ALREADY_ANSWERED branch must
       // fire performAnswerCall directly to trigger WebRTC setup.
       final adoptLatch = Completer<void>();

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
@@ -155,12 +155,12 @@ class CallServiceRouter(
             },
         )
 
-    fun sendSyncConnectionState() =
+    fun replayConnectionStates() =
         route(
-            telecom = { PhoneConnectionService.sendSyncConnectionState(ctx) },
+            telecom = { PhoneConnectionService.replayConnectionStates(ctx) },
             standalone = {
                 if (StandaloneCallService.isRunning) {
-                    StandaloneCallService.communicate(ctx, StandaloneServiceAction.SyncConnectionState, null)
+                    StandaloneCallService.communicate(ctx, StandaloneServiceAction.ReplayConnectionStates, null)
                 }
             },
         )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -319,13 +319,16 @@ interface CallkeepCore {
     fun sendSyncAudioState()
 
     /**
-     * Sends [ServiceAction.SyncConnectionState] to [PhoneConnectionService].
-     * The service re-fires [CallLifecycleEvent.AnswerCall] for every connection whose
-     * [PhoneConnection.hasAnswered] flag is true. Called from [ForegroundService.onCreate] so
-     * that connections answered before the main process started are reflected in
-     * [MainProcessConnectionTracker.connectionStates].
+     * Asks [PhoneConnectionService] to REPLAY the current connection lifecycle back to the main
+     * process, so a freshly (re)attached delegate is seeded with state it would otherwise have
+     * missed. This is a one-way pull (main -> `:callkeep_core` -> re-fired broadcasts), NOT a
+     * two-way sync: the live `:callkeep_core` connections are the source of truth and simply
+     * re-announce themselves. The service re-fires [CallLifecycleEvent.AnswerCall] for every
+     * connection whose [PhoneConnection.hasAnswered] flag is true. Called from
+     * [ForegroundService.onCreate] so that connections answered before the main process started
+     * are reflected in [MainProcessConnectionTracker.connectionStates] (cold-start race).
      */
-    fun sendSyncConnectionState()
+    fun replayConnectionStates()
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -329,7 +329,7 @@ class InProcessCallkeepCore internal constructor(
 
     override fun sendSyncAudioState() = router.sendSyncAudioState()
 
-    override fun sendSyncConnectionState() = router.sendSyncConnectionState()
+    override fun replayConnectionStates() = router.replayConnectionStates()
 
     companion object {
         private const val TAG = "InProcessCallkeepCore"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
@@ -16,7 +16,7 @@ enum class ServiceAction {
     ReserveAnswer,
     CleanConnections,
     SyncAudioState,
-    SyncConnectionState,
+    ReplayConnectionStates,
     NotifyPending,
     ;
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -140,8 +140,8 @@ class PhoneConnectionService : ConnectionService() {
                     handleSyncAudioState()
                 }
 
-                is PhoneServiceCommand.SyncConnection -> {
-                    handleSyncConnectionState()
+                is PhoneServiceCommand.ReplayConnections -> {
+                    handleReplayConnectionStates()
                 }
 
                 is PhoneServiceCommand.CallOp -> {
@@ -483,8 +483,8 @@ class PhoneConnectionService : ConnectionService() {
         connectionManager.getConnections().forEach { it.forceUpdateAudioState() }
     }
 
-    private fun handleSyncConnectionState() {
-        Log.i(TAG, "handleSyncConnectionState: re-emitting lifecycle state for answered connections")
+    private fun handleReplayConnectionStates() {
+        Log.i(TAG, "handleReplayConnectionStates: re-emitting lifecycle state for answered connections")
         connectionManager.getConnections().forEach { connection ->
             if (connection.hasAnswered) {
                 performEventHandle(CallLifecycleEvent.AnswerCall, CallMetadata(callId = connection.callId))
@@ -707,19 +707,19 @@ class PhoneConnectionService : ConnectionService() {
         }
 
         /**
-         * Sends [ServiceAction.SyncConnectionState] to [PhoneConnectionService].
+         * Sends [ServiceAction.ReplayConnectionStates] to [PhoneConnectionService].
          * The service will re-fire [CallLifecycleEvent.AnswerCall] for every connection whose
          * [PhoneConnection.hasAnswered] flag is true. This lets the main process
          * ([ForegroundService]) populate [MainProcessConnectionTracker.connectionStates] even
          * when it starts after the AnswerCall broadcast was originally emitted (cold-start race).
          */
-        fun sendSyncConnectionState(context: Context) {
+        fun replayConnectionStates(context: Context) {
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
-                    action = ServiceAction.SyncConnectionState.action
+                    action = ServiceAction.ReplayConnectionStates.action
                 }
             runCatching { context.startService(intent) }
-                .onFailure { e -> Log.w(TAG, "sendSyncConnectionState: startService failed: $e") }
+                .onFailure { e -> Log.w(TAG, "replayConnectionStates: startService failed: $e") }
         }
 
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
@@ -12,7 +12,7 @@ import com.webtrit.callkeep.models.CallMetadata
  * `CallMetadata.fromBundle` was invoked on the bare intent extras BEFORE the surrounding
  * try/catch: Binder IPC can deliver a non-null but empty [android.os.Bundle] for the no-extras
  * lifecycle commands ([ServiceAction.TearDownConnections], [ServiceAction.CleanConnections],
- * [ServiceAction.SyncAudioState], [ServiceAction.SyncConnectionState]), and the missing-`callId`
+ * [ServiceAction.SyncAudioState], [ServiceAction.ReplayConnectionStates]), and the missing-`callId`
  * `IllegalArgumentException` then propagated uncaught out of `onStartCommand`.
  *
  * With this factory each command type owns exactly the data it needs:
@@ -27,7 +27,7 @@ sealed class PhoneServiceCommand {
 
     data object SyncAudio : PhoneServiceCommand()
 
-    data object SyncConnection : PhoneServiceCommand()
+    data object ReplayConnections : PhoneServiceCommand()
 
     data class Reserve(
         val callId: String,
@@ -63,8 +63,8 @@ sealed class PhoneServiceCommand {
                     SyncAudio
                 }
 
-                ServiceAction.SyncConnectionState -> {
-                    SyncConnection
+                ServiceAction.ReplayConnectionStates -> {
+                    ReplayConnections
                 }
 
                 ServiceAction.ReserveAnswer -> {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -53,7 +53,7 @@ class StandaloneCallService : Service() {
 
     // Tracks whether startForeground() has been called in this service instance.
     // startForeground() is deferred until an actual call is handled so that lifecycle-only
-    // commands (SyncConnectionState, SyncAudioState, etc.) do not post a foreground
+    // commands (ReplayConnectionStates, SyncAudioState, etc.) do not post a foreground
     // notification when there is no call in progress.
     private var isForeground = false
 
@@ -77,7 +77,7 @@ class StandaloneCallService : Service() {
         Log.initFromContext(applicationContext)
         // Register notification channels here as well as in ForegroundService.setUp().
         // This service may start before setUp() is invoked from the Flutter layer
-        // (e.g. when SyncConnectionState is dispatched during app startup). Without this
+        // (e.g. when ReplayConnectionStates is dispatched during app startup). Without this
         // call, startForeground() would crash with
         // CannotPostForegroundServiceNotificationException because the channel does not
         // yet exist in the system.
@@ -147,7 +147,7 @@ class StandaloneCallService : Service() {
                 is StandaloneServiceCommand.TearDown -> handleTearDownConnections()
                 is StandaloneServiceCommand.Clean -> handleCleanConnections()
                 is StandaloneServiceCommand.SyncAudio -> handleSyncAudioState()
-                is StandaloneServiceCommand.SyncConnection -> handleSyncConnectionState()
+                is StandaloneServiceCommand.ReplayConnections -> handleReplayConnectionStates()
                 is StandaloneServiceCommand.Reserve -> handleReserveAnswer(command.callId)
                 is StandaloneServiceCommand.Call -> dispatchCall(command.action, command.metadata)
             }
@@ -156,7 +156,7 @@ class StandaloneCallService : Service() {
         }
 
         // If no calls are active or pending after processing, there is nothing to keep alive.
-        // This handles the case where a lifecycle-only command (SyncConnectionState,
+        // This handles the case where a lifecycle-only command (ReplayConnectionStates,
         // SyncAudioState, CleanConnections) starts the service when no call is in progress.
         stopIfIdle()
 
@@ -230,7 +230,7 @@ class StandaloneCallService : Service() {
             StandaloneServiceAction.CleanConnections,
             StandaloneServiceAction.ReserveAnswer,
             StandaloneServiceAction.SyncAudioState,
-            StandaloneServiceAction.SyncConnectionState,
+            StandaloneServiceAction.ReplayConnectionStates,
             -> Log.w(TAG, "dispatchCall: unexpected non-call action $action, ignoring")
         }
     }
@@ -537,8 +537,8 @@ class StandaloneCallService : Service() {
         answeredCallIds.forEach { callId -> fireInitialAudioState(callId) }
     }
 
-    private fun handleSyncConnectionState() {
-        Log.i(TAG, "handleSyncConnectionState: re-emitting AnswerCall + ACTIVE state for answered calls")
+    private fun handleReplayConnectionStates() {
+        Log.i(TAG, "handleReplayConnectionStates: re-emitting AnswerCall + ACTIVE state for answered calls")
         answeredCallIds.forEach { callId ->
             val meta = callMetadataMap[callId] ?: CallMetadata(callId = callId)
             core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, meta.toBundle())
@@ -760,7 +760,7 @@ enum class StandaloneServiceAction {
     Speaker,
     AudioDeviceSet,
     SyncAudioState,
-    SyncConnectionState,
+    ReplayConnectionStates,
     ;
 
     val action: String get() = "callkeep_standalone_$name"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
@@ -10,7 +10,7 @@ import com.webtrit.callkeep.models.CallMetadata
  * Mirrors [PhoneServiceCommand] for the non-Telecom path. Parsing is done once in [from] so the
  * [CallMetadata] extraction never runs for the no-extras lifecycle commands
  * ([StandaloneServiceAction.TearDownConnections], [StandaloneServiceAction.CleanConnections],
- * [StandaloneServiceAction.SyncAudioState], [StandaloneServiceAction.SyncConnectionState]). This
+ * [StandaloneServiceAction.SyncAudioState], [StandaloneServiceAction.ReplayConnectionStates]). This
  * closes the same latent crash as on the Telecom path: a Binder-delivered empty
  * [android.os.Bundle] would otherwise reach `CallMetadata.fromBundle` and throw an uncaught
  * `IllegalArgumentException`.
@@ -24,7 +24,7 @@ sealed class StandaloneServiceCommand {
 
     data object SyncAudio : StandaloneServiceCommand()
 
-    data object SyncConnection : StandaloneServiceCommand()
+    data object ReplayConnections : StandaloneServiceCommand()
 
     data class Reserve(
         val callId: String,
@@ -56,8 +56,8 @@ sealed class StandaloneServiceCommand {
                     SyncAudio
                 }
 
-                StandaloneServiceAction.SyncConnectionState -> {
-                    SyncConnection
+                StandaloneServiceAction.ReplayConnectionStates -> {
+                    ReplayConnections
                 }
 
                 StandaloneServiceAction.ReserveAnswer -> {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
@@ -80,7 +80,7 @@ class PhoneConnectionServiceDispatcher(
             ServiceAction.NotifyPending,
             ServiceAction.CleanConnections,
             ServiceAction.SyncAudioState,
-            ServiceAction.SyncConnectionState,
+            ServiceAction.ReplayConnectionStates,
             -> logger.w("dispatch: unexpected IPC command action: $action")
         }
     }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -192,7 +192,7 @@ class ForegroundService :
         // notification button before the main process/Flutter opens). The re-fired broadcast
         // populates connectionStates so that the CALL_ID_ALREADY_EXISTS handler in
         // reportNewIncomingCall can correctly identify the call as STATE_ACTIVE.
-        core.sendSyncConnectionState()
+        core.replayConnectionStates()
     }
 
     override fun setUp(
@@ -453,7 +453,7 @@ class ForegroundService :
         logger.i("reportNewIncomingCall: callId=$callId, handle=$handle")
 
         // Build metadata before the early check so we can promote the call into the core shadow
-        // tracker even when the call is already answered (cold-start race: SyncConnectionState
+        // tracker even when the call is already answered (cold-start race: ReplayConnectionStates
         // fires handleCSReportAnswerCall during onCreate, marking the call answered before
         // reportNewIncomingCall arrives from the signaling layer).
         val ringtonePath = StorageDelegate.Sound.getRingtonePath(baseContext)

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -499,7 +499,7 @@ class MainProcessConnectionTrackerTest {
     // -------------------------------------------------------------------------
     // cold-start race: markAnswered before addPending/promote
     //
-    // Reproduces the scenario where SyncConnectionState fires
+    // Reproduces the scenario where ReplayConnectionStates fires
     // handleCSReportAnswerCall during ForegroundService.onCreate (marking the
     // call answered via markAnswered) before reportNewIncomingCall arrives
     // from the signaling layer and calls addPending/promote.
@@ -512,7 +512,7 @@ class MainProcessConnectionTrackerTest {
 
     @Test
     fun `cold-start — markAnswered without prior promote — isAnswered returns true`() {
-        // SyncConnectionState calls markAnswered before the call is registered in the
+        // ReplayConnectionStates calls markAnswered before the call is registered in the
         // tracker. The early check in reportNewIncomingCall must detect this.
         tracker.markAnswered("call-1")
         assertTrue(tracker.isAnswered("call-1"))
@@ -556,7 +556,7 @@ class MainProcessConnectionTrackerTest {
     @Test
     fun `cold-start — full fix sequence — promote then markAnswered leaves tracker consistent`() {
         // Verifies the exact sequence executed by the ALREADY_ANSWERED branch fix:
-        //   1. markAnswered()           <- SyncConnectionState (cold-start)
+        //   1. markAnswered()           <- ReplayConnectionStates (cold-start)
         //   2. promote(STATE_ACTIVE)    <- fix step 1
         //   3. markAnswered()           <- fix step 2 (re-mark after promote clears it)
         //   4. markReportedIncoming()  <- fix step 3

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
@@ -45,8 +45,8 @@ class ServiceCommandTest {
         assertEquals(PhoneServiceCommand.Clean, PhoneServiceCommand.from(intent(ServiceAction.CleanConnections.action, null)))
         assertEquals(PhoneServiceCommand.SyncAudio, PhoneServiceCommand.from(intent(ServiceAction.SyncAudioState.action, null)))
         assertEquals(
-            PhoneServiceCommand.SyncConnection,
-            PhoneServiceCommand.from(intent(ServiceAction.SyncConnectionState.action, null)),
+            PhoneServiceCommand.ReplayConnections,
+            PhoneServiceCommand.from(intent(ServiceAction.ReplayConnectionStates.action, null)),
         )
     }
 

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -201,9 +201,9 @@ When Flutter hot-restarts (development only) the main process Flutter engine is 
 2.  WebtritCallkeepPlugin.onAttachedToEngine()
         |
         v
-3.  ForegroundService.syncConnectionState()
+3.  ForegroundService.replayConnectionStates()
         |   CallkeepCore.sendSyncAudioState()    -> PhoneConnectionService re-emits audio state
-        |   CallkeepCore.sendSyncConnectionState() -> PhoneConnectionService re-fires AnswerCall
+        |   CallkeepCore.replayConnectionStates() -> PhoneConnectionService re-fires AnswerCall
         v
 4.  ForegroundService broadcast handlers receive re-emitted events
         |   MainProcessConnectionTracker updated

--- a/webtrit_callkeep_android/docs/callkeep-core.md
+++ b/webtrit_callkeep_android/docs/callkeep-core.md
@@ -119,7 +119,7 @@ These send intents / broadcasts to `PhoneConnectionService` in `:callkeep_core`.
 | `sendTearDownConnections(ctx)`   | `startService` intent (`TearDownConnections`) | Hang up all + await `TearDownComplete` broadcast |
 | `sendReserveAnswer(ctx, callId)` | `startService` intent                         | Deferred answer for pending call                 |
 | `sendSyncAudioState(ctx)`        | `startService` intent                         | Re-emit audio state after hot-restart            |
-| `sendSyncConnectionState(ctx)`   | `startService` intent                         | Re-emit connection state after hot-restart       |
+| `replayConnectionStates(ctx)`   | `startService` intent                         | Replay connection lifecycle to a freshly attached delegate (cold-start/hot-restart) |
 
 ## Related Components
 

--- a/webtrit_callkeep_android/docs/dual-process.md
+++ b/webtrit_callkeep_android/docs/dual-process.md
@@ -51,7 +51,7 @@ Used for **commands** where delivery must be guaranteed (broadcasts can be dropp
 is not yet registered).
 
 - main → `:callkeep_core` commands: `TearDownConnections`, `ReserveAnswer`, `CleanConnections`,
-  `SyncAudioState`, `SyncConnectionState`, and per-call commands (`AnswerCall`, `DeclineCall`,
+  `SyncAudioState`, `ReplayConnectionStates`, and per-call commands (`AnswerCall`, `DeclineCall`,
   `HungUpCall`, `EstablishCall`, `UpdateCall`, `MuteCall`, `HoldCall`, `SpeakerCall`,
   `SetAudioDevice`, `SendDtmf`).
 - `:callkeep_core` → main: `NotifyPending` (incoming call pending before PhoneConnection exists).
@@ -67,8 +67,8 @@ Because the two processes have independent JVM heaps, call state must be explici
 - `:callkeep_core` maintains `ConnectionManager` (
   see [connection-manager.md](connection-manager.md))
   — the authoritative registry of live `PhoneConnection` objects.
-- On app hot-restart, `ForegroundService.syncConnectionState()` sends `SyncAudioState` and
-  `SyncConnectionState` commands so `:callkeep_core` re-fires its current state to a freshly
+- On app hot-restart, `ForegroundService.replayConnectionStates()` sends `SyncAudioState` and
+  `ReplayConnectionStates` commands so `:callkeep_core` re-fires its current state to a freshly
   attached Flutter engine.
 
 ## Critical Rules

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -25,8 +25,9 @@
 
 - Calls `CallkeepCore.instance.addConnectionEventListener(this)` to subscribe to all
   `:callkeep_core` events routed through the core's single global receiver.
-- Sends `SyncConnectionState` command to `:callkeep_core` — if the service was killed and
-  restarted, `:callkeep_core` re-emits current connection state so the main process catches up.
+- Sends the `ReplayConnectionStates` command to `:callkeep_core` — when the main process starts
+  fresh (cold start / hot restart), `:callkeep_core` replays (re-fires) its current connection
+  lifecycle so the freshly attached delegate catches up on state it missed.
 
 ### `onBind(intent)`
 

--- a/webtrit_callkeep_android/docs/phone-connection-service.md
+++ b/webtrit_callkeep_android/docs/phone-connection-service.md
@@ -77,7 +77,7 @@ encoded as a string extra.
 | `ReserveAnswer`       | Store deferred answer for `callId` (call `ConnectionManager.reserveAnswer()`)      |
 | `CleanConnections`    | Clear all connections without hanging up                                           |
 | `SyncAudioState`      | Re-emit audio state for all active connections (hot-restart recovery)              |
-| `SyncConnectionState` | Re-fire `AnswerCall` broadcast for all answered connections (hot-restart recovery) |
+| `ReplayConnectionStates` | Re-fire `AnswerCall` broadcast for all answered connections (hot-restart recovery) |
 | `AnswerCall`          | Call `PhoneConnection.onAnswer()` for the specified call                           |
 | `DeclineCall`         | Call `PhoneConnection.onReject()`                                                  |
 | `HungUpCall`          | Call `PhoneConnection.onDisconnect()`                                              |


### PR DESCRIPTION
## Overview

The `SyncConnectionState` command and its plumbing were misnamed "sync". It is not a two-way
reconciliation: it is a one-way pull where the main process, on a fresh start, asks
`:callkeep_core` to **replay** (re-fire) its current connection lifecycle so a freshly attached
Flutter delegate is seeded with state it would otherwise have missed. The live `:callkeep_core`
connections remain the single source of truth and simply re-announce themselves.

This renames the command and the whole call chain to convey that intent. Behaviour is unchanged.

## Changes

- `CallkeepCore` / `InProcessCallkeepCore` / `CallServiceRouter`: `sendSyncConnectionState` -> `replayConnectionStates`
- `PhoneConnectionService`: companion `sendSyncConnectionState` -> `replayConnectionStates`; `handleSyncConnectionState` -> `handleReplayConnectionStates` (same in `StandaloneCallService`)
- `ServiceAction` / `StandaloneServiceAction`: `SyncConnectionState` -> `ReplayConnectionStates`
- `PhoneServiceCommand` / `StandaloneServiceCommand`: `SyncConnection` -> `ReplayConnections` (keeps the existing "command = shortened action" pattern)
- KDoc / comments / log tags updated; clarified the one-way replay semantics
- `docs/` references updated (dual-process, call-flows, callkeep-core, phone-connection-service, foreground-service)

`SyncAudioState` is a separate feature (audio re-emit) and is intentionally untouched.

## Notes

- The action string is app-scoped (`callkeep_<name>`) and both processes ship in the same APK, so renaming the enum is safe (no cross-version IPC contract).
- No behaviour change. Gradle unit tests + analyze + flutter test green.
- Touches the same files as the open delegate-attach fix branch; that branch will be rebased after this lands.
