### PR TITLE
fix(android): replay connection state on delegate attach, not on service create

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -187,12 +187,9 @@ class ForegroundService :
         logger.d("onCreate")
         core.addConnectionEventListener(this)
         isRunning = true
-        // Ask :callkeep_core to re-fire AnswerCall for every connection that was already
-        // answered before this service started (cold-start race: the user answers via the
-        // notification button before the main process/Flutter opens). The re-fired broadcast
-        // populates connectionStates so that the CALL_ID_ALREADY_EXISTS handler in
-        // reportNewIncomingCall can correctly identify the call as STATE_ACTIVE.
-        core.replayConnectionStates()
+        // Connection-state replay is triggered from onDelegateSet() (the deterministic
+        // "delegate ready" signal), not here: at onCreate the Flutter delegate is not yet
+        // attached, so a replay fired now would only race the attach.
     }
 
     override fun setUp(
@@ -454,7 +451,7 @@ class ForegroundService :
 
         // Build metadata before the early check so we can promote the call into the core shadow
         // tracker even when the call is already answered (cold-start race: ReplayConnectionStates
-        // fires handleCSReportAnswerCall during onCreate, marking the call answered before
+        // fires handleCSReportAnswerCall on delegate attach, marking the call answered before
         // reportNewIncomingCall arrives from the signaling layer).
         val ringtonePath = StorageDelegate.Sound.getRingtonePath(baseContext)
 
@@ -1218,11 +1215,19 @@ class ForegroundService :
      * foreground and re-establishes its communication channel with this service.
      */
     override fun onDelegateSet() {
-        logger.d("onDelegateSet: Flutter delegate attached. Checking for active connections to restore...")
-        val connections = core.getAll()
+        logger.d("onDelegateSet: Flutter delegate attached. Replaying connection state...")
 
+        // Replay the current connection lifecycle now that the delegate is attached and GUARANTEED
+        // to receive the re-fired events. This is the single replay trigger: it fires only once the
+        // Flutter delegate is ready (so re-delivery is not raced/dropped) and on every attach,
+        // including a warm engine re-attach. It is deliberately NOT gated on the local tracker
+        // below: in a push->foreground handoff the main process has no record of the call yet --
+        // the replay from :callkeep_core is exactly what surfaces it to the freshly attached engine.
+        core.replayConnectionStates()
+
+        val connections = core.getAll()
         if (connections.isEmpty()) {
-            Log.d(TAG, "onDelegateSet: No active connections found.")
+            Log.d(TAG, "onDelegateSet: no locally tracked connections; audio re-sync skipped.")
             return
         }
 

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -25,13 +25,24 @@
 
 - Calls `CallkeepCore.instance.addConnectionEventListener(this)` to subscribe to all
   `:callkeep_core` events routed through the core's single global receiver.
-- Sends the `ReplayConnectionStates` command to `:callkeep_core` — when the main process starts
-  fresh (cold start / hot restart), `:callkeep_core` replays (re-fires) its current connection
-  lifecycle so the freshly attached delegate catches up on state it missed.
+- Does NOT replay connection state: at `onCreate` the Flutter delegate is not yet attached, so a
+  replay fired here would only race the attach. Replay is triggered from `onDelegateSet()`.
 
 ### `onBind(intent)`
 
 - Returns the `IBinder` that `WebtritCallkeepPlugin` uses to obtain the service reference.
+
+### `onDelegateSet()`
+
+- Pigeon callback invoked from Dart (`setDelegate`) once the Flutter delegate is attached and ready
+  to receive events — the deterministic "delegate ready" signal (fires on every attach, including a
+  warm engine re-attach).
+- Sends `ReplayConnectionStates` (ungated) so `:callkeep_core` replays the connection lifecycle to
+  the now-attached delegate: re-fired lifecycle events both repopulate the main-process shadow
+  tracker (`connectionStates`, e.g. for the `CALL_ID_ALREADY_EXISTS` dedup in
+  `reportNewIncomingCall`) and reach Flutter. This is the single, delegate-ready replay point.
+- Then, if the tracker knows of any connections, sends `SyncAudioState` to re-emit audio
+  device/mute state for the Flutter UI.
 
 ### `onDestroy()`
 


### PR DESCRIPTION
## Overview

`replayConnectionStates()` (the command that asks `:callkeep_core` to re-fire its current
connection lifecycle so the main process / Flutter catches up) ran in
`ForegroundService.onCreate()`. But `onCreate()` fires BEFORE the Flutter delegate is attached: the
native `flutterDelegateApi` is set later, on service bind (`WebtritCallkeepPlugin.onServiceConnected`),
and the Dart receiver is registered in `setDelegate`. So the re-fired events that target the
delegate (e.g. a still-ringing incoming call re-delivered to the engine) only reached Flutter by
winning a race against the delegate attach — and could be silently dropped (`flutterDelegateApi?.`).
`onCreate()` also does not run again on a warm engine re-attach.

This moves the replay to `onDelegateSet()` — the deterministic "delegate ready" signal
(Dart `setDelegate` -> `onDelegateSet`), which fires on every attach, including warm re-attach. It
mirrors where audio re-sync (`SyncAudioState`) already lives, making it the single, delegate-ready
replay point.

## Changes

- `ForegroundService.onDelegateSet()`: call `core.replayConnectionStates()` **ungated** (before the
  local-tracker `isEmpty` early-return), because in a push->foreground handoff the main process has
  no record of the call yet — the replay from `:callkeep_core` is what surfaces it.
- `ForegroundService.onCreate()`: remove the replay call (it fired before the delegate existed).
- `docs/foreground-service.md`: document the single delegate-ready replay point.

## Notes

- The re-fired `AnswerCall` still repopulates the shadow tracker (`markAnswered`) for the cold-start
  `CALL_ID_ALREADY_EXISTS` dedup in `reportNewIncomingCall` — now driven from the delegate-ready
  point. The bloc calls `setDelegate` (-> `onDelegateSet`) in its constructor before any handler can
  call `reportNewIncomingCall`, and host calls are FIFO on the channel, so the replay is kicked
  first; it remains an async cross-process round-trip.
- Replay is idempotent: `markAnswered` is a guard set, `updateState` is idempotent,
  `didPushIncomingCall` is deduped by callId on the Flutter side, `performAnswerCall` is idempotent.
- Makes the still-ringing-incoming re-delivery on the delegate-attach fix branch deterministic
  instead of timing-dependent.
- Gradle unit tests + analyze + flutter test green.
