### PR TITLE
feat: drive the call-waiting tone from the app on both platforms

### DIFF
--- a/webtrit_callkeep/lib/src/webtrit_callkeep_sound.dart
+++ b/webtrit_callkeep/lib/src/webtrit_callkeep_sound.dart
@@ -28,4 +28,21 @@ class WebtritCallkeepSound {
   Future<void> stopRingbackSound() {
     return platform.stopRingbackSound();
   }
+
+  /// Play the call-waiting tone.
+  /// Use this method to play a soft, recurrent beep over the active call audio
+  /// when a second incoming call arrives.
+  ///
+  /// Returns [Future] that resolves on sound was successfully played.
+  Future<void> playCallWaitingTone() {
+    return platform.playCallWaitingTone();
+  }
+
+  /// Stop the call-waiting tone.
+  /// Use this method when the second call is answered, declined or ended.
+  ///
+  /// Returns [Future] that resolves on sound was successfully stopped.
+  Future<void> stopCallWaitingTone() {
+    return platform.stopCallWaitingTone();
+  }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/Generated.kt
@@ -1641,6 +1641,8 @@ interface PHostDiagnosticsApi {
 interface PHostSoundApi {
   fun playRingbackSound(callback: (Result<Unit>) -> Unit)
   fun stopRingbackSound(callback: (Result<Unit>) -> Unit)
+  fun playCallWaitingTone(callback: (Result<Unit>) -> Unit)
+  fun stopCallWaitingTone(callback: (Result<Unit>) -> Unit)
 
   companion object {
     /** The codec used by PHostSoundApi. */
@@ -1673,6 +1675,40 @@ interface PHostSoundApi {
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             api.stopRingbackSound{ result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playCallWaitingTone$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.playCallWaitingTone{ result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(GeneratedPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopCallWaitingTone$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.stopCallWaitingTone{ result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(GeneratedPigeonUtils.wrapError(error))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/SoundApi.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/SoundApi.kt
@@ -19,4 +19,14 @@ class SoundApi(
         audioManager.stopRingback()
         callback(Result.success(Unit))
     }
+
+    override fun playCallWaitingTone(callback: (Result<Unit>) -> Unit) {
+        audioManager.startCallWaitingTone()
+        callback(Result.success(Unit))
+    }
+
+    override fun stopCallWaitingTone(callback: (Result<Unit>) -> Unit) {
+        audioManager.stopCallWaitingTone()
+        callback(Result.success(Unit))
+    }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnection.kt
@@ -145,8 +145,10 @@ class PhoneConnection internal constructor(
         logger.d("Showing incoming call UI for callId: $callId")
         notificationManager.showIncomingCallNotification(metadata)
         if (PhoneConnectionService.connectionManager.hasActiveOrHoldingConnection()) {
-            logger.d("Active call detected — playing call-waiting tone instead of ringtone for callId: $callId")
-            audioManager.startCallWaitingTone()
+            // Suppress the full ringtone: TYPE_RINGTONE routes through the earpiece at ringer
+            // volume and hurts the user's ear during an active call. The call-waiting tone
+            // itself is driven by the app through the sound API, same as on iOS.
+            logger.d("Active call detected — suppressing ringtone for callId: $callId")
         } else {
             audioManager.startRingtone(metadata.ringtonePath)
         }

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionCallWaitingTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/connection/PhoneConnectionCallWaitingTest.kt
@@ -18,13 +18,14 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 /**
- * Tests for the call-waiting audio branching logic (WT-1388).
+ * Tests for the call-waiting audio branching logic.
  *
  * When a second incoming call arrives while one call is already active or held,
- * [PhoneConnection.onShowIncomingCallUi] must play a soft call-waiting tone via
- * [AudioManager.startCallWaitingTone] instead of the full ringtone. The ringtone
- * uses TYPE_RINGTONE which routes through the earpiece at full ringtone volume and
- * can hurt the user's ear during an active call.
+ * [PhoneConnection.onShowIncomingCallUi] must suppress the full ringtone: it uses
+ * TYPE_RINGTONE which routes through the earpiece at full ringtone volume and can
+ * hurt the user's ear during an active call. The soft call-waiting tone itself is
+ * driven by the app through the sound API ([SoundApi.playCallWaitingTone]), the
+ * same way as on iOS, so the connection must not auto-play it either.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
@@ -92,27 +93,27 @@ class PhoneConnectionCallWaitingTest {
     }
 
     @Test
-    fun `onShowIncomingCallUi plays call-waiting tone when a call is active`() {
+    fun `onShowIncomingCallUi suppresses all local audio when a call is active`() {
         PhoneConnectionService.connectionManager = managerWithActiveCall()
         val mockAudio = mock(AudioManager::class.java)
         val connection = createConnectionWithAudio(mockAudio)
 
         connection.onShowIncomingCallUi()
 
-        verify(mockAudio).startCallWaitingTone()
         verify(mockAudio, never()).startRingtone(null)
+        verify(mockAudio, never()).startCallWaitingTone()
     }
 
     @Test
-    fun `onShowIncomingCallUi plays call-waiting tone when a call is on hold`() {
+    fun `onShowIncomingCallUi suppresses all local audio when a call is on hold`() {
         PhoneConnectionService.connectionManager = managerWithHeldCall()
         val mockAudio = mock(AudioManager::class.java)
         val connection = createConnectionWithAudio(mockAudio)
 
         connection.onShowIncomingCallUi()
 
-        verify(mockAudio).startCallWaitingTone()
         verify(mockAudio, never()).startRingtone(null)
+        verify(mockAudio, never()).startCallWaitingTone()
     }
 
     @Test

--- a/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_android/lib/src/common/callkeep.pigeon.dart
@@ -1528,6 +1528,42 @@ class PHostSoundApi {
     )
     ;
   }
+
+  Future<void> playCallWaitingTone() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.playCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<void> stopCallWaitingTone() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_android.PHostSoundApi.stopCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
 }
 
 abstract class PDelegateBackgroundRegisterFlutterApi {

--- a/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
+++ b/webtrit_callkeep_android/lib/src/webtrit_callkeep_android.dart
@@ -236,6 +236,16 @@ class WebtritCallkeepAndroid extends WebtritCallkeepPlatform {
   }
 
   @override
+  Future<void> playCallWaitingTone() {
+    return _soundApi.playCallWaitingTone();
+  }
+
+  @override
+  Future<void> stopCallWaitingTone() {
+    return _soundApi.stopCallWaitingTone();
+  }
+
+  @override
   Future<CallkeepConnection?> getConnection(String callId) async {
     return _connectionsApi.getConnection(callId).then((value) => value?.toCallkeep());
   }

--- a/webtrit_callkeep_android/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_android/pigeons/callkeep.messages.dart
@@ -288,6 +288,12 @@ abstract class PHostSoundApi {
 
   @async
   void stopRingbackSound();
+
+  @async
+  void playCallWaitingTone();
+
+  @async
+  void stopCallWaitingTone();
 }
 
 @FlutterApi()

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
@@ -1,0 +1,202 @@
+#import "CallWaitingTonePlayer.h"
+
+// Engine-lifecycle notifications posted by the flutter_webrtc plugin (its audio device
+// module drives one AVAudioEngine per call and recreates it on route changes,
+// voice-processing toggles and CallKit (de)activation). The notification object is the
+// AVAudioEngine; DidConfigureOutput carries the wired mixer node and the output format in
+// userInfo. Names are part of the flutter_webrtc plugin contract - keep them in sync.
+static NSString *const AudioEngineDidCreateNotification = @"FlutterWebRTCAudioEngineDidCreate";
+static NSString *const AudioEngineWillStartNotification = @"FlutterWebRTCAudioEngineWillStart";
+static NSString *const AudioEngineDidStopNotification = @"FlutterWebRTCAudioEngineDidStop";
+static NSString *const AudioEngineWillReleaseNotification = @"FlutterWebRTCAudioEngineWillRelease";
+static NSString *const AudioEngineDidConfigureOutputNotification =
+    @"FlutterWebRTCAudioEngineDidConfigureOutput";
+
+static NSString *const AudioEngineSourceUserInfoKey = @"source";
+static NSString *const AudioEngineFormatUserInfoKey = @"format";
+
+@implementation CallWaitingTonePlayer {
+  AVAudioPlayerNode *_player;
+  AVAudioPCMBuffer *_buffer;
+  __weak AVAudioEngine *_engine;
+  BOOL _active;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self selector:@selector(onEngineDidCreate:) name:AudioEngineDidCreateNotification object:nil];
+    [center addObserver:self selector:@selector(onEngineDidConfigureOutput:) name:AudioEngineDidConfigureOutputNotification object:nil];
+    [center addObserver:self selector:@selector(onEngineWillStart:) name:AudioEngineWillStartNotification object:nil];
+    [center addObserver:self selector:@selector(onEngineDidStop:) name:AudioEngineDidStopNotification object:nil];
+    [center addObserver:self selector:@selector(onEngineWillRelease:) name:AudioEngineWillReleaseNotification object:nil];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - Public
+
+- (void)play {
+  @synchronized(self) {
+    _active = YES;
+    [self scheduleAndPlay];  // if the engine is not running yet, the will-start resume kicks in
+  }
+}
+
+- (void)stop {
+  @synchronized(self) {
+    _active = NO;
+    if (_player != nil && _player.isPlaying) {
+      [_player stop];  // flushes the looped buffer
+    }
+  }
+}
+
+#pragma mark - Engine lifecycle (notifications arrive on the WebRTC worker thread)
+
+- (void)onEngineDidCreate:(NSNotification *)notification {
+  AVAudioEngine *engine = notification.object;
+  if (engine == nil) {
+    return;
+  }
+  @synchronized(self) {
+    _engine = engine;
+    if (_player == nil) {
+      _player = [[AVAudioPlayerNode alloc] init];
+    }
+    @try {
+      if (_player.engine != engine) {
+        [engine attachNode:_player];
+      }
+    } @catch (NSException *e) {
+      NSLog(@"[CallWaitingTonePlayer] attach failed: %@", e);
+    }
+  }
+}
+
+- (void)onEngineDidConfigureOutput:(NSNotification *)notification {
+  // Fires after the engine's output graph is wired (source is the main mixer) with the
+  // real output format - the right place and time to connect the player node.
+  AVAudioEngine *engine = notification.object;
+  AVAudioNode *source = notification.userInfo[AudioEngineSourceUserInfoKey];
+  AVAudioFormat *format = notification.userInfo[AudioEngineFormatUserInfoKey];
+  if (engine == nil || source == nil || format == nil) {
+    return;
+  }
+  @synchronized(self) {
+    if (_player == nil || _player.engine != engine) {
+      return;  // attach on engine creation failed; nothing to connect
+    }
+    @try {
+      // AVAudioPlayerNode cannot render Int16; connect with a float32 format at the
+      // output sample rate and let the mixer convert.
+      AVAudioFormat *playerFmt =
+          [[AVAudioFormat alloc] initStandardFormatWithSampleRate:format.sampleRate channels:1];
+      [engine connect:_player to:source format:playerFmt];
+      _buffer = [self toneBufferForFormat:playerFmt];
+    } @catch (NSException *e) {
+      NSLog(@"[CallWaitingTonePlayer] connect failed: %@", e);
+    }
+  }
+}
+
+- (void)onEngineWillStart:(NSNotification *)notification {
+  AVAudioEngine *engine = notification.object;
+  @synchronized(self) {
+    if (_player != nil && _player.engine == engine) {
+      [_player stop];  // scheduled buffers do not survive an engine (re)start
+    }
+  }
+  // No post-start notification exists; resume the active tone once the engine runs.
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   [self scheduleAndPlay];
+                 });
+}
+
+- (void)onEngineDidStop:(NSNotification *)notification {
+  AVAudioEngine *engine = notification.object;
+  @synchronized(self) {
+    if (_player != nil && _player.engine == engine && _player.isPlaying) {
+      [_player stop];
+    }
+  }
+}
+
+- (void)onEngineWillRelease:(NSNotification *)notification {
+  AVAudioEngine *engine = notification.object;
+  @synchronized(self) {
+    if (_player != nil && _player.engine == engine) {
+      if (_player.isPlaying) {
+        [_player stop];
+      }
+      [engine detachNode:_player];
+    }
+    _engine = nil;
+    _buffer = nil;
+  }
+}
+
+#pragma mark - Playback
+
+- (void)scheduleAndPlay {
+  @synchronized(self) {
+    if (!_active) {
+      return;  // only when explicitly requested; the will-start resume calls this blindly
+    }
+    if (_player == nil || _buffer == nil) {
+      return;
+    }
+    if (_engine == nil || !_engine.isRunning) {
+      return;  // resumes via the will-start hook once the engine is running
+    }
+    if (_player.isPlaying) {
+      return;  // already looping; scheduling again would stack another buffer
+    }
+    [_player scheduleBuffer:_buffer
+                     atTime:nil
+                    options:AVAudioPlayerNodeBufferLoops
+          completionHandler:nil];
+    [_player play];
+  }
+}
+
+// 440 Hz "beep-beep" then ~2 s silence, looped. Non-interleaved float32.
+- (AVAudioPCMBuffer *)toneBufferForFormat:(AVAudioFormat *)format {
+  double sr = format.sampleRate;
+  double toneDur = 0.20, gapDur = 0.15, tailDur = 2.0;
+  AVAudioFrameCount toneN = (AVAudioFrameCount)(sr * toneDur);
+  AVAudioFrameCount gapN = (AVAudioFrameCount)(sr * gapDur);
+  AVAudioFrameCount tailN = (AVAudioFrameCount)(sr * tailDur);
+  AVAudioFrameCount total = toneN + gapN + toneN + tailN;
+  AVAudioPCMBuffer *buf = [[AVAudioPCMBuffer alloc] initWithPCMFormat:format frameCapacity:total];
+  if (buf == nil || buf.floatChannelData == NULL) {
+    return nil;  // needs a non-interleaved float format
+  }
+  buf.frameLength = total;
+  const float freq = 440.0f, amp = 0.18f;
+  for (AVAudioChannelCount ch = 0; ch < format.channelCount; ch++) {
+    float *p = buf.floatChannelData[ch];
+    AVAudioFrameCount idx = 0;
+    for (AVAudioFrameCount i = 0; i < toneN; i++, idx++) {
+      p[idx] = amp * sinf(2.0f * (float)M_PI * freq * i / sr);
+    }
+    for (AVAudioFrameCount i = 0; i < gapN; i++, idx++) {
+      p[idx] = 0.0f;
+    }
+    for (AVAudioFrameCount i = 0; i < toneN; i++, idx++) {
+      p[idx] = amp * sinf(2.0f * (float)M_PI * freq * i / sr);
+    }
+    for (AVAudioFrameCount i = 0; i < tailN; i++, idx++) {
+      p[idx] = 0.0f;
+    }
+  }
+  return buf;
+}
+
+@end

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
@@ -1454,4 +1454,38 @@ void SetUpWTPHostSoundApiWithSuffix(id<FlutterBinaryMessenger> binaryMessenger, 
       [channel setMessageHandler:nil];
     }
   }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.playCallWaitingTone", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:WTGetGeneratedCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(playCallWaitingTone:)], @"WTPHostSoundApi api (%@) doesn't respond to @selector(playCallWaitingTone:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api playCallWaitingTone:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:[NSString stringWithFormat:@"%@%@", @"dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.stopCallWaitingTone", messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+        codec:WTGetGeneratedCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(stopCallWaitingTone:)], @"WTPHostSoundApi api (%@) doesn't respond to @selector(stopCallWaitingTone:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api stopCallWaitingTone:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
 }

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -9,6 +9,7 @@
 #import "Generated.h"
 #import "Converters.h"
 #import "NSUUID+v5.h"
+#import "CallWaitingTonePlayer.h"
 
 static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 
@@ -22,6 +23,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   WTPDelegateFlutterApi *_delegateFlutterApi;
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
+  CallWaitingTonePlayer *_callWaitingTone;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -46,6 +48,9 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _delegateFlutterApi = [[WTPDelegateFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
     SetUpWTPHostApi(binaryMessenger, self);
     SetUpWTPHostSoundApi(binaryMessenger, self);
+    // Created eagerly: it has to observe the call engine's lifecycle notifications
+    // from the very first call, not from the first play request.
+    _callWaitingTone = [[CallWaitingTonePlayer alloc] init];
   }
   return self;
 }
@@ -449,9 +454,19 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     completion(nil);
 }
 
-- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{ 
+- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{
     if(_ringback != nil)[_ringback pause];
-    
+
+    completion(nil);
+}
+
+- (void)playCallWaitingTone:(void (^)(FlutterError * _Nullable))completion{
+    [_callWaitingTone play];
+    completion(nil);
+}
+
+- (void)stopCallWaitingTone:(void (^)(FlutterError * _Nullable))completion{
+    [_callWaitingTone stop];
     completion(nil);
 }
 

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/CallWaitingTonePlayer.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/CallWaitingTonePlayer.h
@@ -1,0 +1,28 @@
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Plays a soft, looping call-waiting beep mixed into the active call's audio playout.
+///
+/// A separate player (AVAudioPlayer/AudioServices) is inaudible over a live WebRTC call:
+/// the voice-processing session ducks any audio that is not part of the call's own render
+/// graph. The only audible path is a node inside the call's AVAudioEngine, which is owned
+/// by the WebRTC audio device module. The flutter_webrtc plugin re-broadcasts that
+/// engine's lifecycle as NSNotifications (plain AVFoundation payloads, no WebRTC types),
+/// and this class attaches an AVAudioPlayerNode onto the engine through them.
+///
+/// The instance must be created early (at plugin registration) so it observes the engine
+/// notifications from the very first call. The tone is audible locally only - it enters
+/// the playout graph downstream of the capture path, so the remote side does not hear it.
+@interface CallWaitingTonePlayer : NSObject
+
+/// Starts the looping beep. If the engine is not running yet, playback begins
+/// automatically once it starts. Safe to call repeatedly.
+- (void)play;
+
+/// Stops the beep and keeps it stopped across engine restarts. Safe to call repeatedly.
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
@@ -254,6 +254,8 @@ extern void SetUpWTAndroidHelperHostApiWithSuffix(id<FlutterBinaryMessenger> bin
 @protocol WTPHostSoundApi
 - (void)playRingbackSound:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopRingbackSound:(void (^)(FlutterError *_Nullable))completion;
+- (void)playCallWaitingTone:(void (^)(FlutterError *_Nullable))completion;
+- (void)stopCallWaitingTone:(void (^)(FlutterError *_Nullable))completion;
 @end
 
 extern void SetUpWTPHostSoundApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<WTPHostSoundApi> *_Nullable api);

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -1425,4 +1425,39 @@ class PHostSoundApi {
     )
     ;
   }
+  Future<void> playCallWaitingTone() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.playCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<void> stopCallWaitingTone() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.webtrit_callkeep_ios.PHostSoundApi.stopCallWaitingTone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
 }

--- a/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
+++ b/webtrit_callkeep_ios/lib/src/webtrit_callkeep_ios.dart
@@ -191,6 +191,16 @@ class WebtritCallkeep extends WebtritCallkeepPlatform {
   Future<void> stopRingbackSound() {
     return _soundApi.stopRingbackSound();
   }
+
+  @override
+  Future<void> playCallWaitingTone() {
+    return _soundApi.playCallWaitingTone();
+  }
+
+  @override
+  Future<void> stopCallWaitingTone() {
+    return _soundApi.stopCallWaitingTone();
+  }
 }
 
 class _CallkeepDelegateRelay implements PDelegateFlutterApi {

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -6,9 +6,7 @@ import 'package:pigeon/pigeon.dart';
     dartTestOut: 'test/src/common/test_callkeep.pigeon.dart',
     objcHeaderOut: 'ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h',
     objcSourceOut: 'ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m',
-    objcOptions: ObjcOptions(
-      prefix: 'WT',
-    ),
+    objcOptions: ObjcOptions(prefix: 'WT'),
   ),
 )
 class PIOSOptions {
@@ -36,33 +34,16 @@ class POptions {
   late PAndroidOptions android;
 }
 
-enum PHandleTypeEnum {
-  generic,
-  number,
-  email,
-}
+enum PHandleTypeEnum { generic, number, email }
 
-enum PCallInfoConsts {
-  uuid,
-  dtmf,
-  isVideo,
-  number,
-  name,
-}
+enum PCallInfoConsts { uuid, dtmf, isVideo, number, name }
 
 class PHandle {
   late PHandleTypeEnum type;
   late String value;
 }
 
-enum PEndCallReasonEnum {
-  failed,
-  remoteEnded,
-  unanswered,
-  answeredElsewhere,
-  declinedElsewhere,
-  missed,
-}
+enum PEndCallReasonEnum { failed, remoteEnded, unanswered, answeredElsewhere, declinedElsewhere, missed }
 
 // TODO: See https://github.com/flutter/flutter/issues/87307
 class PEndCallReason {
@@ -101,19 +82,10 @@ class PCallRequestError {
 @HostApi()
 abstract class PHostAndroidServiceApi {
   @async
-  void hungUp(
-    String callId,
-    String uuidString,
-  );
+  void hungUp(String callId, String uuidString);
 
   @async
-  void incomingCall(
-    String callId,
-    String uuidString,
-    PHandle handle,
-    String? displayName,
-    bool hasVideo,
-  );
+  void incomingCall(String callId, String uuidString, PHandle handle, String? displayName, bool hasVideo);
 }
 
 @HostApi()
@@ -131,12 +103,7 @@ abstract class PHostApi {
 
   @ObjCSelector('reportNewIncomingCall:handle:displayName:hasVideo:')
   @async
-  PIncomingCallError? reportNewIncomingCall(
-    String uuidString,
-    PHandle handle,
-    String? displayName,
-    bool hasVideo,
-  );
+  PIncomingCallError? reportNewIncomingCall(String uuidString, PHandle handle, String? displayName, bool hasVideo);
 
   @ObjCSelector('reportConnectingOutgoingCall:')
   @async
@@ -198,11 +165,7 @@ abstract class PHostApi {
 @FlutterApi()
 abstract class PDelegateFlutterApi {
   @ObjCSelector('continueStartCallIntentHandle:displayName:video:')
-  void continueStartCallIntent(
-    PHandle handle,
-    String? displayName,
-    bool video,
-  );
+  void continueStartCallIntent(PHandle handle, String? displayName, bool video);
 
   @ObjCSelector('didPushIncomingCallHandle:displayName:video:callId:uuid:error:')
   void didPushIncomingCall(
@@ -216,12 +179,7 @@ abstract class PDelegateFlutterApi {
 
   @ObjCSelector('performStartCall:handle:displayNameOrContactIdentifier:video:')
   @async
-  bool performStartCall(
-    String uuidString,
-    PHandle handle,
-    String? displayNameOrContactIdentifier,
-    bool video,
-  );
+  bool performStartCall(String uuidString, PHandle handle, String? displayNameOrContactIdentifier, bool video);
 
   @ObjCSelector('performAnswerCall:')
   @async
@@ -290,4 +248,12 @@ abstract class PHostSoundApi {
   @ObjCSelector('stopRingbackSound')
   @async
   void stopRingbackSound();
+
+  @ObjCSelector('playCallWaitingTone')
+  @async
+  void playCallWaitingTone();
+
+  @ObjCSelector('stopCallWaitingTone')
+  @async
+  void stopCallWaitingTone();
 }

--- a/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/webtrit_callkeep_platform_interface.dart
@@ -236,6 +236,21 @@ abstract class WebtritCallkeepPlatform extends PlatformInterface {
     throw UnimplementedError('stopRingbackSound() has not been implemented.');
   }
 
+  /// Play the call-waiting tone: a soft, recurrent beep mixed into the active
+  /// call audio to signal a second incoming call.
+  ///
+  /// Returns [Future] that resolves on sound was successfully played.
+  Future<void> playCallWaitingTone() {
+    throw UnimplementedError('playCallWaitingTone() has not been implemented.');
+  }
+
+  /// Stop the call-waiting tone.
+  ///
+  /// Returns [Future] that resolves on sound was successfully stopped.
+  Future<void> stopCallWaitingTone() {
+    throw UnimplementedError('stopCallWaitingTone() has not been implemented.');
+  }
+
   /// Get the connection details for the given [callId].
   ///
   /// Returns a [Future] resolving to a [CallkeepConnection] if found, or null otherwise.


### PR DESCRIPTION
## Overview

WT-1415. A second incoming call during an active call needs a soft call-waiting beep instead of the full ringtone. Previously Android played it natively inside the connection service while iOS had no tone at all. This PR unifies the model: both platforms expose the same sound API (`playCallWaitingTone`/`stopCallWaitingTone` on `WebtritCallkeepSound`) and the app decides when to play and stop.

### iOS (new capability)

CallKit does not auto-play a call-waiting tone for VoIP calls, and any separate player (`AVAudioPlayer`/`AudioServices`) is ducked to near-silence by the voice-processing audio session while a call is live - the only audible path is inside the call's own `AVAudioEngine`. The new `CallWaitingTonePlayer`:

- observes the engine lifecycle notifications broadcast by the flutter_webrtc plugin (WebTrit/flutter-webrtc#12); payloads are plain AVFoundation, so callkeep gains no WebRTC dependency;
- attaches an `AVAudioPlayerNode` to the call engine's main mixer, synthesizes a 440 Hz beep-beep loop, and re-establishes the node across engine restarts (route changes, CallKit (de)activation) - the beep mixes into the same playout path as the remote voice: audible at in-call volume, local-only.

### Android (behavior change)

- The sound API delegates to the existing `AudioManager.startCallWaitingTone`/`stopCallWaitingTone`.
- `PhoneConnection.onShowIncomingCallUi` no longer auto-plays the tone; it keeps suppressing the full ringtone while a call is active or held (TYPE_RINGTONE routes through the earpiece at ringer volume). The native stop paths (onSilence/onDisconnect/onActiveConnection) remain as a safety net.
- `PhoneConnectionCallWaitingTest` updated to the new contract.

Pigeon files (both platform packages) are hand-extended additively, mirroring the ringback methods, to avoid a full regeneration.

## Testing

- iOS device (iPhone, iOS 26.4): beep audible in the earpiece over the active call when a second call rings; silent with a single call; stops on answer/decline/hangup.
- Android: `./gradlew testDebugUnitTest` green; `flutter analyze` clean across packages.

## Dependencies

- iOS playback requires WebTrit/flutter-webrtc#12 (engine lifecycle notifications).
- Consumed by the webtrit_phone PR that drives the tone from CallBloc.