### PR TITLE
feat(android): background-activity-start permission for lock-screen calls (WT-1349)

### DIFF
--- a/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
@@ -51,6 +51,40 @@ class WebtritCallkeepPermissions {
     return platform.openFullScreenIntentSettings();
   }
 
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// capability (MIUI/HyperOS), which gates showing the incoming-call UI over
+  /// the lock screen.
+  ///
+  /// On non-Android platforms and web, returns
+  /// [CallkeepSpecialPermissionStatus.granted] (the capability does not apply).
+  Future<CallkeepSpecialPermissionStatus> getBackgroundActivityStartPermissionStatus() {
+    if (kIsWeb) {
+      return Future.value(CallkeepSpecialPermissionStatus.granted);
+    }
+
+    if (!Platform.isAndroid) {
+      return Future.value(CallkeepSpecialPermissionStatus.granted);
+    }
+
+    return platform.getBackgroundActivityStartPermissionStatus();
+  }
+
+  /// Attempts to open the OEM permissions screen hosting the "display pop-up
+  /// windows while running in background" toggle.
+  ///
+  /// On non-Android platforms and web, this call does nothing.
+  Future<void> openBackgroundActivityStartSettings() {
+    if (kIsWeb) {
+      return Future.value();
+    }
+
+    if (!Platform.isAndroid) {
+      return Future.value();
+    }
+
+    return platform.openBackgroundActivityStartSettings();
+  }
+
   /// Attempts to open the system settings screen for managing the app's permissions.
   // TODO(Serdun): Add support for iOS.
   Future<void> openSettings() {
@@ -129,10 +163,12 @@ extension CallkeepSpecialPermissionsExtension on CallkeepSpecialPermissions {
   /// If the permission is [CallkeepSpecialPermissions.fullScreenIntent], it checks the full screen intent permission status.
   /// Returns a [Future] that resolves to a [CallkeepSpecialPermissionStatus] indicating the status of the permission.
   Future<CallkeepSpecialPermissionStatus> status() async {
-    if (this == CallkeepSpecialPermissions.fullScreenIntent) {
-      final callkeepPermissions = WebtritCallkeepPermissions();
-      return callkeepPermissions.getFullScreenIntentPermissionStatus();
+    final callkeepPermissions = WebtritCallkeepPermissions();
+    switch (this) {
+      case CallkeepSpecialPermissions.fullScreenIntent:
+        return callkeepPermissions.getFullScreenIntentPermissionStatus();
+      case CallkeepSpecialPermissions.backgroundActivityStart:
+        return callkeepPermissions.getBackgroundActivityStartPermissionStatus();
     }
-    return CallkeepSpecialPermissionStatus.granted;
   }
 }

--- a/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_permissions.dart
@@ -85,6 +85,39 @@ class WebtritCallkeepPermissions {
     return platform.openBackgroundActivityStartSettings();
   }
 
+  /// Status of the OEM "show on lock screen" capability (MIUI/HyperOS), which
+  /// gates showing the incoming-call UI over the lock screen.
+  ///
+  /// On non-Android platforms and web, returns
+  /// [CallkeepSpecialPermissionStatus.granted] (the capability does not apply).
+  Future<CallkeepSpecialPermissionStatus> getShowWhenLockedPermissionStatus() {
+    if (kIsWeb) {
+      return Future.value(CallkeepSpecialPermissionStatus.granted);
+    }
+
+    if (!Platform.isAndroid) {
+      return Future.value(CallkeepSpecialPermissionStatus.granted);
+    }
+
+    return platform.getShowWhenLockedPermissionStatus();
+  }
+
+  /// Attempts to open the OEM permissions screen hosting the "show on lock
+  /// screen" toggle.
+  ///
+  /// On non-Android platforms and web, this call does nothing.
+  Future<void> openShowWhenLockedSettings() {
+    if (kIsWeb) {
+      return Future.value();
+    }
+
+    if (!Platform.isAndroid) {
+      return Future.value();
+    }
+
+    return platform.openShowWhenLockedSettings();
+  }
+
   /// Attempts to open the system settings screen for managing the app's permissions.
   // TODO(Serdun): Add support for iOS.
   Future<void> openSettings() {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -1453,6 +1453,8 @@ interface PHostBackgroundPushNotificationIsolateApi {
 interface PHostPermissionsApi {
   fun getFullScreenIntentPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
   fun openFullScreenIntentSettings(callback: (Result<Unit>) -> Unit)
+  fun getBackgroundActivityStartPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
+  fun openBackgroundActivityStartSettings(callback: (Result<Unit>) -> Unit)
   fun openSettings(callback: (Result<Unit>) -> Unit)
   fun getBatteryMode(callback: (Result<PCallkeepAndroidBatteryMode>) -> Unit)
   /**
@@ -1495,6 +1497,41 @@ interface PHostPermissionsApi {
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             api.openFullScreenIntentSettings{ result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getBackgroundActivityStartPermissionStatus$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.getBackgroundActivityStartPermissionStatus{ result: Result<PSpecialPermissionStatusTypeEnum> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openBackgroundActivityStartSettings$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.openBackgroundActivityStartSettings{ result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -1453,8 +1453,30 @@ interface PHostBackgroundPushNotificationIsolateApi {
 interface PHostPermissionsApi {
   fun getFullScreenIntentPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
   fun openFullScreenIntentSettings(callback: (Result<Unit>) -> Unit)
+  /**
+   * Status of the OEM "display pop-up windows while running in background"
+   * capability (MIUI/HyperOS `OP_BACKGROUND_START_ACTIVITY`), which gates
+   * showing the incoming-call Activity over the lock screen. Best-effort:
+   * reports granted on devices where the capability does not apply.
+   */
   fun getBackgroundActivityStartPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
+  /**
+   * Opens the OEM permissions screen that hosts the "display pop-up windows
+   * while running in background" toggle, with a fallback to app settings.
+   */
   fun openBackgroundActivityStartSettings(callback: (Result<Unit>) -> Unit)
+  /**
+   * Status of the OEM "display pop-up windows while running in background"
+   * MIUI/HyperOS `OP_SHOW_WHEN_LOCKED` capability, which gates showing the
+   * incoming-call Activity over the lock screen. Best-effort: reports
+   * granted on devices where the capability does not apply.
+   */
+  fun getShowWhenLockedPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit)
+  /**
+   * Opens the OEM permissions screen that hosts the "show on lock screen"
+   * toggle, with a fallback to app settings.
+   */
+  fun openShowWhenLockedSettings(callback: (Result<Unit>) -> Unit)
   fun openSettings(callback: (Result<Unit>) -> Unit)
   fun getBatteryMode(callback: (Result<PCallkeepAndroidBatteryMode>) -> Unit)
   /**
@@ -1532,6 +1554,41 @@ interface PHostPermissionsApi {
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             api.openBackgroundActivityStartSettings{ result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getShowWhenLockedPermissionStatus$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.getShowWhenLockedPermissionStatus{ result: Result<PSpecialPermissionStatusTypeEnum> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(GeneratedPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openShowWhenLockedSettings$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.openShowWhenLockedSettings{ result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -53,6 +53,32 @@ class PermissionsApi(
     }
 
     /**
+     * Reports the status of the OEM "display pop-up windows while running in
+     * background" capability (MIUI/HyperOS), which gates showing the incoming
+     * call UI over the lock screen. Best-effort; reports granted where the
+     * capability does not apply.
+     */
+    override fun getBackgroundActivityStartPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit) {
+        val granted = PermissionsHelper(context).isBackgroundActivityStartGranted()
+        val status =
+            if (granted) PSpecialPermissionStatusTypeEnum.GRANTED else PSpecialPermissionStatusTypeEnum.DENIED
+        callback.invoke(Result.success(status))
+    }
+
+    /**
+     * Opens the OEM permissions screen hosting the "display pop-up windows while
+     * running in background" toggle, with a fallback to app settings.
+     */
+    override fun openBackgroundActivityStartSettings(callback: (Result<Unit>) -> Unit) {
+        try {
+            PermissionsHelper(context).launchBackgroundActivityStartSettings()
+            callback.invoke(Result.success(Unit))
+        } catch (e: Exception) {
+            callback.invoke(Result.failure(e))
+        }
+    }
+
+    /**
      * Attempts to open the common system settings screen
      */
     override fun openSettings(callback: (Result<Unit>) -> Unit) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -59,9 +59,12 @@ class PermissionsApi(
      * capability does not apply.
      */
     override fun getBackgroundActivityStartPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit) {
-        val granted = PermissionsHelper(context).isBackgroundActivityStartGranted()
         val status =
-            if (granted) PSpecialPermissionStatusTypeEnum.GRANTED else PSpecialPermissionStatusTypeEnum.DENIED
+            when (PermissionsHelper(context).isBackgroundActivityStartGranted()) {
+                true -> PSpecialPermissionStatusTypeEnum.GRANTED
+                false -> PSpecialPermissionStatusTypeEnum.DENIED
+                null -> PSpecialPermissionStatusTypeEnum.UNKNOWN
+            }
         callback.invoke(Result.success(status))
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/PermissionsApi.kt
@@ -82,6 +82,34 @@ class PermissionsApi(
     }
 
     /**
+     * Reports the status of the OEM "show on lock screen" capability
+     * (MIUI/HyperOS), which gates showing the incoming call UI over the lock
+     * screen. Best-effort; reports granted where the capability does not apply.
+     */
+    override fun getShowWhenLockedPermissionStatus(callback: (Result<PSpecialPermissionStatusTypeEnum>) -> Unit) {
+        val status =
+            when (PermissionsHelper(context).isShowWhenLockedGranted()) {
+                true -> PSpecialPermissionStatusTypeEnum.GRANTED
+                false -> PSpecialPermissionStatusTypeEnum.DENIED
+                null -> PSpecialPermissionStatusTypeEnum.UNKNOWN
+            }
+        callback.invoke(Result.success(status))
+    }
+
+    /**
+     * Opens the OEM permissions screen hosting the "show on lock screen"
+     * toggle, with a fallback to app settings.
+     */
+    override fun openShowWhenLockedSettings(callback: (Result<Unit>) -> Unit) {
+        try {
+            PermissionsHelper(context).launchShowWhenLockedSettings()
+            callback.invoke(Result.success(Unit))
+        } catch (e: Exception) {
+            callback.invoke(Result.failure(e))
+        }
+    }
+
+    /**
      * Attempts to open the common system settings screen
      */
     override fun openSettings(callback: (Result<Unit>) -> Unit) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -41,6 +41,75 @@ class PermissionsHelper(
         context.startActivity(intent)
     }
 
+    /**
+     * Whether this device is a Xiaomi-family build (MIUI/HyperOS), where the
+     * "display pop-up windows while running in background" capability gates
+     * showing an Activity over the lock screen.
+     */
+    fun isXiaomiFamily(): Boolean {
+        val brand = (Build.MANUFACTURER ?: "").lowercase()
+        return brand == "xiaomi" || brand == "redmi" || brand == "poco"
+    }
+
+    /**
+     * Best-effort check of the MIUI/HyperOS "display pop-up windows while running
+     * in background" capability (OP_BACKGROUND_START_ACTIVITY). There is no public
+     * API for it, so this reads the hidden AppOps op via reflection.
+     *
+     * - Non Xiaomi-family devices: treated as granted (capability does not apply).
+     * - Xiaomi-family where the op cannot be read: treated as denied, so the app
+     *   can surface guidance rather than silently failing on the lock screen.
+     */
+    fun isBackgroundActivityStartGranted(): Boolean {
+        if (!isXiaomiFamily()) return true
+        return try {
+            val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as android.app.AppOpsManager
+            val method =
+                android.app.AppOpsManager::class.java.getMethod(
+                    "checkOpNoThrow",
+                    Int::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType,
+                    String::class.java,
+                )
+            val mode =
+                method.invoke(appOps, OP_BACKGROUND_START_ACTIVITY, context.applicationInfo.uid, context.packageName) as Int
+            mode == android.app.AppOpsManager.MODE_ALLOWED
+        } catch (e: Throwable) {
+            Log.w(TAG, "Unable to read background-activity-start AppOp; treating as denied: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Opens the MIUI/HyperOS "Other permissions" editor where the
+     * "display pop-up windows while running in background" toggle lives.
+     * Falls back to app details settings, then to the common settings.
+     */
+    fun launchBackgroundActivityStartSettings() {
+        val pkg = context.packageName
+        val candidates =
+            listOf(
+                Intent()
+                    .setClassName("com.miui.securitycenter", "com.miui.permcenter.permissions.PermissionsEditorActivity")
+                    .putExtra("extra_pkgname", pkg),
+                Intent("miui.intent.action.APP_PERM_EDITOR").putExtra("extra_pkgname", pkg),
+                Intent(
+                    android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    android.net.Uri.fromParts("package", pkg, null),
+                ),
+            )
+        for (intent in candidates) {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            try {
+                context.startActivity(intent)
+                return
+            } catch (e: Exception) {
+                Log.w(TAG, "Background-activity-start settings intent not available: ${e.message}")
+            }
+        }
+        launchSettings()
+    }
+
     fun hasCameraPermission(): Boolean {
         val cameraPermission = context.checkSelfPermission(Manifest.permission.CAMERA)
         return cameraPermission == PackageManager.PERMISSION_GRANTED
@@ -64,5 +133,8 @@ class PermissionsHelper(
 
     companion object {
         private const val TAG = "PermissionsHelper"
+
+        // MIUI/HyperOS AppOps op for "display pop-up windows while running in background".
+        private const val OP_BACKGROUND_START_ACTIVITY = 10021
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -48,7 +48,9 @@ class PermissionsHelper(
      */
     fun isXiaomiFamily(): Boolean {
         val brand = (Build.MANUFACTURER ?: "").lowercase()
-        return brand == "xiaomi" || brand == "redmi" || brand == "poco"
+        // Substring match (not exact equality) to catch reported variants such as
+        // "Xiaomi Communications"; mirrors the detection in CallDiagnostics.
+        return brand.contains("xiaomi") || brand.contains("redmi") || brand.contains("poco")
     }
 
     /**

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -56,11 +56,13 @@ class PermissionsHelper(
      * in background" capability (OP_BACKGROUND_START_ACTIVITY). There is no public
      * API for it, so this reads the hidden AppOps op via reflection.
      *
-     * - Non Xiaomi-family devices: treated as granted (capability does not apply).
-     * - Xiaomi-family where the op cannot be read: treated as denied, so the app
-     *   can surface guidance rather than silently failing on the lock screen.
+     * @return `true` granted (or the capability does not apply on this device),
+     *   `false` explicitly denied, `null` when the state cannot be determined
+     *   (op not readable on this build). Callers should treat `null` as unknown
+     *   rather than denied, to avoid prompting users who may already have granted
+     *   it on builds where the hidden op is inaccessible.
      */
-    fun isBackgroundActivityStartGranted(): Boolean {
+    fun isBackgroundActivityStartGranted(): Boolean? {
         if (!isXiaomiFamily()) return true
         return try {
             val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as android.app.AppOpsManager
@@ -73,10 +75,19 @@ class PermissionsHelper(
                 )
             val mode =
                 method.invoke(appOps, OP_BACKGROUND_START_ACTIVITY, context.applicationInfo.uid, context.packageName) as Int
-            mode == android.app.AppOpsManager.MODE_ALLOWED
+            // MODE_DEFAULT/MODE_FOREGROUND are effectively allowed on MIUI; only an
+            // explicit MODE_IGNORED/MODE_ERRORED denies showing over the lock screen.
+            when (mode) {
+                android.app.AppOpsManager.MODE_ALLOWED,
+                android.app.AppOpsManager.MODE_DEFAULT,
+                android.app.AppOpsManager.MODE_FOREGROUND,
+                -> true
+
+                else -> false
+            }
         } catch (e: Throwable) {
-            Log.w(TAG, "Unable to read background-activity-start AppOp; treating as denied: ${e.message}")
-            false
+            Log.w(TAG, "Unable to read background-activity-start AppOp; reporting unknown: ${e.message}")
+            null
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/PermissionsHelper.kt
@@ -123,6 +123,76 @@ class PermissionsHelper(
         launchSettings()
     }
 
+    /**
+     * Best-effort check of the MIUI/HyperOS "show on lock screen" capability
+     * (OP_SHOW_WHEN_LOCKED). There is no public API for it, so this reads the
+     * hidden AppOps op via reflection.
+     *
+     * @return `true` granted (or the capability does not apply on this device),
+     *   `false` explicitly denied, `null` when the state cannot be determined
+     *   (op not readable on this build). Callers should treat `null` as unknown
+     *   rather than denied, to avoid prompting users who may already have granted
+     *   it on builds where the hidden op is inaccessible.
+     */
+    fun isShowWhenLockedGranted(): Boolean? {
+        if (!isXiaomiFamily()) return true
+        return try {
+            val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as android.app.AppOpsManager
+            val method =
+                android.app.AppOpsManager::class.java.getMethod(
+                    "checkOpNoThrow",
+                    Int::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType,
+                    String::class.java,
+                )
+            val mode =
+                method.invoke(appOps, OP_SHOW_WHEN_LOCKED, context.applicationInfo.uid, context.packageName) as Int
+            // MODE_DEFAULT/MODE_FOREGROUND are effectively allowed on MIUI; only an
+            // explicit MODE_IGNORED/MODE_ERRORED denies showing over the lock screen.
+            when (mode) {
+                android.app.AppOpsManager.MODE_ALLOWED,
+                android.app.AppOpsManager.MODE_DEFAULT,
+                android.app.AppOpsManager.MODE_FOREGROUND,
+                -> true
+
+                else -> false
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "Unable to read show-when-locked AppOp; reporting unknown: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Opens the MIUI/HyperOS "Other permissions" editor where the
+     * "show on lock screen" toggle lives. Falls back to app details settings,
+     * then to the common settings.
+     */
+    fun launchShowWhenLockedSettings() {
+        val pkg = context.packageName
+        val candidates =
+            listOf(
+                Intent()
+                    .setClassName("com.miui.securitycenter", "com.miui.permcenter.permissions.PermissionsEditorActivity")
+                    .putExtra("extra_pkgname", pkg),
+                Intent("miui.intent.action.APP_PERM_EDITOR").putExtra("extra_pkgname", pkg),
+                Intent(
+                    android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    android.net.Uri.fromParts("package", pkg, null),
+                ),
+            )
+        for (intent in candidates) {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            try {
+                context.startActivity(intent)
+                return
+            } catch (e: Exception) {
+                Log.w(TAG, "Show-when-locked settings intent not available: ${e.message}")
+            }
+        }
+        launchSettings()
+    }
+
     fun hasCameraPermission(): Boolean {
         val cameraPermission = context.checkSelfPermission(Manifest.permission.CAMERA)
         return cameraPermission == PackageManager.PERMISSION_GRANTED
@@ -149,5 +219,8 @@ class PermissionsHelper(
 
         // MIUI/HyperOS AppOps op for "display pop-up windows while running in background".
         private const val OP_BACKGROUND_START_ACTIVITY = 10021
+
+        // MIUI/HyperOS AppOps op for "show on lock screen".
+        private const val OP_SHOW_WHEN_LOCKED = 10020
     }
 }

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -1350,6 +1350,43 @@ class PHostPermissionsApi {
     ;
   }
 
+  Future<PSpecialPermissionStatusTypeEnum> getBackgroundActivityStartPermissionStatus() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getBackgroundActivityStartPermissionStatus$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as PSpecialPermissionStatusTypeEnum;
+  }
+
+  Future<void> openBackgroundActivityStartSettings() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openBackgroundActivityStartSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
   Future<void> openSettings() async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -1350,6 +1350,10 @@ class PHostPermissionsApi {
     ;
   }
 
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// capability (MIUI/HyperOS `OP_BACKGROUND_START_ACTIVITY`), which gates
+  /// showing the incoming-call Activity over the lock screen. Best-effort:
+  /// reports granted on devices where the capability does not apply.
   Future<PSpecialPermissionStatusTypeEnum> getBackgroundActivityStartPermissionStatus() async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getBackgroundActivityStartPermissionStatus$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1369,8 +1373,53 @@ class PHostPermissionsApi {
     return pigeonVar_replyValue! as PSpecialPermissionStatusTypeEnum;
   }
 
+  /// Opens the OEM permissions screen that hosts the "display pop-up windows
+  /// while running in background" toggle, with a fallback to app settings.
   Future<void> openBackgroundActivityStartSettings() async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openBackgroundActivityStartSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// MIUI/HyperOS `OP_SHOW_WHEN_LOCKED` capability, which gates showing the
+  /// incoming-call Activity over the lock screen. Best-effort: reports
+  /// granted on devices where the capability does not apply.
+  Future<PSpecialPermissionStatusTypeEnum> getShowWhenLockedPermissionStatus() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.getShowWhenLockedPermissionStatus$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as PSpecialPermissionStatusTypeEnum;
+  }
+
+  /// Opens the OEM permissions screen that hosts the "show on lock screen"
+  /// toggle, with a fallback to app settings.
+  Future<void> openShowWhenLockedSettings() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostPermissionsApi.openShowWhenLockedSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -187,6 +187,16 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<CallkeepSpecialPermissionStatus> getBackgroundActivityStartPermissionStatus() {
+    return _permissionsApi.getBackgroundActivityStartPermissionStatus().then((value) => value.toCallkeep());
+  }
+
+  @override
+  Future<void> openBackgroundActivityStartSettings() {
+    return _permissionsApi.openBackgroundActivityStartSettings();
+  }
+
+  @override
   Future<void> openSettings() {
     return _permissionsApi.openSettings();
   }

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -197,6 +197,16 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<CallkeepSpecialPermissionStatus> getShowWhenLockedPermissionStatus() {
+    return _permissionsApi.getShowWhenLockedPermissionStatus().then((value) => value.toCallkeep());
+  }
+
+  @override
+  Future<void> openShowWhenLockedSettings() {
+    return _permissionsApi.openShowWhenLockedSettings();
+  }
+
+  @override
   Future<void> openSettings() {
     return _permissionsApi.openSettings();
   }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -77,7 +77,15 @@ class PHandle {
   late String value;
 }
 
-enum PEndCallReasonEnum { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed, missedWhileConnecting }
+enum PEndCallReasonEnum {
+  failed,
+  remoteEnded,
+  unanswered,
+  answeredElsewhere,
+  declinedElsewhere,
+  missed,
+  missedWhileConnecting,
+}
 
 // TODO: See https://github.com/flutter/flutter/issues/87307
 class PEndCallReason {
@@ -256,6 +264,18 @@ abstract class PHostPermissionsApi {
 
   @async
   void openFullScreenIntentSettings();
+
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// capability (MIUI/HyperOS `OP_BACKGROUND_START_ACTIVITY`), which gates
+  /// showing the incoming-call Activity over the lock screen. Best-effort:
+  /// reports granted on devices where the capability does not apply.
+  @async
+  PSpecialPermissionStatusTypeEnum getBackgroundActivityStartPermissionStatus();
+
+  /// Opens the OEM permissions screen that hosts the "display pop-up windows
+  /// while running in background" toggle, with a fallback to app settings.
+  @async
+  void openBackgroundActivityStartSettings();
 
   @async
   void openSettings();

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -277,6 +277,18 @@ abstract class PHostPermissionsApi {
   @async
   void openBackgroundActivityStartSettings();
 
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// MIUI/HyperOS `OP_SHOW_WHEN_LOCKED` capability, which gates showing the
+  /// incoming-call Activity over the lock screen. Best-effort: reports
+  /// granted on devices where the capability does not apply.
+  @async
+  PSpecialPermissionStatusTypeEnum getShowWhenLockedPermissionStatus();
+
+  /// Opens the OEM permissions screen that hosts the "show on lock screen"
+  /// toggle, with a fallback to app settings.
+  @async
+  void openShowWhenLockedSettings();
+
   @async
   void openSettings();
 

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_special_permission.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_special_permission.dart
@@ -1,1 +1,1 @@
-enum CallkeepSpecialPermissions { fullScreenIntent }
+enum CallkeepSpecialPermissions { fullScreenIntent, backgroundActivityStart }

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -180,6 +180,19 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('launchFullScreenIntentSettings() has not been implemented.');
   }
 
+  /// Status of the OEM "display pop-up windows while running in background"
+  /// capability (MIUI/HyperOS), which gates showing the incoming-call UI over
+  /// the lock screen. Best-effort; reports granted where it does not apply.
+  Future<CallkeepSpecialPermissionStatus> getBackgroundActivityStartPermissionStatus() {
+    throw UnimplementedError('getBackgroundActivityStartPermissionStatus() has not been implemented.');
+  }
+
+  /// Open the OEM permissions screen hosting the "display pop-up windows while
+  /// running in background" toggle.
+  Future<void> openBackgroundActivityStartSettings() {
+    throw UnimplementedError('openBackgroundActivityStartSettings() has not been implemented.');
+  }
+
   ///  Open the common settings screen
   Future<void> openSettings() {
     throw UnimplementedError('openSettings() has not been implemented.');

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -193,6 +193,18 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('openBackgroundActivityStartSettings() has not been implemented.');
   }
 
+  /// Status of the OEM "show on lock screen" capability (MIUI/HyperOS), which
+  /// gates showing the incoming-call UI over the lock screen. Best-effort;
+  /// reports granted where it does not apply.
+  Future<CallkeepSpecialPermissionStatus> getShowWhenLockedPermissionStatus() {
+    throw UnimplementedError('getShowWhenLockedPermissionStatus() has not been implemented.');
+  }
+
+  /// Open the OEM permissions screen hosting the "show on lock screen" toggle.
+  Future<void> openShowWhenLockedSettings() {
+    throw UnimplementedError('openShowWhenLockedSettings() has not been implemented.');
+  }
+
   ///  Open the common settings screen
   Future<void> openSettings() {
     throw UnimplementedError('openSettings() has not been implemented.');


### PR DESCRIPTION
## Problem

On Xiaomi/HyperOS the incoming-call Activity does not cover the lock screen even though the app side is correct: `USE_FULL_SCREEN_INTENT` is granted, the full-screen intent is applied, and `setShowWhenLocked`/`setTurnScreenOn` are accepted by the framework.

Logcat shows the OEM gate firing repeatedly:
```
ActivityRecordImpl: MIUILOG- Show when locked PermissionDenied pkg : com.webtrit.app
```
even after `setShowWhenLocked(true)` succeeds. The real blocker is the MIUI/HyperOS capability "Display pop-up windows while running in background" (OP_BACKGROUND_START_ACTIVITY), which is separate from the user-facing "Show on lock screen" toggle and has no public API. Granting it removes the denial and produces a proper KEYGUARD_OCCLUDE transition.

## Change

Adds `CallkeepSpecialPermissions.backgroundActivityStart` to the existing special-permission component:

- `getBackgroundActivityStartPermissionStatus()` - best-effort status via the hidden AppOps op (checkOpNoThrow, op 10021), Xiaomi-family only. Reports granted where the capability does not apply; treats an unreadable op as denied so guidance can be surfaced.
- `openBackgroundActivityStartSettings()` - deep links to the MIUI "Other permissions" editor with a fallback to app details and then common settings.

Wiring: pigeon regenerated; platform interface, Android impl, and the `WebtritCallkeepPermissions` facade + `status()` extension updated. No behaviour change on non-Xiaomi devices or iOS.

WT-1349
