### PR TITLE
refactor(android): drop redundant tracker guard before audio re-sync in onDelegateSet

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1225,15 +1225,13 @@ class ForegroundService :
         // the replay from :callkeep_core is exactly what surfaces it to the freshly attached engine.
         core.replayConnectionStates()
 
-        val connections = core.getAll()
-        if (connections.isEmpty()) {
-            Log.d(TAG, "onDelegateSet: no locally tracked connections; audio re-sync skipped.")
-            return
-        }
-
-        // Ask :callkeep_core to re-emit audio state (device + mute) for all active connections.
+        // Ask :callkeep_core to re-emit audio state (device + mute) for any active connections.
         // PhoneConnection.forceUpdateAudioState() runs in the :callkeep_core process and sends
         // CallMediaEvent broadcasts back to the main process, which updates the Flutter UI.
+        // Not gated on the main-process tracker: handleSyncAudioState() iterates the live
+        // :callkeep_core connections, so it is already a no-op when there are none -- and the
+        // local tracker is transiently empty right after the replay above (and during a
+        // push->foreground handoff), which would otherwise skip the re-sync exactly when needed.
         core.sendSyncAudioState()
     }
 

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -41,8 +41,9 @@
   the now-attached delegate: re-fired lifecycle events both repopulate the main-process shadow
   tracker (`connectionStates`, e.g. for the `CALL_ID_ALREADY_EXISTS` dedup in
   `reportNewIncomingCall`) and reach Flutter. This is the single, delegate-ready replay point.
-- Then, if the tracker knows of any connections, sends `SyncAudioState` to re-emit audio
-  device/mute state for the Flutter UI.
+- Also sends `SyncAudioState` to re-emit audio device/mute state for the Flutter UI. Not gated on
+  the main-process tracker: the `:callkeep_core` handler iterates its live connections (a no-op when
+  there are none), and the local tracker is transiently empty right after the replay above.
 
 ### `onDestroy()`
 


### PR DESCRIPTION
## Overview

`onDelegateSet()` guarded the audio re-sync with an early-return on
`core.getAll().isEmpty()`. That guard is redundant and slightly wrong:

- **Redundant**: `sendSyncAudioState()` ultimately runs `handleSyncAudioState()` in
  `:callkeep_core`, which iterates its own live connections
  (`connectionManager.getConnections()` / `answeredCallIds`). With no connections it is already a
  no-op, so pre-checking is pointless.
- **Slightly wrong**: the guard reads the main-process shadow tracker, which is transiently empty
  right after `replayConnectionStates()` (an async cross-process round-trip) and during a
  push->foreground handoff (`:callkeep_core` has the call, the main tracker has not learned of it
  yet). So it would skip the audio re-sync exactly when a call exists.

## Changes

- `ForegroundService.onDelegateSet()`: remove the `getAll().isEmpty()` early-return; call
  `sendSyncAudioState()` unconditionally.
- `docs/foreground-service.md`: reflect the ungated audio re-sync.

## Notes

- Cost is one extra cheap `startService` intent to a `:callkeep_core` process that
  `replayConnectionStates()` already woke on the line above; no foreground notification, no-op when
  idle.
- Gradle unit tests + analyze + flutter test green.
