### PR TITLE
refactor(android): rename SyncAudioState to ReplayAudioState

### DIFF
--- a/webtrit_callkeep_android/AGENTS.md
+++ b/webtrit_callkeep_android/AGENTS.md
@@ -80,7 +80,7 @@ explicit `startService` intents. Events are grouped by broadcaster:
 | `TearDownComplete`    | `:callkeep_core` -> Main | --       | Ack that tearDown completed                                                                                                                              |
 | `ReserveAnswer`       | Main -> `:callkeep_core` | `callId` | Deferred answer reservation cross-process                                                                                                                |
 | `CleanConnections`    | Main -> `:callkeep_core` | --       | Clear all connections without `hungUp()`                                                                                                                 |
-| `SyncAudioState`      | Main -> `:callkeep_core` | --       | Ask all PhoneConnections to re-emit audio device + mute state; used by `ForegroundService.onDelegateSet()` to restore Flutter audio UI after hot restart |
+| `ReplayAudioState`      | Main -> `:callkeep_core` | --       | Ask all PhoneConnections to re-emit audio device + mute state; used by `ForegroundService.onDelegateSet()` to restore Flutter audio UI after hot restart |
 
 ---
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallServiceRouter.kt
@@ -145,12 +145,12 @@ class CallServiceRouter(
             standalone = { StandaloneCallService.communicate(ctx, StandaloneServiceAction.CleanConnections, null) },
         )
 
-    fun sendSyncAudioState() =
+    fun replayAudioState() =
         route(
-            telecom = { PhoneConnectionService.sendSyncAudioState(ctx) },
+            telecom = { PhoneConnectionService.replayAudioState(ctx) },
             standalone = {
                 if (StandaloneCallService.isRunning) {
-                    StandaloneCallService.communicate(ctx, StandaloneServiceAction.SyncAudioState, null)
+                    StandaloneCallService.communicate(ctx, StandaloneServiceAction.ReplayAudioState, null)
                 }
             },
         )

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -311,12 +311,13 @@ interface CallkeepCore {
     fun sendCleanConnections()
 
     /**
-     * Sends [ServiceAction.SyncAudioState] to [PhoneConnectionService].
-     * The service re-emits audio device and mute state for all active connections back to the
-     * main process via broadcasts. Called from [ForegroundService.onDelegateSet] to restore
-     * Flutter audio UI after hot restart.
+     * Asks [PhoneConnectionService] to REPLAY the current audio state (device + mute) for all
+     * active connections back to the main process via broadcasts -- a one-way pull, not a two-way
+     * sync. Called from [ForegroundService.onDelegateSet] to restore the Flutter audio UI once a
+     * freshly attached delegate is ready (cold start / hot restart / warm re-attach). The sibling
+     * of [replayConnectionStates].
      */
-    fun sendSyncAudioState()
+    fun replayAudioState()
 
     /**
      * Asks [PhoneConnectionService] to REPLAY the current connection lifecycle back to the main

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -327,7 +327,7 @@ class InProcessCallkeepCore internal constructor(
 
     override fun sendCleanConnections() = router.sendCleanConnections()
 
-    override fun sendSyncAudioState() = router.sendSyncAudioState()
+    override fun replayAudioState() = router.replayAudioState()
 
     override fun replayConnectionStates() = router.replayConnectionStates()
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionEnums.kt
@@ -15,7 +15,7 @@ enum class ServiceAction {
     TearDownConnections,
     ReserveAnswer,
     CleanConnections,
-    SyncAudioState,
+    ReplayAudioState,
     ReplayConnectionStates,
     NotifyPending,
     ;

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -136,8 +136,8 @@ class PhoneConnectionService : ConnectionService() {
                     handleCleanConnections()
                 }
 
-                is PhoneServiceCommand.SyncAudio -> {
-                    handleSyncAudioState()
+                is PhoneServiceCommand.ReplayAudio -> {
+                    handleReplayAudioState()
                 }
 
                 is PhoneServiceCommand.ReplayConnections -> {
@@ -478,8 +478,8 @@ class PhoneConnectionService : ConnectionService() {
         connectionManager.cleanConnections()
     }
 
-    private fun handleSyncAudioState() {
-        Log.i(TAG, "handleSyncAudioState: re-emitting audio state for all active connections")
+    private fun handleReplayAudioState() {
+        Log.i(TAG, "handleReplayAudioState: re-emitting audio state for all active connections")
         connectionManager.getConnections().forEach { it.forceUpdateAudioState() }
     }
 
@@ -692,18 +692,18 @@ class PhoneConnectionService : ConnectionService() {
         }
 
         /**
-         * Sends [ServiceAction.SyncAudioState] to [PhoneConnectionService].
+         * Sends [ServiceAction.ReplayAudioState] to [PhoneConnectionService].
          * The service will call [PhoneConnection.forceUpdateAudioState] on all active connections,
          * which re-emits audio device and mute state broadcasts back to the main process.
          * Used by [ForegroundService.onDelegateSet] to restore Flutter UI after hot restart.
          */
-        fun sendSyncAudioState(context: Context) {
+        fun replayAudioState(context: Context) {
             val intent =
                 Intent(context, PhoneConnectionService::class.java).apply {
-                    action = ServiceAction.SyncAudioState.action
+                    action = ServiceAction.ReplayAudioState.action
                 }
             runCatching { context.startService(intent) }
-                .onFailure { e -> Log.w(TAG, "sendSyncAudioState: startService failed: $e") }
+                .onFailure { e -> Log.w(TAG, "replayAudioState: startService failed: $e") }
         }
 
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneServiceCommand.kt
@@ -12,7 +12,7 @@ import com.webtrit.callkeep.models.CallMetadata
  * `CallMetadata.fromBundle` was invoked on the bare intent extras BEFORE the surrounding
  * try/catch: Binder IPC can deliver a non-null but empty [android.os.Bundle] for the no-extras
  * lifecycle commands ([ServiceAction.TearDownConnections], [ServiceAction.CleanConnections],
- * [ServiceAction.SyncAudioState], [ServiceAction.ReplayConnectionStates]), and the missing-`callId`
+ * [ServiceAction.ReplayAudioState], [ServiceAction.ReplayConnectionStates]), and the missing-`callId`
  * `IllegalArgumentException` then propagated uncaught out of `onStartCommand`.
  *
  * With this factory each command type owns exactly the data it needs:
@@ -25,7 +25,7 @@ sealed class PhoneServiceCommand {
 
     data object Clean : PhoneServiceCommand()
 
-    data object SyncAudio : PhoneServiceCommand()
+    data object ReplayAudio : PhoneServiceCommand()
 
     data object ReplayConnections : PhoneServiceCommand()
 
@@ -59,8 +59,8 @@ sealed class PhoneServiceCommand {
                     Clean
                 }
 
-                ServiceAction.SyncAudioState -> {
-                    SyncAudio
+                ServiceAction.ReplayAudioState -> {
+                    ReplayAudio
                 }
 
                 ServiceAction.ReplayConnectionStates -> {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -53,7 +53,7 @@ class StandaloneCallService : Service() {
 
     // Tracks whether startForeground() has been called in this service instance.
     // startForeground() is deferred until an actual call is handled so that lifecycle-only
-    // commands (ReplayConnectionStates, SyncAudioState, etc.) do not post a foreground
+    // commands (ReplayConnectionStates, ReplayAudioState, etc.) do not post a foreground
     // notification when there is no call in progress.
     private var isForeground = false
 
@@ -146,7 +146,7 @@ class StandaloneCallService : Service() {
             when (command) {
                 is StandaloneServiceCommand.TearDown -> handleTearDownConnections()
                 is StandaloneServiceCommand.Clean -> handleCleanConnections()
-                is StandaloneServiceCommand.SyncAudio -> handleSyncAudioState()
+                is StandaloneServiceCommand.ReplayAudio -> handleReplayAudioState()
                 is StandaloneServiceCommand.ReplayConnections -> handleReplayConnectionStates()
                 is StandaloneServiceCommand.Reserve -> handleReserveAnswer(command.callId)
                 is StandaloneServiceCommand.Call -> dispatchCall(command.action, command.metadata)
@@ -157,7 +157,7 @@ class StandaloneCallService : Service() {
 
         // If no calls are active or pending after processing, there is nothing to keep alive.
         // This handles the case where a lifecycle-only command (ReplayConnectionStates,
-        // SyncAudioState, CleanConnections) starts the service when no call is in progress.
+        // ReplayAudioState, CleanConnections) starts the service when no call is in progress.
         stopIfIdle()
 
         return START_NOT_STICKY
@@ -229,7 +229,7 @@ class StandaloneCallService : Service() {
             StandaloneServiceAction.TearDownConnections,
             StandaloneServiceAction.CleanConnections,
             StandaloneServiceAction.ReserveAnswer,
-            StandaloneServiceAction.SyncAudioState,
+            StandaloneServiceAction.ReplayAudioState,
             StandaloneServiceAction.ReplayConnectionStates,
             -> Log.w(TAG, "dispatchCall: unexpected non-call action $action, ignoring")
         }
@@ -532,8 +532,8 @@ class StandaloneCallService : Service() {
         core.notifyConnectionEvent(CallMediaEvent.AudioDeviceSet, updated.toBundle())
     }
 
-    private fun handleSyncAudioState() {
-        Log.i(TAG, "handleSyncAudioState: re-emitting audio state for answered calls")
+    private fun handleReplayAudioState() {
+        Log.i(TAG, "handleReplayAudioState: re-emitting audio state for answered calls")
         answeredCallIds.forEach { callId -> fireInitialAudioState(callId) }
     }
 
@@ -759,7 +759,7 @@ enum class StandaloneServiceAction {
     Muting,
     Speaker,
     AudioDeviceSet,
-    SyncAudioState,
+    ReplayAudioState,
     ReplayConnectionStates,
     ;
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneServiceCommand.kt
@@ -10,7 +10,7 @@ import com.webtrit.callkeep.models.CallMetadata
  * Mirrors [PhoneServiceCommand] for the non-Telecom path. Parsing is done once in [from] so the
  * [CallMetadata] extraction never runs for the no-extras lifecycle commands
  * ([StandaloneServiceAction.TearDownConnections], [StandaloneServiceAction.CleanConnections],
- * [StandaloneServiceAction.SyncAudioState], [StandaloneServiceAction.ReplayConnectionStates]). This
+ * [StandaloneServiceAction.ReplayAudioState], [StandaloneServiceAction.ReplayConnectionStates]). This
  * closes the same latent crash as on the Telecom path: a Binder-delivered empty
  * [android.os.Bundle] would otherwise reach `CallMetadata.fromBundle` and throw an uncaught
  * `IllegalArgumentException`.
@@ -22,7 +22,7 @@ sealed class StandaloneServiceCommand {
 
     data object Clean : StandaloneServiceCommand()
 
-    data object SyncAudio : StandaloneServiceCommand()
+    data object ReplayAudio : StandaloneServiceCommand()
 
     data object ReplayConnections : StandaloneServiceCommand()
 
@@ -52,8 +52,8 @@ sealed class StandaloneServiceCommand {
                     Clean
                 }
 
-                StandaloneServiceAction.SyncAudioState -> {
-                    SyncAudio
+                StandaloneServiceAction.ReplayAudioState -> {
+                    ReplayAudio
                 }
 
                 StandaloneServiceAction.ReplayConnectionStates -> {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/dispatchers/PhoneConnectionServiceDispatcher.kt
@@ -79,7 +79,7 @@ class PhoneConnectionServiceDispatcher(
             ServiceAction.ReserveAnswer,
             ServiceAction.NotifyPending,
             ServiceAction.CleanConnections,
-            ServiceAction.SyncAudioState,
+            ServiceAction.ReplayAudioState,
             ServiceAction.ReplayConnectionStates,
             -> logger.w("dispatch: unexpected IPC command action: $action")
         }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -1228,11 +1228,11 @@ class ForegroundService :
         // Ask :callkeep_core to re-emit audio state (device + mute) for any active connections.
         // PhoneConnection.forceUpdateAudioState() runs in the :callkeep_core process and sends
         // CallMediaEvent broadcasts back to the main process, which updates the Flutter UI.
-        // Not gated on the main-process tracker: handleSyncAudioState() iterates the live
+        // Not gated on the main-process tracker: handleReplayAudioState() iterates the live
         // :callkeep_core connections, so it is already a no-op when there are none -- and the
         // local tracker is transiently empty right after the replay above (and during a
         // push->foreground handoff), which would otherwise skip the re-sync exactly when needed.
-        core.sendSyncAudioState()
+        core.replayAudioState()
     }
 
     //

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/ServiceCommandTest.kt
@@ -43,7 +43,7 @@ class ServiceCommandTest {
     @Test
     fun phone_lifecycleAction_withNullExtras_returnsLifecycleCommand() {
         assertEquals(PhoneServiceCommand.Clean, PhoneServiceCommand.from(intent(ServiceAction.CleanConnections.action, null)))
-        assertEquals(PhoneServiceCommand.SyncAudio, PhoneServiceCommand.from(intent(ServiceAction.SyncAudioState.action, null)))
+        assertEquals(PhoneServiceCommand.ReplayAudio, PhoneServiceCommand.from(intent(ServiceAction.ReplayAudioState.action, null)))
         assertEquals(
             PhoneServiceCommand.ReplayConnections,
             PhoneServiceCommand.from(intent(ServiceAction.ReplayConnectionStates.action, null)),

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -202,7 +202,7 @@ When Flutter hot-restarts (development only) the main process Flutter engine is 
         |
         v
 3.  ForegroundService.replayConnectionStates()
-        |   CallkeepCore.sendSyncAudioState()    -> PhoneConnectionService re-emits audio state
+        |   CallkeepCore.replayAudioState()    -> PhoneConnectionService re-emits audio state
         |   CallkeepCore.replayConnectionStates() -> PhoneConnectionService re-fires AnswerCall
         v
 4.  ForegroundService broadcast handlers receive re-emitted events

--- a/webtrit_callkeep_android/docs/callkeep-core.md
+++ b/webtrit_callkeep_android/docs/callkeep-core.md
@@ -118,7 +118,7 @@ These send intents / broadcasts to `PhoneConnectionService` in `:callkeep_core`.
 | `tearDownService(ctx)`           | `startService` intent (`CleanConnections`)    | Reset without hanging up                         |
 | `sendTearDownConnections(ctx)`   | `startService` intent (`TearDownConnections`) | Hang up all + await `TearDownComplete` broadcast |
 | `sendReserveAnswer(ctx, callId)` | `startService` intent                         | Deferred answer for pending call                 |
-| `sendSyncAudioState(ctx)`        | `startService` intent                         | Re-emit audio state after hot-restart            |
+| `replayAudioState(ctx)`        | `startService` intent                         | Re-emit audio state after hot-restart            |
 | `replayConnectionStates(ctx)`   | `startService` intent                         | Replay connection lifecycle to a freshly attached delegate (cold-start/hot-restart) |
 
 ## Related Components

--- a/webtrit_callkeep_android/docs/dual-process.md
+++ b/webtrit_callkeep_android/docs/dual-process.md
@@ -51,7 +51,7 @@ Used for **commands** where delivery must be guaranteed (broadcasts can be dropp
 is not yet registered).
 
 - main → `:callkeep_core` commands: `TearDownConnections`, `ReserveAnswer`, `CleanConnections`,
-  `SyncAudioState`, `ReplayConnectionStates`, and per-call commands (`AnswerCall`, `DeclineCall`,
+  `ReplayAudioState`, `ReplayConnectionStates`, and per-call commands (`AnswerCall`, `DeclineCall`,
   `HungUpCall`, `EstablishCall`, `UpdateCall`, `MuteCall`, `HoldCall`, `SpeakerCall`,
   `SetAudioDevice`, `SendDtmf`).
 - `:callkeep_core` → main: `NotifyPending` (incoming call pending before PhoneConnection exists).
@@ -67,7 +67,7 @@ Because the two processes have independent JVM heaps, call state must be explici
 - `:callkeep_core` maintains `ConnectionManager` (
   see [connection-manager.md](connection-manager.md))
   — the authoritative registry of live `PhoneConnection` objects.
-- On app hot-restart, `ForegroundService.replayConnectionStates()` sends `SyncAudioState` and
+- On app hot-restart, `ForegroundService.replayConnectionStates()` sends `ReplayAudioState` and
   `ReplayConnectionStates` commands so `:callkeep_core` re-fires its current state to a freshly
   attached Flutter engine.
 

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -41,7 +41,7 @@
   the now-attached delegate: re-fired lifecycle events both repopulate the main-process shadow
   tracker (`connectionStates`, e.g. for the `CALL_ID_ALREADY_EXISTS` dedup in
   `reportNewIncomingCall`) and reach Flutter. This is the single, delegate-ready replay point.
-- Also sends `SyncAudioState` to re-emit audio device/mute state for the Flutter UI. Not gated on
+- Also sends `ReplayAudioState` to re-emit audio device/mute state for the Flutter UI. Not gated on
   the main-process tracker: the `:callkeep_core` handler iterates its live connections (a no-op when
   there are none), and the local tracker is transiently empty right after the replay above.
 

--- a/webtrit_callkeep_android/docs/phone-connection-service.md
+++ b/webtrit_callkeep_android/docs/phone-connection-service.md
@@ -76,7 +76,7 @@ encoded as a string extra.
 | `TearDownConnections` | Call `hungUp()` on every `PhoneConnection`, then broadcast `TearDownComplete`      |
 | `ReserveAnswer`       | Store deferred answer for `callId` (call `ConnectionManager.reserveAnswer()`)      |
 | `CleanConnections`    | Clear all connections without hanging up                                           |
-| `SyncAudioState`      | Re-emit audio state for all active connections (hot-restart recovery)              |
+| `ReplayAudioState`      | Re-emit audio state for all active connections (hot-restart recovery)              |
 | `ReplayConnectionStates` | Re-fire `AnswerCall` broadcast for all answered connections (hot-restart recovery) |
 | `AnswerCall`          | Call `PhoneConnection.onAnswer()` for the specified call                           |
 | `DeclineCall`         | Call `PhoneConnection.onReject()`                                                  |


### PR DESCRIPTION
## Overview

Sibling cleanup to the `ReplayConnectionStates` rename (#329). `SyncAudioState` is the same
one-way pull, not a two-way sync: the main process asks `:callkeep_core` to re-emit (replay) the
current audio device + mute state to a freshly attached Flutter delegate. After the connection-state
fix both commands now sit next to each other in `onDelegateSet()` doing the same "replay current
state to the attached delegate" job, so the naming is made symmetric.

## Changes

- `CallkeepCore` / `InProcessCallkeepCore` / `CallServiceRouter`: `sendSyncAudioState` -> `replayAudioState`
- `PhoneConnectionService`: companion `sendSyncAudioState` -> `replayAudioState`; `handleSyncAudioState` -> `handleReplayAudioState` (same in `StandaloneCallService`)
- `ServiceAction` / `StandaloneServiceAction`: `SyncAudioState` -> `ReplayAudioState`
- `PhoneServiceCommand` / `StandaloneServiceCommand`: `SyncAudio` -> `ReplayAudio` (keeps the "command = shortened action" pattern)
- KDoc / comments / log tags, `docs/` and `AGENTS.md` updated

## Notes

- The action string is app-scoped (`callkeep_<name>`) and both processes ship in the same APK, so renaming the enum is safe (no cross-version IPC contract).
- No behaviour change. Gradle unit tests + analyze + flutter test green.
