### PR TITLE
refactor(android): drop reportedIncoming suppression, rely on Flutter callId dedup

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -160,27 +160,6 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
-    /**
-     * Mark [callId] as having been reported by the host app via `reportNewIncomingCall`
-     * (the app/signaling path), as opposed to discovered by callkeep through the push/Telecom path.
-     *
-     * Purpose: de-duplicate the incoming-call notification to Flutter. When the app itself reported
-     * the call, Flutter already knows about it (`__onCallSignalingEventIncoming`). The
-     * `DidPushIncomingCall` broadcast that still arrives afterwards via the `:callkeep_core` IPC
-     * round-trip is then suppressed (see [consumeReportedIncoming]) so it does not add a second,
-     * push-path ActiveCall (line -1) alongside the existing app-path entry (line 0) for the same callId.
-     */
-    fun markReportedIncoming(callId: String)
-
-    /**
-     * Returns true and clears the mark if [callId] was app-reported (see [markReportedIncoming]).
-     *
-     * Consume-on-read: the guard fires at most once per call, so the first `DidPushIncomingCall`
-     * for an app-reported call is suppressed and any subsequent delivery (e.g. an explicit
-     * re-emit to a newly attached delegate) is no longer affected.
-     */
-    fun consumeReportedIncoming(callId: String): Boolean
-
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -111,20 +111,6 @@ interface ConnectionTracker {
      */
     fun markEndCallDispatched(callId: String): Boolean
 
-    /**
-     * Mark [callId] as having been reported by the host app via
-     * ForegroundService.reportNewIncomingCall. Suppresses the DidPushIncomingCall broadcast
-     * that follows via the :callkeep_core IPC round-trip, preventing a duplicate
-     * push-path ActiveCall entry in the app's call state.
-     */
-    fun markReportedIncoming(callId: String)
-
-    /**
-     * Returns true and removes the mark if [callId] was app-reported (see [markReportedIncoming]).
-     * Consuming on first read ensures the guard fires at most once per call.
-     */
-    fun consumeReportedIncoming(callId: String): Boolean
-
     // -------------------------------------------------------------------------
     // Read operations
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -186,10 +186,6 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndCallDispatched(callId: String): Boolean = tracker.markEndCallDispatched(callId)
 
-    override fun markReportedIncoming(callId: String) = tracker.markReportedIncoming(callId)
-
-    override fun consumeReportedIncoming(callId: String): Boolean = tracker.consumeReportedIncoming(callId)
-
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -56,12 +56,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // performEndCall for a Telecom-terminated call. Prevents duplicate performEndCall.
     private val endCallDispatchedCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
-    // callIds successfully registered via ForegroundService.reportNewIncomingCall
-    // (foreground signaling path). Suppresses the DidPushIncomingCall broadcast that
-    // follows via the :callkeep_core IPC round-trip, preventing a duplicate push-path
-    // ActiveCall entry alongside the signaling-path entry.
-    private val reportedIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     // last known Pigeon connection state per callId, kept for getConnections() queries
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
 
@@ -93,12 +87,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // reportedIncomingCallIds is intentionally NOT cleared here. addPending is called
-        // both by the initial registration site (before markReportedIncoming) and again
-        // inside InProcessCallkeepCore.startIncomingCall (after markReportedIncoming). Clearing
-        // it here would erase the guard on the second call and let DidPushIncomingCall through.
-        // The guard is cleared by consumeReportedIncoming (normal flow) or markTerminated
-        // (call-end cleanup, covers callId reuse).
         return pendingCallIds.add(callId)
     }
 
@@ -120,10 +108,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         pendingAnswers.remove(callId)
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
-        // reportedIncomingCallIds is intentionally NOT cleared here. promote() is called
-        // inside handleCSReportDidPushIncomingCall, immediately before consumeReportedIncoming
-        // checks the guard. Clearing it here would defeat the suppression and let
-        // didPushIncomingCall reach Flutter for signaling-path calls.
         connections[callId] = metadata
         pendingCallIds.remove(callId)
         connectionStates[callId] = state
@@ -189,7 +173,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         answeredCallIds.remove(callId)
         pendingCallIds.remove(callId)
         pendingAnswers.remove(callId)
-        reportedIncomingCallIds.remove(callId)
         connectionStates[callId] = PCallkeepConnectionState.STATE_DISCONNECTED
     }
 
@@ -314,7 +297,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         connectionStates.clear()
         directNotifiedCallIds.clear()
         endCallDispatchedCallIds.clear()
-        reportedIncomingCallIds.clear()
     }
 
     // -------------------------------------------------------------------------
@@ -328,12 +310,6 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     override fun consumeDirectNotified(callId: String): Boolean = directNotifiedCallIds.remove(callId)
 
     override fun markEndCallDispatched(callId: String): Boolean = endCallDispatchedCallIds.add(callId)
-
-    override fun markReportedIncoming(callId: String) {
-        reportedIncomingCallIds.add(callId)
-    }
-
-    override fun consumeReportedIncoming(callId: String): Boolean = reportedIncomingCallIds.remove(callId)
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -494,7 +494,6 @@ class ForegroundService :
                 // this callback returns but before _CallPerformEvent.answered is processed.
                 core.promote(callId, metadata, PCallkeepConnectionState.STATE_ACTIVE)
                 core.markAnswered(callId)
-                core.markReportedIncoming(callId)
                 flutterDelegateApi?.performAnswerCall(callId) {}
                 logger.i("reportNewIncomingCall: adopted already-answered call callId=$callId, fired performAnswerCall")
             } else {
@@ -550,13 +549,6 @@ class ForegroundService :
                 null
             }
 
-        // Mark this callId as signaling-registered BEFORE calling startIncomingCall so
-        // that the DidPushIncomingCall broadcast (fired by :callkeep_core during the IPC
-        // round-trip) is suppressed even if it arrives before the onSuccess callback runs.
-        // Flutter learns about this call from __onCallSignalingEventIncoming, so the
-        // duplicate push-path didPushIncomingCall must not reach it.
-        core.markReportedIncoming(callId)
-
         // Note: core.startIncomingCall can throw synchronously (e.g. uninitialized
         // ContextHolder). The exception bypasses our onError handler and propagates to
         // Pigeon as channel-error. The 5 s timeoutRunnable above is our safety-net for
@@ -569,7 +561,6 @@ class ForegroundService :
             onSuccess = {
                 logger.d("reportNewIncomingCall: startIncomingCall success callId=$callId")
                 // pendingIncomingCallbacks and timeout are already registered above.
-                // markReportedIncoming was already called before startIncomingCall.
             },
             onError = { error ->
                 // Cancel timeout and clear maps only if this call owns the pending slot.
@@ -636,10 +627,9 @@ class ForegroundService :
 
                     else -> {
                         logger.e("reportNewIncomingCall: startIncomingCall failed callId=$callId, error=$error")
-                        // Roll back the signaling-registered guard. The pending entry has already
-                        // been drained by InProcessCallkeepCore.startIncomingCall before invoking
-                        // this onError callback, so no core.removePending(callId) is needed here.
-                        core.consumeReportedIncoming(callId)
+                        // The pending entry has already been drained by
+                        // InProcessCallkeepCore.startIncomingCall before invoking this onError
+                        // callback, so no core.removePending(callId) is needed here.
                         callback(Result.success(error))
                     }
                 }
@@ -667,7 +657,7 @@ class ForegroundService :
         // directNotifiedCallIds so the stale async HungUp broadcast is suppressed
         // in handleCSReportDeclineCall.
         // core.clear() at the end of tearDown handles all per-session state including
-        // callback guards (directNotified, endCallDispatched, reportedIncoming).
+        // callback guards (directNotified, endCallDispatched).
 
         // Step 1: Collect active call IDs from the core shadow state (promoted connections).
         val activeCallIds = core.getAll().map { it.callId }
@@ -1016,21 +1006,13 @@ class ForegroundService :
             // so Flutter learns the call is live via the resolved callback (null = no error).
             resolvePendingIncomingCallback(metadata.callId, Result.success(null))
 
-            // If this call was registered via reportNewIncomingCall (the foreground signaling
-            // path), Flutter already knows about it through __onCallSignalingEventIncoming.
-            // Suppress didPushIncomingCall to prevent a duplicate push-path entry (line -1)
-            // from being added to state.activeCalls alongside the existing signaling entry
-            // (line 0). In the :callkeep_core separate-process architecture, this broadcast
-            // arrives AFTER the reportNewIncomingCall Pigeon response (IPC round-trip latency),
-            // so without this guard the push-path handler always runs after the signaling
-            // handler and creates a second ActiveCall for the same callId.
-            if (core.consumeReportedIncoming(metadata.callId)) {
-                logger.d(
-                    "handleCSReportDidPushIncomingCall: suppressing didPushIncomingCall for app-reported call ${metadata.callId}",
-                )
-                return@let
-            }
-
+            // Deliver unconditionally. When the call was also reported via reportNewIncomingCall
+            // (foreground signaling path), Flutter already knows about it through
+            // __onCallSignalingEventIncoming - but the Dart CallBloc deduplicates by callId, so a
+            // didPushIncomingCall for an already-known call does NOT create a second ActiveCall
+            // (CallBloc._onCallPushEventIncoming skips when the callId already exists; the signaling
+            // mutation merges into the existing entry). The native-side suppression guard was
+            // therefore redundant and was removed.
             val handle = metadata.handle
             if (handle == null) {
                 // Cannot build a PHandle without a number; skip rather than crash on a
@@ -1069,10 +1051,6 @@ class ForegroundService :
         extras?.let {
             val callMetaData = CallMetadata.fromBundle(it)
             val callId = callMetaData.callId
-
-            // consumeReportedIncoming cleans up any pending signaling guard for this
-            // callId (edge case: call terminates before DidPushIncomingCall arrives).
-            core.consumeReportedIncoming(callId)
 
             // Suppress stale async HungUp/Decline broadcasts for calls that were already
             // directly notified via performEndCall in tearDown(). Without this guard, the

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -559,20 +559,16 @@ class MainProcessConnectionTrackerTest {
         //   1. markAnswered()           <- ReplayConnectionStates (cold-start)
         //   2. promote(STATE_ACTIVE)    <- fix step 1
         //   3. markAnswered()           <- fix step 2 (re-mark after promote clears it)
-        //   4. markReportedIncoming()  <- fix step 3
         tracker.markAnswered("call-1") // cold-start
         assertTrue(tracker.isAnswered("call-1"))
 
         tracker.promote("call-1", metadata(), PCallkeepConnectionState.STATE_ACTIVE) // fix 1
         tracker.markAnswered("call-1") // fix 2
-        tracker.markReportedIncoming("call-1") // fix 3
 
         assertTrue(tracker.exists("call-1"))
         assertTrue(tracker.isAnswered("call-1"))
         assertFalse(tracker.isPending("call-1"))
         assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
-        // DidPushIncomingCall broadcast must be suppressed after adoption
-        assertTrue(tracker.consumeReportedIncoming("call-1"))
     }
 
     @Test

--- a/webtrit_callkeep_android/docs/connection-tracker.md
+++ b/webtrit_callkeep_android/docs/connection-tracker.md
@@ -28,13 +28,16 @@ State is updated exclusively from broadcast events emitted by `PhoneConnectionSe
 
 ## Callback Guards
 
-Three additional sets prevent duplicate Dart notifications for the same call:
+These sets prevent duplicate Dart notifications for the same call:
 
-| Guard                        | Purpose                                                                                                                                                                  |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `directNotifiedCallIds`      | Calls notified directly during `tearDown()`. Suppresses a subsequent `HungUp` broadcast for the same call.                                                               |
-| `endCallDispatchedCallIds`   | Calls for which `performEndCall()` has already been sent to Dart. Prevents a second dispatch.                                                                            |
-| `signalingRegisteredCallIds` | Calls for which `reportNewIncomingCall()` succeeded. Suppresses the corresponding `DidPushIncomingCall` broadcast (which would result in a duplicate Dart notification). |
+| Guard                        | Purpose                                                                                                    |
+|------------------------------|------------------------------------------------------------------------------------------------------------|
+| `directNotifiedCallIds`      | Calls notified directly during `tearDown()`. Suppresses a subsequent `HungUp` broadcast for the same call. |
+| `endCallDispatchedCallIds`   | Calls for which `performEndCall()` has already been sent to Dart. Prevents a second dispatch.              |
+
+(The former `signalingRegisteredCallIds` / `reportedIncoming` guard that suppressed `DidPushIncomingCall`
+for app-reported calls was removed: the Dart `CallBloc` deduplicates incoming calls by callId, so a
+push-path `didPushIncomingCall` for an already-known call does not create a second `ActiveCall`.)
 
 ## State Transitions
 


### PR DESCRIPTION
## Overview

The native `consumeReportedIncoming` guard suppressed the `DidPushIncomingCall` broadcast for
calls already reported via `reportNewIncomingCall` (the foreground signaling path), to avoid a
duplicate push-path `ActiveCall`. It is redundant: the Dart `CallBloc` already deduplicates
incoming calls by callId, so a `didPushIncomingCall` for an already-known call does not create a
second `ActiveCall` regardless of arrival order. This removes the guard and makes
`DidPushIncomingCall` a pure, unconditional delivery.

This is the delivery-axis step of the incoming-call event decomposition (see plan in the agent
workspace): once delivery is unconditional, the replay path can reuse `DidPushIncomingCall`, so the
dedicated `ReEmitIncomingCall` event (introduced on the unmerged delegate-attach branch) becomes
unnecessary and is dropped on that branch's rebase.

## Why it is safe (Phase 0 dedup proof, webtrit_phone CallBloc)

- `_onCallPushEventIncoming` resolves the contact (async) then RE-CHECKS
  `state.activeCalls.any((c) => c.callId == event.callId)` and **skips** if present (the re-check
  exists specifically for "the signaling path created it during the async gap").
- `__onMutationSignalingIncoming` does `retrieveActiveCall(callId)` -> **merges** into the existing
  entry (sets line + offer) if present, else creates. So a push-placed call is enriched, not
  duplicated.
- `copyWithPushActiveCall` blindly appends -> the dedup lives in those two caller guards (callId).
- Order analysis: push-first -> signaling merges; signaling-first -> push re-check skips => one
  `ActiveCall` either way.

## Changes

- Remove `reportedIncomingCallIds` + `markReportedIncoming` + `consumeReportedIncoming`
  (`MainProcessConnectionTracker`, `ConnectionTracker`, `CallkeepCore`, `InProcessCallkeepCore`).
- `ForegroundService`: drop the two `markReportedIncoming` call sites and the three
  consume/cleanup sites; `handleCSReportDidPushIncomingCall` now always delivers.
- Update the cold-start adoption unit test and `docs/connection-tracker.md`.

## DRAFT - merge gate (call-critical)

Needs on-device verification before merge:
- No transient double incoming UI / double CallKit / double notification before the bloc dedups
  (Android + iOS), for foreground-signaling + push + push->foreground handoff.
- Confirm push callId == signaling callId across flavors (the dedup key).

Background: the guard was the ORIGINAL fix from the dual-process split (#200); the Flutter
callId dedup re-check was added later (WT-1167 #1070), making the native guard a now-redundant
second layer. Gradle unit + analyze + flutter test green.
