### PR TITLE
refactor(android): rename DidPushIncomingCall event to IncomingConnectionReported

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/WebtritCallkeepPlugin.kt
@@ -376,7 +376,7 @@ class WebtritCallkeepPlugin :
             val core = CallkeepCore.instance
             val promoted = core.getAll()
             // Also check pending calls to cover the broadcast-lag window: CS may have
-            // created a PhoneConnection and be about to send DidPushIncomingCall, but the
+            // created a PhoneConnection and be about to send IncomingConnectionReported, but the
             // core shadow has not yet promoted the call. Without this check, ON_START during
             // that window would incorrectly clear the lock-screen and turn-screen-on flags.
             val hasActiveConnections = promoted.isNotEmpty() || core.getPendingCallIds().isNotEmpty()

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/broadcaster/ConnectionServicePerformBroadcaster.kt
@@ -30,7 +30,11 @@ enum class CallLifecycleEvent : ConnectionEvent {
     DeclineCall,
     HungUp,
     OngoingCall,
-    DidPushIncomingCall,
+    // An incoming PhoneConnection was created in :callkeep_core (onCreateIncomingConnection). The
+    // main process registers it in the shadow state and then notifies the Flutter delegate via the
+    // public didPushIncomingCall callback. Named after the cross-process fact (a connection was
+    // reported), NOT the public callback -- the handler does register + deliver, not just deliver.
+    IncomingConnectionReported,
     // Carries the authoritative connection state (CallMetadata.connectionState) so the main process
     // can MIRROR it into the shadow state, instead of inferring a fixed state per event type. Emitted
     // from PhoneConnection.onStateChanged (Telecom) / StandaloneCallService transitions. Live states

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -166,7 +166,7 @@ interface CallkeepCore {
      *
      * Purpose: de-duplicate the incoming-call notification to Flutter. When the app itself reported
      * the call, Flutter already knows about it (`__onCallSignalingEventIncoming`). The
-     * `DidPushIncomingCall` broadcast that still arrives afterwards via the `:callkeep_core` IPC
+     * `IncomingConnectionReported` broadcast that still arrives afterwards via the `:callkeep_core` IPC
      * round-trip is then suppressed (see [consumeReportedIncoming]) so it does not add a second,
      * push-path ActiveCall (line -1) alongside the existing app-path entry (line 0) for the same callId.
      */
@@ -175,7 +175,7 @@ interface CallkeepCore {
     /**
      * Returns true and clears the mark if [callId] was app-reported (see [markReportedIncoming]).
      *
-     * Consume-on-read: the guard fires at most once per call, so the first `DidPushIncomingCall`
+     * Consume-on-read: the guard fires at most once per call, so the first `IncomingConnectionReported`
      * for an app-reported call is suppressed and any subsequent delivery (e.g. an explicit
      * re-emit to a newly attached delegate) is no longer affected.
      */

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -113,7 +113,7 @@ interface ConnectionTracker {
 
     /**
      * Mark [callId] as having been reported by the host app via
-     * ForegroundService.reportNewIncomingCall. Suppresses the DidPushIncomingCall broadcast
+     * ForegroundService.reportNewIncomingCall. Suppresses the IncomingConnectionReported broadcast
      * that follows via the :callkeep_core IPC round-trip, preventing a duplicate
      * push-path ActiveCall entry in the app's call state.
      */

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -244,7 +244,7 @@ class InProcessCallkeepCore internal constructor(
     ) {
         val callId = metadata.callId
         // Reserve the pendingCallIds entry before handing off to the backend so that
-        // answerCall() / endCall() issued before DidPushIncomingCall fires can locate
+        // answerCall() / endCall() issued before IncomingConnectionReported fires can locate
         // the call via core.isPending() during the broadcast-lag window.
         //
         // addPending() returns true only when this invocation actually inserted the entry.
@@ -346,7 +346,7 @@ class InProcessCallkeepCore internal constructor(
          */
         internal val GLOBAL_LISTENER_EVENTS: List<ConnectionEvent> =
             listOf(
-                CallLifecycleEvent.DidPushIncomingCall,
+                CallLifecycleEvent.IncomingConnectionReported,
                 CallLifecycleEvent.ConnectionStateChanged,
                 CallLifecycleEvent.DeclineCall,
                 CallLifecycleEvent.HungUp,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
  * connection state in the main process.
  *
  * Updated from broadcasts emitted by [com.webtrit.callkeep.services.services.connection.PhoneConnectionService]:
- * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.DidPushIncomingCall] -> promote incoming
+ * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.IncomingConnectionReported] -> promote incoming
  * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.AnswerCall]           -> markAnswered
  * - [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.HungUp] /
  *   [com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent.DeclineCall]          -> markTerminated
@@ -57,7 +57,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     private val endCallDispatchedCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // callIds successfully registered via ForegroundService.reportNewIncomingCall
-    // (foreground signaling path). Suppresses the DidPushIncomingCall broadcast that
+    // (foreground signaling path). Suppresses the IncomingConnectionReported broadcast that
     // follows via the :callkeep_core IPC round-trip, preventing a duplicate push-path
     // ActiveCall entry alongside the signaling-path entry.
     private val reportedIncomingCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
@@ -96,7 +96,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         // reportedIncomingCallIds is intentionally NOT cleared here. addPending is called
         // both by the initial registration site (before markReportedIncoming) and again
         // inside InProcessCallkeepCore.startIncomingCall (after markReportedIncoming). Clearing
-        // it here would erase the guard on the second call and let DidPushIncomingCall through.
+        // it here would erase the guard on the second call and let IncomingConnectionReported through.
         // The guard is cleared by consumeReportedIncoming (normal flow) or markTerminated
         // (call-end cleanup, covers callId reuse).
         return pendingCallIds.add(callId)
@@ -121,7 +121,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         endCallDispatchedCallIds.remove(callId)
         directNotifiedCallIds.remove(callId)
         // reportedIncomingCallIds is intentionally NOT cleared here. promote() is called
-        // inside handleCSReportDidPushIncomingCall, immediately before consumeReportedIncoming
+        // inside handleCSIncomingConnectionReported, immediately before consumeReportedIncoming
         // checks the guard. Clearing it here would defeat the suppression and let
         // didPushIncomingCall reach Flutter for signaling-path calls.
         connections[callId] = metadata

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -128,7 +128,7 @@ class PhoneConnection internal constructor(
      * through the earpiece at full volume during a call and can hurt with the phone to the ear,
      * WT-1388).
      *
-     * The control-plane notification to the main process (DidPushIncomingCall) is NOT emitted
+     * The control-plane notification to the main process (IncomingConnectionReported) is NOT emitted
      * here. It is dispatched deterministically from [PhoneConnectionService.onCreateIncomingConnection]
      * when the connection is created, so it does not depend on this system UI callback's timing
      * (which the framework schedules separately and which is skipped for an immediately-answered call).

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionService.kt
@@ -343,8 +343,8 @@ class PhoneConnectionService : ConnectionService() {
             // Only the not-yet-answered branch emits it: a call with a consumed deferred answer is
             // being answered immediately (no incoming UI), so it is surfaced to Flutter via the
             // answer flow instead — matching the previous behaviour where onShowIncomingCallUi
-            // (and therefore DidPushIncomingCall) did not fire for an immediately-answered call.
-            performEventHandle(CallLifecycleEvent.DidPushIncomingCall, metadata)
+            // (and therefore IncomingConnectionReported) did not fire for an immediately-answered call.
+            performEventHandle(CallLifecycleEvent.IncomingConnectionReported, metadata)
         }
 
         phoneConnectionServiceDispatcher.dispatchLifecycle(

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -293,7 +293,7 @@ class StandaloneCallService : Service() {
         // for this broadcast to resolve its pendingIncomingCallbacks entry and promote the call
         // into the core shadow state, matching the PhoneConnectionService.onCreateIncomingConnection
         // path in the Telecom-enabled flow.
-        core.notifyConnectionEvent(CallLifecycleEvent.DidPushIncomingCall, metadata.toBundle())
+        core.notifyConnectionEvent(CallLifecycleEvent.IncomingConnectionReported, metadata.toBundle())
 
         // If an answer was reserved before this call was registered (ReserveAnswer arrived first),
         // consume the pending reservation and immediately trigger the answer flow.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -96,7 +96,7 @@ class ForegroundService :
 
     // Pigeon callbacks for reportNewIncomingCall() that are waiting for Telecom confirmation.
     // Populated in startIncomingCall.onSuccess instead of resolving immediately, so that
-    // Flutter only gets "success" once Telecom has actually accepted the call (DidPushIncomingCall)
+    // Flutter only gets "success" once Telecom has actually accepted the call (IncomingConnectionReported)
     // or gets CALL_REJECTED_BY_SYSTEM when Telecom rejects it (HungUp / onCreateIncomingConnectionFailed).
     private val pendingIncomingCallbacks: ConcurrentHashMap<String, (Result<PIncomingCallError?>) -> Unit> =
         ConcurrentHashMap()
@@ -132,8 +132,8 @@ class ForegroundService :
     ) {
         logger.d("onConnectionEvent: ${event.name}")
         when (event) {
-            CallLifecycleEvent.DidPushIncomingCall -> {
-                handleCSReportDidPushIncomingCall(data)
+            CallLifecycleEvent.IncomingConnectionReported -> {
+                handleCSIncomingConnectionReported(data)
             }
 
             CallLifecycleEvent.ConnectionStateChanged -> {
@@ -471,7 +471,7 @@ class ForegroundService :
         // from :callkeep_core and is never updated with answered/terminated transitions.
         //
         // exists() is also checked here to short-circuit duplicate detection without a Telecom
-        // round-trip. When DidPushIncomingCall has already been delivered and promoted the call,
+        // round-trip. When IncomingConnectionReported has already been delivered and promoted the call,
         // the second reportNewIncomingCall must return CALL_ID_ALREADY_EXISTS immediately rather
         // than going to Telecom, which would otherwise trigger the CALL_ID_ALREADY_EXISTS adoption
         // path and return null (masking the duplicate from Flutter).
@@ -510,7 +510,7 @@ class ForegroundService :
         }
 
         // Pre-register the Pigeon callback and safety timeout BEFORE calling startIncomingCall.
-        // DidPushIncomingCall can arrive synchronously — during the addNewIncomingCall Telecom
+        // IncomingConnectionReported can arrive synchronously — during the addNewIncomingCall Telecom
         // call inside startIncomingCall — before the IPC onSuccess callback returns to this
         // process. Without pre-registration, resolvePendingIncomingCallback finds no entry and
         // the confirmation is lost, causing the 5-second timeout to fire unconditionally.
@@ -520,7 +520,7 @@ class ForegroundService :
         // before any of them completes) cannot overwrite each other's callback. Only the first
         // caller owns the slot (ownsPendingSlot=true) and registers the timeout; duplicates
         // skip both registrations and, in their onError handler, must not touch the maps so
-        // the first callback remains in place until DidPushIncomingCall resolves it.
+        // the first callback remains in place until IncomingConnectionReported resolves it.
         val ownsPendingSlot = pendingIncomingCallbacks.putIfAbsent(callId, callback) == null
         // Non-owners post no timeout and have nothing to cancel in onError — null makes
         // the ownership contract explicit and avoids allocating a no-op Runnable per call.
@@ -551,7 +551,7 @@ class ForegroundService :
             }
 
         // Mark this callId as signaling-registered BEFORE calling startIncomingCall so
-        // that the DidPushIncomingCall broadcast (fired by :callkeep_core during the IPC
+        // that the IncomingConnectionReported broadcast (fired by :callkeep_core during the IPC
         // round-trip) is suppressed even if it arrives before the onSuccess callback runs.
         // Flutter learns about this call from __onCallSignalingEventIncoming, so the
         // duplicate push-path didPushIncomingCall must not reach it.
@@ -574,7 +574,7 @@ class ForegroundService :
             onError = { error ->
                 // Cancel timeout and clear maps only if this call owns the pending slot.
                 // A non-owner (ownsPendingSlot=false) must leave the maps untouched so the
-                // first caller's callback stays in place for DidPushIncomingCall to resolve.
+                // first caller's callback stays in place for IncomingConnectionReported to resolve.
                 timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
                 if (ownsPendingSlot) {
                     pendingIncomingTimeouts.remove(callId)
@@ -607,7 +607,7 @@ class ForegroundService :
                         } else {
                             // Call still ringing in Telecom but not yet promoted in the tracker
                             // (narrow race: Telecom created the PhoneConnection before the
-                            // DidPushIncomingCall broadcast was delivered to this process).
+                            // IncomingConnectionReported broadcast was delivered to this process).
                             // Promote into the tracker so answerCall() / endCall() can locate it,
                             // then return CALL_ID_ALREADY_EXISTS so Flutter treats this as a
                             // duplicate rather than a new registration — the call was already
@@ -674,7 +674,7 @@ class ForegroundService :
 
         // Step 1b: Drain any deferred reportNewIncomingCall callbacks that are still waiting
         // for Telecom confirmation. These calls were accepted by startIncomingCall() but
-        // DidPushIncomingCall has not yet arrived. Resolve them with CALL_REJECTED_BY_SYSTEM
+        // IncomingConnectionReported has not yet arrived. Resolve them with CALL_REJECTED_BY_SYSTEM
         // and mark directNotified so that any subsequent HungUp broadcast is suppressed.
         // Must run before drainUnconnectedPendingCallIds() so the callIds are removed from
         // pendingCallIds first, preventing tearDown from also firing performEndCall for them.
@@ -690,7 +690,7 @@ class ForegroundService :
         }
 
         // Step 2: Drain pending calls that were registered with Telecom but whose
-        // PhoneConnection was never created (no DidPushIncomingCall received yet).
+        // PhoneConnection was never created (no IncomingConnectionReported received yet).
         val unconnectedPending = core.drainUnconnectedPendingCallIds()
 
         // Step 3: Notify Flutter for active connections. Mark directNotified
@@ -709,7 +709,7 @@ class ForegroundService :
         // Mark in directNotified BEFORE firing performEndCall so that any async HungUp
         // broadcast from connection.hungUp() (Step 5) is suppressed — this happens when
         // the deferred-answer path caused CS to create a PhoneConnection via reserveAnswer
-        // even though DidPushIncomingCall had not yet arrived and the callId was still pending.
+        // even though IncomingConnectionReported had not yet arrived and the callId was still pending.
         // Also mark terminated + endCallDispatched to match the onDestroy path and prevent
         // a duplicate startHungUpCall IPC if endCall() arrives during the tearDown window.
         unconnectedPending.forEach { callId ->
@@ -859,7 +859,7 @@ class ForegroundService :
         callback: (Result<PCallRequestError?>) -> Unit,
     ) {
         val metadata = CallMetadata(callId = callId)
-        // DidPushIncomingCall is delivered via sendBroadcast() which is async. Between the
+        // IncomingConnectionReported is delivered via sendBroadcast() which is async. Between the
         // moment CS creates the PhoneConnection and the moment the broadcast reaches
         // ForegroundService, core.exists() is false even though the call is live on the
         // CS side. Resolution order:
@@ -1003,49 +1003,62 @@ class ForegroundService :
         }
     }
 
-    private fun handleCSReportDidPushIncomingCall(extras: Bundle?) {
-        logger.d("handleCSReportDidPushIncomingCall")
+    private fun handleCSIncomingConnectionReported(extras: Bundle?) {
+        logger.d("handleCSIncomingConnectionReported")
         extras?.let {
             val metadata = CallMetadata.fromBundle(it)
-            // Promote from pending to fully registered incoming connection.
-            core.promote(metadata.callId, metadata, PCallkeepConnectionState.STATE_RINGING)
-            syncScreenWakelock()
-
-            // Resolve any deferred reportNewIncomingCall Pigeon callback waiting for this
-            // Telecom confirmation. This is the success path: Telecom accepted the call,
-            // so Flutter learns the call is live via the resolved callback (null = no error).
-            resolvePendingIncomingCallback(metadata.callId, Result.success(null))
-
-            // If this call was registered via reportNewIncomingCall (the foreground signaling
-            // path), Flutter already knows about it through __onCallSignalingEventIncoming.
-            // Suppress didPushIncomingCall to prevent a duplicate push-path entry (line -1)
-            // from being added to state.activeCalls alongside the existing signaling entry
-            // (line 0). In the :callkeep_core separate-process architecture, this broadcast
-            // arrives AFTER the reportNewIncomingCall Pigeon response (IPC round-trip latency),
-            // so without this guard the push-path handler always runs after the signaling
-            // handler and creates a second ActiveCall for the same callId.
-            if (core.consumeReportedIncoming(metadata.callId)) {
-                logger.d(
-                    "handleCSReportDidPushIncomingCall: suppressing didPushIncomingCall for app-reported call ${metadata.callId}",
-                )
-                return@let
-            }
-
-            val handle = metadata.handle
-            if (handle == null) {
-                // Cannot build a PHandle without a number; skip rather than crash on a
-                // malformed/handle-less broadcast (the call is already promoted above).
-                logger.w("handleCSReportDidPushIncomingCall: missing handle for callId=${metadata.callId}; skipping didPushIncomingCall")
-                return@let
-            }
-            flutterDelegateApi?.didPushIncomingCall(
-                handleArg = handle.toPHandle(),
-                displayNameArg = metadata.displayName,
-                videoArg = metadata.hasVideo ?: false,
-                callIdArg = metadata.callId,
-                errorArg = null,
-            ) {}
+            // The IncomingConnectionReported event is two concerns: register the connection in the
+            // main-process shadow state, then notify the Flutter delegate. They stay in this single
+            // handler (one cross-process broadcast) so registration is atomic with delivery.
+            registerIncomingConnection(metadata)
+            deliverIncomingToDelegate(metadata)
         }
+    }
+
+    /**
+     * Register a reported incoming connection in the main-process shadow state: promote it from
+     * pending to a fully tracked connection, refresh the screen wakelock, and resolve any deferred
+     * reportNewIncomingCall Pigeon callback (the success path: Telecom accepted the call, so Flutter
+     * learns it is live via the resolved callback, null = no error).
+     */
+    private fun registerIncomingConnection(metadata: CallMetadata) {
+        core.promote(metadata.callId, metadata, PCallkeepConnectionState.STATE_RINGING)
+        syncScreenWakelock()
+        resolvePendingIncomingCallback(metadata.callId, Result.success(null))
+    }
+
+    /**
+     * Notify the Flutter delegate of a reported incoming call via the public `didPushIncomingCall`
+     * callback. This is the only place the public push-incoming notification name is used; the
+     * cross-process event itself is [CallLifecycleEvent.IncomingConnectionReported].
+     */
+    private fun deliverIncomingToDelegate(metadata: CallMetadata) {
+        // If this call was registered via reportNewIncomingCall (the foreground signaling path),
+        // Flutter already knows about it through __onCallSignalingEventIncoming. Suppress
+        // didPushIncomingCall to prevent a duplicate push-path entry (line -1) from being added to
+        // state.activeCalls alongside the existing signaling entry (line 0). In the :callkeep_core
+        // separate-process architecture, this broadcast arrives AFTER the reportNewIncomingCall
+        // Pigeon response (IPC round-trip latency), so without this guard the push-path handler
+        // always runs after the signaling handler and creates a second ActiveCall for the same callId.
+        if (core.consumeReportedIncoming(metadata.callId)) {
+            logger.d("deliverIncomingToDelegate: suppressing didPushIncomingCall for app-reported call ${metadata.callId}")
+            return
+        }
+
+        val handle = metadata.handle
+        if (handle == null) {
+            // Cannot build a PHandle without a number; skip rather than crash on a
+            // malformed/handle-less broadcast (the call is already promoted above).
+            logger.w("deliverIncomingToDelegate: missing handle for callId=${metadata.callId}; skipping didPushIncomingCall")
+            return
+        }
+        flutterDelegateApi?.didPushIncomingCall(
+            handleArg = handle.toPHandle(),
+            displayNameArg = metadata.displayName,
+            videoArg = metadata.hasVideo ?: false,
+            callIdArg = metadata.callId,
+            errorArg = null,
+        ) {}
     }
 
     /**
@@ -1071,7 +1084,7 @@ class ForegroundService :
             val callId = callMetaData.callId
 
             // consumeReportedIncoming cleans up any pending signaling guard for this
-            // callId (edge case: call terminates before DidPushIncomingCall arrives).
+            // callId (edge case: call terminates before IncomingConnectionReported arrives).
             core.consumeReportedIncoming(callId)
 
             // Suppress stale async HungUp/Decline broadcasts for calls that were already
@@ -1305,7 +1318,7 @@ class ForegroundService :
         private const val OUTGOING_CALL_TIMEOUT_MS = 5_000L
         private const val TEAR_DOWN_ACK_TIMEOUT_MS = 3_000L
 
-        // Maximum time to wait for Telecom to confirm an incoming call via DidPushIncomingCall.
+        // Maximum time to wait for Telecom to confirm an incoming call via IncomingConnectionReported.
         // If this elapses without confirmation or rejection, resolve the Pigeon callback with
         // CALL_REJECTED_BY_SYSTEM to avoid leaking the deferred callback.
         private const val INCOMING_CALL_CONFIRMATION_TIMEOUT_MS = 5_000L

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -571,7 +571,7 @@ class MainProcessConnectionTrackerTest {
         assertTrue(tracker.isAnswered("call-1"))
         assertFalse(tracker.isPending("call-1"))
         assertEquals(PCallkeepConnectionState.STATE_ACTIVE, tracker.getState("call-1"))
-        // DidPushIncomingCall broadcast must be suppressed after adoption
+        // IncomingConnectionReported broadcast must be suppressed after adoption
         assertTrue(tracker.consumeReportedIncoming("call-1"))
     }
 

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -27,7 +27,7 @@ Triggered by an FCM message or a direct Dart call to `reportNewIncomingCall`.
         v
 6.  Telecom --> PhoneConnectionService.onCreateIncomingConnection()
         |   PhoneConnection created (STATE_RINGING)
-        |   broadcast: DidPushIncomingCall
+        |   broadcast: IncomingConnectionReported
         v
 7.  ForegroundService.connectionServicePerformReceiver
         |   CallkeepCore.promote(callId, meta, state)

--- a/webtrit_callkeep_android/docs/callkeep-core.md
+++ b/webtrit_callkeep_android/docs/callkeep-core.md
@@ -66,7 +66,7 @@ CallkeepCore.instance.removeConnectionEventListener(this)
 | `unregisterConnectionEvents(...)`     | Unregister a temporary receiver                          |
 
 **Global events** (routed to all `ConnectionEventListener` subscribers):
-`DidPushIncomingCall`, `ConnectionStateChanged`, `DeclineCall`, `HungUp`, `ConnectionNotFound`,
+`IncomingConnectionReported`, `ConnectionStateChanged`, `DeclineCall`, `HungUp`, `ConnectionNotFound`,
 `AnswerCall`, `AudioDeviceSet`, `AudioDevicesUpdate`, `AudioMuting`, `ConnectionHolding`,
 `SentDTMF`.
 
@@ -81,7 +81,7 @@ reports events via `CallkeepCore`. They update `MainProcessConnectionTracker`.
 | Method                             | Triggered by                       | Effect                          |
 |------------------------------------|------------------------------------|---------------------------------|
 | `addPending(callId)`               | `NotifyPending` intent from CS     | Registers call as pending       |
-| `promote(callId, metadata, state)` | `DidPushIncomingCall` broadcast    | Full registration with metadata |
+| `promote(callId, metadata, state)` | `IncomingConnectionReported` broadcast    | Full registration with metadata |
 | `markAnswered(callId)`             | `AnswerCall` broadcast             | Marks answered (guard only; no state stamp) |
 | `updateState(callId, state)`       | `ConnectionStateChanged` broadcast | Mirrors authoritative connection state (unconditional; ignores DISCONNECTED) |
 | `markTerminated(callId)`           | `HungUp` / `DeclineCall` broadcast | Moves to terminated set         |

--- a/webtrit_callkeep_android/docs/connection-tracker.md
+++ b/webtrit_callkeep_android/docs/connection-tracker.md
@@ -34,7 +34,7 @@ Three additional sets prevent duplicate Dart notifications for the same call:
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `directNotifiedCallIds`      | Calls notified directly during `tearDown()`. Suppresses a subsequent `HungUp` broadcast for the same call.                                                               |
 | `endCallDispatchedCallIds`   | Calls for which `performEndCall()` has already been sent to Dart. Prevents a second dispatch.                                                                            |
-| `signalingRegisteredCallIds` | Calls for which `reportNewIncomingCall()` succeeded. Suppresses the corresponding `DidPushIncomingCall` broadcast (which would result in a duplicate Dart notification). |
+| `signalingRegisteredCallIds` | Calls for which `reportNewIncomingCall()` succeeded. Suppresses the corresponding `IncomingConnectionReported` broadcast (which would result in a duplicate Dart notification). |
 
 ## State Transitions
 

--- a/webtrit_callkeep_android/docs/dual-process.md
+++ b/webtrit_callkeep_android/docs/dual-process.md
@@ -39,7 +39,7 @@ Used for **event notifications** that the receiver handles asynchronously.
 - Sender calls `context.sendBroadcast(intent.setPackage(packageName))`.
 - Receiver registers with `registerReceiverCompat`.
 - Events flow in **both directions**:
-  - `:callkeep_core` → main: call lifecycle events (`AnswerCall`, `HungUp`, `DidPushIncomingCall`,
+  - `:callkeep_core` → main: call lifecycle events (`AnswerCall`, `HungUp`, `IncomingConnectionReported`,
       media events, etc.)
   - main → `:callkeep_core`: ack events (`TearDownComplete`)
 

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -93,7 +93,7 @@ registered `ConnectionEventListener`. `ForegroundService` does not register its 
 
 | Event                 | Handler                               | Main Action                                                              |
 |-----------------------|---------------------------------------|--------------------------------------------------------------------------|
-| `DidPushIncomingCall`    | `handleCSReportDidPushIncomingCall()`    | Promote call in tracker, call `performIncomingCall()` on Dart delegate   |
+| `IncomingConnectionReported`    | `handleCSIncomingConnectionReported()`    | Promote call in tracker, call `performIncomingCall()` on Dart delegate   |
 | `ConnectionStateChanged` | `handleCSReportConnectionStateChanged()` | `updateState()` -- mirror the authoritative connection state into the tracker |
 | `AnswerCall`             | `handleCSReportAnswerCall()`             | `markAnswered()` guard in tracker, call `performAnswerCall()` on Dart delegate |
 | `DeclineCall`         | `handleCSReportDeclineCall()`         | `markTerminated()`, call `performEndCall()`                              |

--- a/webtrit_callkeep_android/docs/ipc-broadcasting.md
+++ b/webtrit_callkeep_android/docs/ipc-broadcasting.md
@@ -22,7 +22,7 @@ The event type is carried as a string extra inside the intent.
 
 | Event                 | Payload                         | Meaning                                          |
 |-----------------------|---------------------------------|--------------------------------------------------|
-| `DidPushIncomingCall`    | `callId`, `CallMetadata` bundle              | Incoming `PhoneConnection` created, UI shown               |
+| `IncomingConnectionReported`    | `callId`, `CallMetadata` bundle              | Incoming `PhoneConnection` created, UI shown               |
 | `AnswerCall`             | `callId`                                     | Answer signal (guard); the ACTIVE state arrives separately via `ConnectionStateChanged` |
 | `ConnectionStateChanged` | `callId`, `CallMetadata` bundle (carries `connectionState`) | Authoritative live connection state to mirror into the shadow state (RINGING/DIALING/ACTIVE/HOLDING). Terminal DISCONNECTED is NOT sent here -- it stays on the cause-carrying `HungUp`/`DeclineCall`. |
 | `DeclineCall`            | `callId`                                     | User rejected the call                                     |

--- a/webtrit_callkeep_android/docs/phone-connection-service.md
+++ b/webtrit_callkeep_android/docs/phone-connection-service.md
@@ -49,7 +49,7 @@ Its responsibilities:
 - Looks up metadata from `ConnectionManager.getPendingMetadata(callId)`.
 - If metadata is not yet available (race condition), falls back to extracting from the `request`
   Bundle.
-- Calls `performEventHandle(DidPushIncomingCall, ...)` to notify the main process.
+- Calls `performEventHandle(IncomingConnectionReported, ...)` to notify the main process.
 - If `ConnectionManager.consumeAnswer(callId)` returns true (deferred answer), calls
   `connection.onAnswer()` immediately.
 


### PR DESCRIPTION
## Overview

The internal `CallLifecycleEvent.DidPushIncomingCall` borrowed the name of the PUBLIC delegate
callback `didPushIncomingCall`, but the event is really a cross-process connection-lifecycle fact -
"an incoming `PhoneConnection` was created in `:callkeep_core`" (`onCreateIncomingConnection`) - and
its handler does **registration + delivery**, not just the push notification. The shared name hid
that overload and conflated an internal IPC event with the host-facing API.

This renames the internal event + handler to say what they are. The public
`PDelegateFlutterApi.didPushIncomingCall` callback is the host contract and is left untouched - it
is now used only at the delivery boundary.

## Changes

- `CallLifecycleEvent.DidPushIncomingCall` -> `IncomingConnectionReported` (app-scoped broadcast
  action; emitted from both the Telecom and Standalone backends). Handler
  `handleCSReportDidPushIncomingCall` -> `handleCSIncomingConnectionReported`.
- Split the handler into two named steps (same single broadcast, same order):
  - `registerIncomingConnection(metadata)` - promote into the shadow tracker + wakelock + resolve
    the pending `reportNewIncomingCall` Pigeon callback.
  - `deliverIncomingToDelegate(metadata)` - the public `didPushIncomingCall` (with the existing
    app-reported suppression guard).
- Update comments and `docs/`.

## Notes

- Register + deliver stay in the same handler / single cross-process broadcast on purpose: keeping
  them atomic avoids the broadcast-ordering hazard that a second event would introduce.
- The public `didPushIncomingCall` (Pigeon `PDelegateFlutterApi`) is unchanged; the rename is
  internal only (app-scoped action string, both processes in one APK -> no IPC-contract break).
- `deliverIncomingToDelegate` is a single, named delivery point that the delegate-attach replay work
  can reuse later.
- No behaviour change. Gradle unit tests + analyze + flutter test green.
