### PR TITLE
docs(android): document incoming-call delivery paths + mark SMS trigger dormant

### DIFF
--- a/webtrit_callkeep_android/docs/background-services.md
+++ b/webtrit_callkeep_android/docs/background-services.md
@@ -17,7 +17,9 @@ Flutter app is backgrounded or killed.
 
 ### Responsibility
 
-Spawned when an FCM push notification (or SMS trigger) announces an incoming call. It:
+Spawned when an FCM push notification (or the dormant SMS trigger — not tested / not actively
+developed, see [incoming-call-handling.md](incoming-call-handling.md)) announces an incoming call.
+It:
 
 1. Starts a short-lived Flutter background isolate.
 2. Shows the incoming-call notification / system UI.
@@ -27,9 +29,9 @@ Spawned when an FCM push notification (or SMS trigger) announces an incoming cal
 ### Lifecycle
 
 - Started via:
-  - `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall()` (from Dart or a
+    - `BackgroundPushNotificationIsolateBootstrapApi.reportNewIncomingCall()` (from Dart or a
       background message handler).
-  - `NotificationManager.showIncomingCallNotification()` (from FCM handler code).
+    - `NotificationManager.showIncomingCallNotification()` (from FCM handler code).
 - `onCreate()` — calls `startForeground()` with a placeholder notification immediately to avoid
   Android's 10-second ANR window for foreground service start; subscribes to `CallkeepCore`
   events via `CallkeepCore.instance.addConnectionEventListener(this)`.

--- a/webtrit_callkeep_android/docs/foreground-service.md
+++ b/webtrit_callkeep_android/docs/foreground-service.md
@@ -93,7 +93,7 @@ registered `ConnectionEventListener`. `ForegroundService` does not register its 
 
 | Event                 | Handler                               | Main Action                                                              |
 |-----------------------|---------------------------------------|--------------------------------------------------------------------------|
-| `IncomingConnectionReported`    | `handleCSIncomingConnectionReported()`    | Promote call in tracker, call `performIncomingCall()` on Dart delegate   |
+| `IncomingConnectionReported`    | `handleCSIncomingConnectionReported()`    | `registerIncomingConnection()` (promote + wakelock + resolve pending Pigeon callback) then `deliverIncomingToDelegate()` (`didPushIncomingCall`) |
 | `ConnectionStateChanged` | `handleCSReportConnectionStateChanged()` | `updateState()` -- mirror the authoritative connection state into the tracker |
 | `AnswerCall`             | `handleCSReportAnswerCall()`             | `markAnswered()` guard in tracker, call `performAnswerCall()` on Dart delegate |
 | `DeclineCall`         | `handleCSReportDeclineCall()`         | `markTerminated()`, call `performEndCall()`                              |

--- a/webtrit_callkeep_android/docs/incoming-call-handling.md
+++ b/webtrit_callkeep_android/docs/incoming-call-handling.md
@@ -14,7 +14,8 @@ Color: blue = callkeep, orange = host app, grey = external (Telecom / system UI)
 
 ## Who owns the background work
 
-After a call is reported and `IncomingCallService` starts, `IncomingCallHandler.maybeInitBackgroundHandling`
+After a call is reported and `IncomingCallService` starts,
+`IncomingCallHandler.maybeInitBackgroundHandling`
 decides whether callkeep spawns its own background isolate:
 
 ```mermaid
@@ -65,3 +66,37 @@ sequenceDiagram
         PCS->>SYS: dismiss incoming UI
     end
 ```
+
+## Delivery to the Flutter delegate
+
+Surfacing the incoming call in a Flutter delegate (`didPushIncomingCall`) happens through different
+channels depending on where the call materialises and which engine is attached. There are two
+`ConnectionEventListener`s: `ForegroundService` (main process, **bound to the Activity** — the
+foreground delegate) and `IncomingCallService` (background isolate); see
+[foreground-service.md](foreground-service.md) and [background-services.md](background-services.md).
+
+| Context                                                               | How the delegate learns of the incoming call                                                                                                      | Live `IncomingConnectionReported` -> `didPushIncomingCall`                                                                                       |
+|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Foreground signaling (`reportNewIncomingCall`)                        | The app's own signaling creates the call in Dart (`__onCallSignalingEventIncoming`)                                                               | **suppressed** — `reportNewIncomingCall` set the `reportedIncoming` guard, so the broadcast is not re-delivered (would duplicate the ActiveCall) |
+| Push -> foreground handoff (call exists before the Activity comes up) | `onDelegateSet` -> `replayConnectionStates` -> `ReplayIncomingCall` -> `didPushIncomingCall` re-delivers on attach                                | not the delivery — it fired before `ForegroundService` was alive                                                                                 |
+| Background, app dead                                                  | `IncomingCallService` shows the call directly via `IncomingCallHandler` on its own isolate delegate; its event listener only acts on `AnswerCall` | not used by `IncomingCallService`                                                                                                                |
+| SMS trigger (`IncomingCallSmsTriggerReceiver` -> `startIncomingCall`) | No signaling and the delegate is already attached (Activity up), so the live `didPushIncomingCall` is the only delivery                           | the delivery — but the SMS path is dormant (see below)                                                                                           |
+
+**Invariant.** `ForegroundService` is the foreground `ConnectionEventListener` and is bound to the
+Activity lifecycle (`bindForegroundService` on attach, `unbind + stop` on detach). Its live
+`IncomingConnectionReported` -> `didPushIncomingCall` delivery is therefore **foreground-only**.
+With the SMS trigger not in use, every real foreground incoming reaches the delegate via either its
+own signaling (live delivery suppressed) or the `onDelegateSet` replay (handoff) — so the live
+delivery has **no remaining live consumer**; it is kept only as the contract for the dormant SMS
+path. Background incoming is delivered by `IncomingCallService` directly, not by this event. The
+`IncomingConnectionReported` event itself is still load-bearing for its **registration** side
+(promote into the shadow tracker + resolve the pending `reportNewIncomingCall` Pigeon callback),
+which is independent of the delegate delivery.
+
+## SMS-triggered incoming (dormant / likely deprecated)
+
+The SMS-based incoming-call trigger (`IncomingCallSmsTriggerReceiver` +
+`SmsReceptionConfigBootstrapApi.initializeSmsReception`, message prefix `<#> WEBTRIT:`) is
+**currently not tested and not actively developed — treat it as dormant / likely deprecated**. It
+is the only path that relies on the live `IncomingConnectionReported` -> `didPushIncomingCall`
+delivery while the app is foreground. Do not assume it is exercised; verify before depending on it.

--- a/webtrit_callkeep_android/docs/pigeon-apis.md
+++ b/webtrit_callkeep_android/docs/pigeon-apis.md
@@ -121,6 +121,8 @@ Implemented by: `BackgroundPushNotificationIsolateBootstrapApi`
 ### `SmsReceptionConfigBootstrapApi`
 
 Configures the optional SMS-based incoming call trigger (`IncomingCallSmsTriggerReceiver`).
+**Dormant / likely deprecated**: not tested and not actively developed; see
+[incoming-call-handling.md](incoming-call-handling.md) (SMS-triggered incoming).
 
 ---
 

--- a/webtrit_callkeep_android/docs/plugin.md
+++ b/webtrit_callkeep_android/docs/plugin.md
@@ -21,7 +21,8 @@ Called once when the Flutter engine attaches:
   storage so services can access them without a Flutter engine).
 - Registers bootstrap APIs for background isolates:
   - `BackgroundPushNotificationIsolateBootstrapApi` (push-triggered incoming call service)
-  - `SmsReceptionConfigBootstrapApi` (optional SMS fallback)
+  - `SmsReceptionConfigBootstrapApi` (optional SMS fallback — dormant / likely deprecated, see
+    [incoming-call-handling.md](incoming-call-handling.md))
 - Registers `PHostDiagnosticsApi`, `PHostPermissionsApi`, `PHostActivityControlApi`,
   `PHostConnectionsApi`, `PHostSoundApi`.
 


### PR DESCRIPTION
## Overview

The incoming-call **delivery-to-Flutter-delegate** behaviour (which channel surfaces the call in a
delegate, per context) was not documented anywhere. This adds it, and records the architectural
invariant we relied on, plus the current status of the SMS trigger. Docs only - no code change.

## Changes

- `incoming-call-handling.md`: new **"Delivery to the Flutter delegate"** section - a matrix of how
  the incoming call reaches a delegate per context, plus the invariant:
  - foreground signaling -> the app's own Dart event (`__onCallSignalingEventIncoming`); the live
    `IncomingConnectionReported -> didPushIncomingCall` is **suppressed** (reportedIncoming guard);
  - push -> foreground handoff -> `onDelegateSet -> replayConnectionStates -> ReplayIncomingCall`;
  - background, app dead -> `IncomingCallService` delivers directly (its event listener only acts on
    `AnswerCall`);
  - SMS trigger -> the live `didPushIncomingCall` (the only path that relies on it).
  - Invariant: `ForegroundService` is the **Activity-bound** foreground `ConnectionEventListener`,
    so its live delivery is foreground-only; with SMS not in use it has **no remaining live
    consumer** - the event stays load-bearing only for **registration** (promote + resolve the
    pending `reportNewIncomingCall` Pigeon callback).
- New **"SMS-triggered incoming (dormant / likely deprecated)"** note, cross-referenced from
  `background-services.md`, `pigeon-apis.md`, `plugin.md`.
- `foreground-service.md`: the `IncomingConnectionReported` handler row now reflects the
  register/deliver split.

## Notes

- Captures findings established by reading the code: `ForegroundService` bind/unbind on Activity
  attach/detach; the two `ConnectionEventListener`s; `IncomingCallService.onConnectionEvent` only
  handling `AnswerCall`.
- No behaviour change; this documents existing behaviour and the SMS feature status (not tested /
  not actively developed).
