### PR TITLE
fix: suppress ghost incoming when call terminated before connection-state replay

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -275,7 +275,8 @@ enum class PEndCallReasonEnum(val raw: Int) {
   UNANSWERED(2),
   ANSWERED_ELSEWHERE(3),
   DECLINED_ELSEWHERE(4),
-  MISSED(5);
+  MISSED(5),
+  MISSED_WHILE_CONNECTING(6);
 
   companion object {
     fun ofRaw(raw: Int): PEndCallReasonEnum? {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -160,11 +160,11 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
-    /** Record that the app just ended [callId]; see [ConnectionTracker.markRecentlyEnded]. */
-    fun markRecentlyEnded(callId: String)
+    /** See [ConnectionTracker.markEndedWithoutFlutterState]. */
+    fun markEndedWithoutFlutterState(callId: String)
 
-    /** Returns true if the app recently ended [callId]; see [ConnectionTracker.wasRecentlyEnded]. */
-    fun wasRecentlyEnded(callId: String): Boolean
+    /** See [ConnectionTracker.consumeEndedWithoutFlutterState]. */
+    fun consumeEndedWithoutFlutterState(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -163,8 +163,8 @@ interface CallkeepCore {
     /** See [ConnectionTracker.markEndedWithoutFlutterState]. */
     fun markEndedWithoutFlutterState(callId: String)
 
-    /** See [ConnectionTracker.consumeEndedWithoutFlutterState]. */
-    fun consumeEndedWithoutFlutterState(callId: String): Boolean
+    /** See [ConnectionTracker.wasEndedWithoutFlutterState]. */
+    fun wasEndedWithoutFlutterState(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/CallkeepCore.kt
@@ -160,6 +160,12 @@ interface CallkeepCore {
 
     fun markEndCallDispatched(callId: String): Boolean
 
+    /** Record that the app just ended [callId]; see [ConnectionTracker.markRecentlyEnded]. */
+    fun markRecentlyEnded(callId: String)
+
+    /** Returns true if the app recently ended [callId]; see [ConnectionTracker.wasRecentlyEnded]. */
+    fun wasRecentlyEnded(callId: String): Boolean
+
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -124,10 +124,11 @@ interface ConnectionTracker {
     fun markEndedWithoutFlutterState(callId: String)
 
     /**
-     * Returns true (and removes the mark) if [markEndedWithoutFlutterState] was recorded for
-     * [callId]. Consumed on first read so a genuine later reuse of the same id is not blocked.
+     * Returns true if [markEndedWithoutFlutterState] was recorded for [callId]. Sticky (not removed
+     * on read): a stale handshake can replay the dead incoming several times, so every
+     * re-presentation must be rejected, not just the first. Cleared on tearDown via [clear].
      */
-    fun consumeEndedWithoutFlutterState(callId: String): Boolean
+    fun wasEndedWithoutFlutterState(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Read operations

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -112,21 +112,22 @@ interface ConnectionTracker {
     fun markEndCallDispatched(callId: String): Boolean
 
     /**
-     * Record that the app just ended [callId] (signaling hangup or explicit endCall).
-     * Time-stamped so [wasRecentlyEnded] can expire the mark after a short TTL.
+     * Record that the app ended [callId] while it was never presented in Flutter state (the
+     * call==null signaling-hangup path). Used to reject a stale ghost re-presentation of the same
+     * call: in a push->foreground handoff the connection-state replay can re-drive an incoming call
+     * for a callId the signaling layer already hung up, arriving as a fresh reportNewIncomingCall.
      *
-     * Used to suppress a ghost re-presentation: in a push->foreground handoff the
-     * connection-state replay can re-drive an incoming call for a callId the signaling
-     * layer already hung up, arriving as a fresh reportNewIncomingCall seconds later.
+     * Semantic, not time-based: a transfer-back always reuses a call the app DID know about, so its
+     * end never lands here - the mark therefore distinguishes a ghost from a legitimate reuse
+     * without any timing window.
      */
-    fun markRecentlyEnded(callId: String)
+    fun markEndedWithoutFlutterState(callId: String)
 
     /**
-     * Returns true if [markRecentlyEnded] was called for [callId] within the recent-ended
-     * TTL window. Distinct from [isTerminated]: this is a short-lived, time-bounded mark
-     * so a legitimate same-id call arriving later is NOT blocked (unlike a permanent guard).
+     * Returns true (and removes the mark) if [markEndedWithoutFlutterState] was recorded for
+     * [callId]. Consumed on first read so a genuine later reuse of the same id is not blocked.
      */
-    fun wasRecentlyEnded(callId: String): Boolean
+    fun consumeEndedWithoutFlutterState(callId: String): Boolean
 
     // -------------------------------------------------------------------------
     // Read operations

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/ConnectionTracker.kt
@@ -111,6 +111,23 @@ interface ConnectionTracker {
      */
     fun markEndCallDispatched(callId: String): Boolean
 
+    /**
+     * Record that the app just ended [callId] (signaling hangup or explicit endCall).
+     * Time-stamped so [wasRecentlyEnded] can expire the mark after a short TTL.
+     *
+     * Used to suppress a ghost re-presentation: in a push->foreground handoff the
+     * connection-state replay can re-drive an incoming call for a callId the signaling
+     * layer already hung up, arriving as a fresh reportNewIncomingCall seconds later.
+     */
+    fun markRecentlyEnded(callId: String)
+
+    /**
+     * Returns true if [markRecentlyEnded] was called for [callId] within the recent-ended
+     * TTL window. Distinct from [isTerminated]: this is a short-lived, time-bounded mark
+     * so a legitimate same-id call arriving later is NOT blocked (unlike a permanent guard).
+     */
+    fun wasRecentlyEnded(callId: String): Boolean
+
     // -------------------------------------------------------------------------
     // Read operations
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -188,8 +188,8 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndedWithoutFlutterState(callId: String) = tracker.markEndedWithoutFlutterState(callId)
 
-    override fun consumeEndedWithoutFlutterState(callId: String): Boolean =
-        tracker.consumeEndedWithoutFlutterState(callId)
+    override fun wasEndedWithoutFlutterState(callId: String): Boolean =
+        tracker.wasEndedWithoutFlutterState(callId)
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -186,6 +186,10 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndCallDispatched(callId: String): Boolean = tracker.markEndCallDispatched(callId)
 
+    override fun markRecentlyEnded(callId: String) = tracker.markRecentlyEnded(callId)
+
+    override fun wasRecentlyEnded(callId: String): Boolean = tracker.wasRecentlyEnded(callId)
+
     // -------------------------------------------------------------------------
     // Connection event receivers
     // -------------------------------------------------------------------------

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/InProcessCallkeepCore.kt
@@ -186,9 +186,10 @@ class InProcessCallkeepCore internal constructor(
 
     override fun markEndCallDispatched(callId: String): Boolean = tracker.markEndCallDispatched(callId)
 
-    override fun markRecentlyEnded(callId: String) = tracker.markRecentlyEnded(callId)
+    override fun markEndedWithoutFlutterState(callId: String) = tracker.markEndedWithoutFlutterState(callId)
 
-    override fun wasRecentlyEnded(callId: String): Boolean = tracker.wasRecentlyEnded(callId)
+    override fun consumeEndedWithoutFlutterState(callId: String): Boolean =
+        tracker.consumeEndedWithoutFlutterState(callId)
 
     // -------------------------------------------------------------------------
     // Connection event receivers

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -60,10 +60,11 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
 
     // callIds the app ended while they were never presented in Flutter state (the call==null
-    // signaling-hangup path). Used by reportNewIncomingCall to reject a stale ghost re-presentation
-    // of such a call. Consumed on first read, so a genuine later reuse of the same id is not blocked.
-    // Not time-based: a transfer-back always reuses a call the app DID know, so its end never lands
-    // here - making this a semantic discriminator rather than a timing bet.
+    // signaling-hangup path). Used by reportNewIncomingCall to reject EVERY stale ghost
+    // re-presentation of such a call (a stale handshake can replay the dead incoming several times,
+    // so this is a sticky flag, not one-shot). Cleared on tearDown via clear(). Not time-based: a
+    // transfer-back always reuses a call the app DID know, so its end never lands here - making this
+    // a semantic discriminator rather than a timing bet, and safe to keep sticky.
     private val endedWithoutFlutterStateCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // -------------------------------------------------------------------------
@@ -323,8 +324,8 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         endedWithoutFlutterStateCallIds.add(callId)
     }
 
-    override fun consumeEndedWithoutFlutterState(callId: String): Boolean =
-        endedWithoutFlutterStateCallIds.remove(callId)
+    override fun wasEndedWithoutFlutterState(callId: String): Boolean =
+        endedWithoutFlutterStateCallIds.contains(callId)
 
     companion object {
         /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -4,7 +4,6 @@ import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PCallkeepDisconnectCause
 import com.webtrit.callkeep.PCallkeepDisconnectCauseType
-import android.os.SystemClock
 import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import java.util.concurrent.ConcurrentHashMap
@@ -60,9 +59,12 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
     // last known Pigeon connection state per callId, kept for getConnections() queries
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
 
-    // callId -> elapsedRealtime() when the app last ended the call. Short-lived (see
-    // RECENTLY_ENDED_TTL_MS); used by reportNewIncomingCall to reject a ghost re-presentation.
-    private val recentlyEndedAtElapsedMs = ConcurrentHashMap<String, Long>()
+    // callIds the app ended while they were never presented in Flutter state (the call==null
+    // signaling-hangup path). Used by reportNewIncomingCall to reject a stale ghost re-presentation
+    // of such a call. Consumed on first read, so a genuine later reuse of the same id is not blocked.
+    // Not time-based: a transfer-back always reuses a call the app DID know, so its end never lands
+    // here - making this a semantic discriminator rather than a timing bet.
+    private val endedWithoutFlutterStateCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // -------------------------------------------------------------------------
     // Write operations — called from ForegroundService broadcast receiver
@@ -302,7 +304,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         connectionStates.clear()
         directNotifiedCallIds.clear()
         endCallDispatchedCallIds.clear()
-        recentlyEndedAtElapsedMs.clear()
+        endedWithoutFlutterStateCallIds.clear()
     }
 
     // -------------------------------------------------------------------------
@@ -317,26 +319,14 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
 
     override fun markEndCallDispatched(callId: String): Boolean = endCallDispatchedCallIds.add(callId)
 
-    override fun markRecentlyEnded(callId: String) {
-        recentlyEndedAtElapsedMs[callId] = SystemClock.elapsedRealtime()
+    override fun markEndedWithoutFlutterState(callId: String) {
+        endedWithoutFlutterStateCallIds.add(callId)
     }
 
-    override fun wasRecentlyEnded(callId: String): Boolean {
-        val endedAt = recentlyEndedAtElapsedMs[callId] ?: return false
-        val fresh = SystemClock.elapsedRealtime() - endedAt < RECENTLY_ENDED_TTL_MS
-        if (!fresh) recentlyEndedAtElapsedMs.remove(callId)
-        return fresh
-    }
+    override fun consumeEndedWithoutFlutterState(callId: String): Boolean =
+        endedWithoutFlutterStateCallIds.remove(callId)
 
     companion object {
-        /**
-         * How long after the app ends a call a fresh reportNewIncomingCall for the same callId is
-         * treated as a ghost re-presentation and rejected. Comfortably covers the observed
-         * push->foreground handoff replay window (~1-2 s) while staying short enough that a
-         * genuine later re-use of the same callId is not blocked.
-         */
-        private const val RECENTLY_ENDED_TTL_MS = 10_000L
-
         /**
          * Process-wide singleton. All main-process components ([ForegroundService],
          * [com.webtrit.callkeep.ConnectionsApi], etc.) share this single instance so that

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTracker.kt
@@ -4,6 +4,7 @@ import com.webtrit.callkeep.PCallkeepConnection
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PCallkeepDisconnectCause
 import com.webtrit.callkeep.PCallkeepDisconnectCauseType
+import android.os.SystemClock
 import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
 import java.util.concurrent.ConcurrentHashMap
@@ -58,6 +59,10 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
 
     // last known Pigeon connection state per callId, kept for getConnections() queries
     private val connectionStates = ConcurrentHashMap<String, PCallkeepConnectionState>()
+
+    // callId -> elapsedRealtime() when the app last ended the call. Short-lived (see
+    // RECENTLY_ENDED_TTL_MS); used by reportNewIncomingCall to reject a ghost re-presentation.
+    private val recentlyEndedAtElapsedMs = ConcurrentHashMap<String, Long>()
 
     // -------------------------------------------------------------------------
     // Write operations — called from ForegroundService broadcast receiver
@@ -297,6 +302,7 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
         connectionStates.clear()
         directNotifiedCallIds.clear()
         endCallDispatchedCallIds.clear()
+        recentlyEndedAtElapsedMs.clear()
     }
 
     // -------------------------------------------------------------------------
@@ -311,7 +317,26 @@ class MainProcessConnectionTracker internal constructor() : ConnectionTracker {
 
     override fun markEndCallDispatched(callId: String): Boolean = endCallDispatchedCallIds.add(callId)
 
+    override fun markRecentlyEnded(callId: String) {
+        recentlyEndedAtElapsedMs[callId] = SystemClock.elapsedRealtime()
+    }
+
+    override fun wasRecentlyEnded(callId: String): Boolean {
+        val endedAt = recentlyEndedAtElapsedMs[callId] ?: return false
+        val fresh = SystemClock.elapsedRealtime() - endedAt < RECENTLY_ENDED_TTL_MS
+        if (!fresh) recentlyEndedAtElapsedMs.remove(callId)
+        return fresh
+    }
+
     companion object {
+        /**
+         * How long after the app ends a call a fresh reportNewIncomingCall for the same callId is
+         * treated as a ghost re-presentation and rejected. Comfortably covers the observed
+         * push->foreground handoff replay window (~1-2 s) while staying short enough that a
+         * genuine later re-use of the same callId is not blocked.
+         */
+        private const val RECENTLY_ENDED_TTL_MS = 10_000L
+
         /**
          * Process-wide singleton. All main-process components ([ForegroundService],
          * [com.webtrit.callkeep.ConnectionsApi], etc.) share this single instance so that

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -17,6 +17,7 @@ import com.webtrit.callkeep.PCallRequestErrorEnum
 import com.webtrit.callkeep.PCallkeepConnectionState
 import com.webtrit.callkeep.PDelegateFlutterApi
 import com.webtrit.callkeep.PEndCallReason
+import com.webtrit.callkeep.PEndCallReasonEnum
 import com.webtrit.callkeep.PHandle
 import com.webtrit.callkeep.PHostApi
 import com.webtrit.callkeep.PIncomingCallError
@@ -453,17 +454,19 @@ class ForegroundService :
     ) {
         logger.i("reportNewIncomingCall: callId=$callId, handle=$handle")
 
-        // Reject a ghost re-presentation: the app just ended this callId (signaling hangup or
-        // explicit endCall), but a connection-state replay from :callkeep_core re-drove the incoming
-        // call and it arrives here seconds later as a fresh registration. Returning
-        // CALL_ID_ALREADY_TERMINATED short-circuits before any Telecom/IncomingCallService work, so
-        // no second ringtone/notification is shown. The Dart CallBloc already handles this error
-        // (treats it as not-an-error and ends the call), so no call is left stranded in state.
-        // Time-bounded (RECENTLY_ENDED_TTL_MS) so a legitimate later re-use of the same callId is
-        // unaffected -- unlike the permanent isTerminated guard, which is intentionally not checked
-        // here (see below).
-        if (core.wasRecentlyEnded(callId)) {
-            logger.i("reportNewIncomingCall: callId=$callId was recently ended; rejecting as terminated to suppress ghost re-presentation")
+        // Reject a stale ghost re-presentation: the app ended this callId while it was never
+        // presented in Flutter state (a push->foreground handoff where the remote hung up before
+        // CallBloc registered the call - reportEndCall with MISSED_WHILE_CONNECTING armed the guard),
+        // and a connection-state replay from :callkeep_core now re-drives the incoming call as a fresh
+        // registration. Returning CALL_ID_ALREADY_TERMINATED short-circuits before any
+        // Telecom/IncomingCallService work, so no second ringtone/notification is shown. The Dart
+        // CallBloc already handles this error (not treated as a failure; the call is ended), so
+        // nothing is stranded. The guard is consumed on read and is armed ONLY by the never-presented
+        // end - a transfer-back reuses a call the app DID know, so it never arms it and re-report
+        // proceeds normally (the permanent isTerminated guard is intentionally not checked here; see
+        // below).
+        if (core.consumeEndedWithoutFlutterState(callId)) {
+            logger.i("reportNewIncomingCall: callId=$callId ended without Flutter state; rejecting as terminated to suppress ghost re-presentation")
             callback(Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED)))
             return
         }
@@ -864,10 +867,15 @@ class ForegroundService :
         // to cross-process latency. Doing it here lets deliverIncomingToDelegate suppress a
         // late-arriving connection-state replay for a call the app already reported as ended.
         core.markTerminated(callId)
-        // Short-lived mark so a ghost re-presentation (a connection-state replay that re-drives
-        // reportNewIncomingCall for this just-ended callId during a push->foreground handoff) is
-        // rejected rather than ringing again. See reportNewIncomingCall.
-        core.markRecentlyEnded(callId)
+        // When the app ends a call it never presented in Flutter state (MISSED_WHILE_CONNECTING:
+        // the remote hung up an incoming call before CallBloc registered it), arm a one-shot guard
+        // so a stale connection-state replay that re-drives reportNewIncomingCall for the same
+        // callId is rejected rather than ringing again. Only this never-presented end arms it - a
+        // transfer-back always reuses a call the app DID know, so it is unaffected. See
+        // reportNewIncomingCall.
+        if (reason.value == PEndCallReasonEnum.MISSED_WHILE_CONNECTING) {
+            core.markEndedWithoutFlutterState(callId)
+        }
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }
@@ -913,10 +921,6 @@ class ForegroundService :
         callback: (Result<PCallRequestError?>) -> Unit,
     ) {
         logger.i("endCall $callId.")
-
-        // The app is explicitly ending this call; suppress a ghost re-presentation for the same
-        // callId for a short window (see reportNewIncomingCall / MainProcessConnectionTracker).
-        core.markRecentlyEnded(callId)
 
         // If there is a deferred reportNewIncomingCall callback waiting for Telecom
         // confirmation, resolve it immediately with null (success). The call was

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -453,6 +453,21 @@ class ForegroundService :
     ) {
         logger.i("reportNewIncomingCall: callId=$callId, handle=$handle")
 
+        // Reject a ghost re-presentation: the app just ended this callId (signaling hangup or
+        // explicit endCall), but a connection-state replay from :callkeep_core re-drove the incoming
+        // call and it arrives here seconds later as a fresh registration. Returning
+        // CALL_ID_ALREADY_TERMINATED short-circuits before any Telecom/IncomingCallService work, so
+        // no second ringtone/notification is shown. The Dart CallBloc already handles this error
+        // (treats it as not-an-error and ends the call), so no call is left stranded in state.
+        // Time-bounded (RECENTLY_ENDED_TTL_MS) so a legitimate later re-use of the same callId is
+        // unaffected -- unlike the permanent isTerminated guard, which is intentionally not checked
+        // here (see below).
+        if (core.wasRecentlyEnded(callId)) {
+            logger.i("reportNewIncomingCall: callId=$callId was recently ended; rejecting as terminated to suppress ghost re-presentation")
+            callback(Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED)))
+            return
+        }
+
         // Build metadata before the early check so we can promote the call into the core shadow
         // tracker even when the call is already answered (cold-start race: ReplayConnectionStates
         // fires handleCSReportAnswerCall on delegate attach, marking the call answered before
@@ -849,6 +864,10 @@ class ForegroundService :
         // to cross-process latency. Doing it here lets deliverIncomingToDelegate suppress a
         // late-arriving connection-state replay for a call the app already reported as ended.
         core.markTerminated(callId)
+        // Short-lived mark so a ghost re-presentation (a connection-state replay that re-drives
+        // reportNewIncomingCall for this just-ended callId during a push->foreground handoff) is
+        // rejected rather than ringing again. See reportNewIncomingCall.
+        core.markRecentlyEnded(callId)
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }
@@ -894,6 +913,10 @@ class ForegroundService :
         callback: (Result<PCallRequestError?>) -> Unit,
     ) {
         logger.i("endCall $callId.")
+
+        // The app is explicitly ending this call; suppress a ghost re-presentation for the same
+        // callId for a short window (see reportNewIncomingCall / MainProcessConnectionTracker).
+        core.markRecentlyEnded(callId)
 
         // If there is a deferred reportNewIncomingCall callback waiting for Telecom
         // confirmation, resolve it immediately with null (success). The call was

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -844,6 +844,11 @@ class ForegroundService :
         if (!IncomingCallService.isRunning) {
             PendingBroadcastQueue.post(PendingBroadcastQueue.incomingReleaseKey(callId))
         }
+        // Mark terminated synchronously in the main-process tracker. startDeclineCall only marks
+        // terminated once the DeclineCall broadcast echoes back from :callkeep_core, which is subject
+        // to cross-process latency. Doing it here lets deliverIncomingToDelegate suppress a
+        // late-arriving connection-state replay for a call the app already reported as ended.
+        core.markTerminated(callId)
         core.startDeclineCall(callMetaData)
         callback.invoke(Result.success(Unit))
     }
@@ -1027,11 +1032,19 @@ class ForegroundService :
     /**
      * Notify the Flutter delegate of an incoming call via the public `didPushIncomingCall` callback.
      * The single delivery point to the foreground delegate, used by the connection-state replay
-     * ([handleCSReplayIncomingCall]) to seed a freshly attached delegate. Delivery is unconditional:
-     * the Dart CallBloc deduplicates by callId, so re-delivering a call the app already knows about
+     * ([handleCSReplayIncomingCall]) to seed a freshly attached delegate. A call already terminated
+     * in the main-process tracker is skipped (see below); otherwise delivery is unconditional: the
+     * Dart CallBloc deduplicates by callId, so re-delivering a call the app already knows about
      * (e.g. from signaling) does not create a second ActiveCall.
      */
     private fun deliverIncomingToDelegate(metadata: CallMetadata) {
+        if (core.isTerminated(metadata.callId)) {
+            // The call was already reported ended in the main process (e.g. a signaling hangup
+            // arrived while the connection-state replay was still in flight from :callkeep_core).
+            // Delivering it now would seed a ghost incoming call into CallBloc for a dead call.
+            logger.w("deliverIncomingToDelegate: callId=${metadata.callId} already terminated; skipping seed")
+            return
+        }
         val handle = metadata.handle
         if (handle == null) {
             // Cannot build a PHandle without a number; skip rather than crash on a

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/foreground/ForegroundService.kt
@@ -461,11 +461,12 @@ class ForegroundService :
         // registration. Returning CALL_ID_ALREADY_TERMINATED short-circuits before any
         // Telecom/IncomingCallService work, so no second ringtone/notification is shown. The Dart
         // CallBloc already handles this error (not treated as a failure; the call is ended), so
-        // nothing is stranded. The guard is consumed on read and is armed ONLY by the never-presented
-        // end - a transfer-back reuses a call the app DID know, so it never arms it and re-report
-        // proceeds normally (the permanent isTerminated guard is intentionally not checked here; see
-        // below).
-        if (core.consumeEndedWithoutFlutterState(callId)) {
+        // nothing is stranded. The guard is sticky (a stale handshake replays the dead incoming
+        // several times, so every re-presentation must be rejected) and is armed ONLY by the
+        // never-presented end - a transfer-back reuses a call the app DID know, so it never arms it
+        // and re-report proceeds normally (the permanent isTerminated guard is intentionally not
+        // checked here; see below).
+        if (core.wasEndedWithoutFlutterState(callId)) {
             logger.i("reportNewIncomingCall: callId=$callId ended without Flutter state; rejecting as terminated to suppress ghost re-presentation")
             callback(Result.success(PIncomingCallError(PIncomingCallErrorEnum.CALL_ID_ALREADY_TERMINATED)))
             return

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -612,4 +612,41 @@ class MainProcessConnectionTrackerTest {
         val drained = tracker.drainUnconnectedPendingCallIds()
         assertFalse(drained.contains("call-1"))
     }
+
+    // -------------------------------------------------------------------------
+    // markEndedWithoutFlutterState / consumeEndedWithoutFlutterState (ghost-call suppression)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `consumeEndedWithoutFlutterState — false for an unmarked call`() {
+        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+    }
+
+    @Test
+    fun `consumeEndedWithoutFlutterState — true after marking`() {
+        tracker.markEndedWithoutFlutterState("call-1")
+        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
+    }
+
+    @Test
+    fun `consumeEndedWithoutFlutterState — is one-shot (second read is false)`() {
+        // The ghost replay is rejected once; a genuine later reuse of the same id is not blocked.
+        tracker.markEndedWithoutFlutterState("call-1")
+        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
+        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+    }
+
+    @Test
+    fun `markEndedWithoutFlutterState — only the marked id is flagged`() {
+        tracker.markEndedWithoutFlutterState("call-1")
+        assertFalse(tracker.consumeEndedWithoutFlutterState("call-2"))
+        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
+    }
+
+    @Test
+    fun `clear — consumeEndedWithoutFlutterState returns false`() {
+        tracker.markEndedWithoutFlutterState("call-1")
+        tracker.clear()
+        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+    }
 }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/core/MainProcessConnectionTrackerTest.kt
@@ -614,39 +614,41 @@ class MainProcessConnectionTrackerTest {
     }
 
     // -------------------------------------------------------------------------
-    // markEndedWithoutFlutterState / consumeEndedWithoutFlutterState (ghost-call suppression)
+    // markEndedWithoutFlutterState / wasEndedWithoutFlutterState (ghost-call suppression)
     // -------------------------------------------------------------------------
 
     @Test
-    fun `consumeEndedWithoutFlutterState — false for an unmarked call`() {
-        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+    fun `wasEndedWithoutFlutterState — false for an unmarked call`() {
+        assertFalse(tracker.wasEndedWithoutFlutterState("call-1"))
     }
 
     @Test
-    fun `consumeEndedWithoutFlutterState — true after marking`() {
+    fun `wasEndedWithoutFlutterState — true after marking`() {
         tracker.markEndedWithoutFlutterState("call-1")
-        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
+        assertTrue(tracker.wasEndedWithoutFlutterState("call-1"))
     }
 
     @Test
-    fun `consumeEndedWithoutFlutterState — is one-shot (second read is false)`() {
-        // The ghost replay is rejected once; a genuine later reuse of the same id is not blocked.
+    fun `wasEndedWithoutFlutterState — is sticky across repeated reads`() {
+        // A stale handshake can replay the dead incoming several times; every re-presentation must
+        // be rejected, so the flag must survive repeated reads (not one-shot).
         tracker.markEndedWithoutFlutterState("call-1")
-        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
-        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+        assertTrue(tracker.wasEndedWithoutFlutterState("call-1"))
+        assertTrue(tracker.wasEndedWithoutFlutterState("call-1"))
+        assertTrue(tracker.wasEndedWithoutFlutterState("call-1"))
     }
 
     @Test
     fun `markEndedWithoutFlutterState — only the marked id is flagged`() {
         tracker.markEndedWithoutFlutterState("call-1")
-        assertFalse(tracker.consumeEndedWithoutFlutterState("call-2"))
-        assertTrue(tracker.consumeEndedWithoutFlutterState("call-1"))
+        assertFalse(tracker.wasEndedWithoutFlutterState("call-2"))
+        assertTrue(tracker.wasEndedWithoutFlutterState("call-1"))
     }
 
     @Test
-    fun `clear — consumeEndedWithoutFlutterState returns false`() {
+    fun `clear — wasEndedWithoutFlutterState returns false`() {
         tracker.markEndedWithoutFlutterState("call-1")
         tracker.clear()
-        assertFalse(tracker.consumeEndedWithoutFlutterState("call-1"))
+        assertFalse(tracker.wasEndedWithoutFlutterState("call-1"))
     }
 }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -152,6 +152,7 @@ enum PEndCallReasonEnum {
   answeredElsewhere,
   declinedElsewhere,
   missed,
+  missedWhileConnecting,
 }
 
 enum PAudioDeviceType {

--- a/webtrit_callkeep_android/lib/src/common/converters.dart
+++ b/webtrit_callkeep_android/lib/src/common/converters.dart
@@ -107,6 +107,8 @@ extension CallkeepEndCallReasonConverter on CallkeepEndCallReason {
         return PEndCallReasonEnum.declinedElsewhere;
       case CallkeepEndCallReason.missed:
         return PEndCallReasonEnum.missed;
+      case CallkeepEndCallReason.missedWhileConnecting:
+        return PEndCallReasonEnum.missedWhileConnecting;
     }
   }
 }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -77,7 +77,7 @@ class PHandle {
   late String value;
 }
 
-enum PEndCallReasonEnum { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed }
+enum PEndCallReasonEnum { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed, missedWhileConnecting }
 
 // TODO: See https://github.com/flutter/flutter/issues/87307
 class PEndCallReason {

--- a/webtrit_callkeep_android/test/converters_test.dart
+++ b/webtrit_callkeep_android/test/converters_test.dart
@@ -218,6 +218,10 @@ void main() {
     test('missed maps to PEndCallReasonEnum.missed', () {
       expect(CallkeepEndCallReason.missed.toPigeon(), PEndCallReasonEnum.missed);
     });
+
+    test('missedWhileConnecting maps to PEndCallReasonEnum.missedWhileConnecting', () {
+      expect(CallkeepEndCallReason.missedWhileConnecting.toPigeon(), PEndCallReasonEnum.missedWhileConnecting);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/webtrit_callkeep_ios/lib/src/common/converters.dart
+++ b/webtrit_callkeep_ios/lib/src/common/converters.dart
@@ -95,6 +95,10 @@ extension CallkeepEndCallReasonConverter on CallkeepEndCallReason {
         return PEndCallReasonEnum.declinedElsewhere;
       case CallkeepEndCallReason.missed:
         return PEndCallReasonEnum.missed;
+      case CallkeepEndCallReason.missedWhileConnecting:
+        // iOS has no push->foreground ghost-call path; the never-presented flag is Android-only.
+        // Collapse to remoteEnded so no iOS pigeon/CallKit change is needed.
+        return PEndCallReasonEnum.remoteEnded;
     }
   }
 }

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_end_call_reason.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_end_call_reason.dart
@@ -1,1 +1,15 @@
-enum CallkeepEndCallReason { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed }
+enum CallkeepEndCallReason {
+  failed,
+  remoteEnded,
+  unanswered,
+  answeredElsewhere,
+  declinedElsewhere,
+  missed,
+
+  /// The call was ended while it was never presented in the Flutter app state - the remote party
+  /// hung up an incoming call before it was registered in CallBloc (e.g. a push->foreground handoff
+  /// where the caller gives up while signaling is still connecting). Distinct from [remoteEnded]:
+  /// it signals that the app never knew about this call, so a later re-presentation of the same
+  /// callId is a stale ghost (NOT a transfer-back, which always reuses a call the app did know).
+  missedWhileConnecting,
+}


### PR DESCRIPTION
## Overview

Fixes the ghost incoming call in the push -> foreground-handoff scenario: the callee taps an incoming-call notification, the app starts, and while signaling is still connecting the caller hangs up. The signaling hangup is dropped (the call is not in CallBloc state yet), but a connection-state replay from :callkeep_core re-drives the incoming call seconds later, ringing/notifying for a call that is already dead.

Root cause is cross-process broadcast latency: the replay can take several seconds to reach the main process; by the time it lands, the signaling hangup has already come and gone.

## Changes

Two layers, because the replay manifests in two places:

1. Delegate seed (deliverIncomingToDelegate): skip delivery when the call is already terminated in the main-process tracker (core.isTerminated). reportEndCall marks termination synchronously in-main instead of relying on the DeclineCall broadcast echo from :callkeep_core.

2. Fresh re-presentation (reportNewIncomingCall): when the app ends a call it never presented in Flutter state, a connection-state replay can re-drive the whole incoming flow and arrive as a new reportNewIncomingCall for the same callId. We reject that, but ONLY for this never-presented case - so a legitimate same-callId reuse / blind transfer-back is never blocked.

## How re-presentation is gated (the important part)

A blind transfer-back reuses the same callId immediately after the previous leg ends, and that is an explicitly supported, integration-tested contract (callkeep_stress_test "callId reuse supported", callkeep_background_services_test "transfer-back"). So time-based suppression is wrong: a real returning call can land in any timing window and would be silently dropped.

Instead the discriminator is semantic, via the end reason:

- New end reason missedWhileConnecting (added additively to PEndCallReasonEnum / CallkeepEndCallReason). The phone emits it (webtrit_phone PR #1407) from the call==null signaling-hangup branch - i.e. only when the app ends a call it never had in CallBloc state.
- reportEndCall(missedWhileConnecting) arms a one-shot flag (markEndedWithoutFlutterState) in MainProcessConnectionTracker. A normal end (real call) and endCall(...) never arm it.
- reportNewIncomingCall consumes the flag; a match returns CALL_ID_ALREADY_TERMINATED before any Telecom / IncomingCallService work, so no second ringtone/notification. The Dart CallBloc already handles that error (not a failure; the call is ended).

Because a transfer-back always reuses a call the app DID know (it ended via a normal path, which never arms the flag), it is unaffected. No timing window, no risk of dropping a real returning call.

## Verification

On-device integration suite (Xiaomi, Android 15), this branch vs develop baseline: identical pass/fail profile, zero new regressions, zero callIdAlreadyTerminated regressions. (An earlier TTL-based attempt on this branch did regress the callId-reuse/transfer-back tests; the integration run caught it and it was replaced by the semantic gate above.) The 4 remaining integration failures are pre-existing flakiness present identically on develop (Telecom timeout / stale async callbacks), unrelated to this change. Kotlin unit tests + Dart converter/tracker tests green.

Paired with webtrit_phone PR #1407.