### PR TITLE
fix: open app UI and swap notification when standalone call is answered

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -101,6 +101,24 @@
         <service android:name=".services.services.foreground.ForegroundService" />
 
         <!--
+          Invisible trampoline behind the Answer action of the standalone incoming-call
+          notification. Android 12+ forbids services launched from a notification action from
+          starting activities (notification trampoline restriction), so the Answer PendingIntent
+          targets this activity instead: it forwards the answer command to StandaloneCallService,
+          brings the host app to the front and finishes. showWhenLocked lets the tap work from the
+          lock-screen notification; the empty taskAffinity keeps this ephemeral activity out of
+          the host app's task.
+        -->
+        <activity
+            android:name=".activities.StandaloneAnswerTrampolineActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:noHistory="true"
+            android:showWhenLocked="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <!--
           [Optional Integration] SMS Fallback Receiver
 
           This receiver is used to trigger the foreground service when an incoming call is announced via SMS,

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/activities/StandaloneAnswerTrampolineActivity.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/activities/StandaloneAnswerTrampolineActivity.kt
@@ -1,0 +1,42 @@
+package com.webtrit.callkeep.activities
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.webtrit.callkeep.common.ActivityHolder
+import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+
+/**
+ * Trampoline for the Answer action of the standalone incoming-call notification.
+ *
+ * Android 12+ blocks activity starts from a service that was launched by a notification
+ * action (notification trampoline restriction). When the Answer PendingIntent targeted
+ * [StandaloneCallService] directly, the ActivityHolder.start() call inside its answer
+ * handler was rejected with "Indirect notification activity start (trampoline) blocked"
+ * whenever the app was in the background. An activity PendingIntent is exempt from that
+ * restriction, so the notification launches this invisible activity instead: it forwards
+ * the answer command to [StandaloneCallService], brings the host app to the front (legal,
+ * because this activity itself is now the foreground) and finishes immediately.
+ */
+class StandaloneAnswerTrampolineActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val forward =
+            Intent(this, StandaloneCallService::class.java).apply {
+                action = intent.action
+                intent.extras?.let { putExtras(it) }
+            }
+        try {
+            startService(forward)
+        } catch (e: Exception) {
+            Log.e(TAG, "onCreate: failed to forward '${intent.action}' to StandaloneCallService", e)
+        }
+        ActivityHolder.start(this)
+        finish()
+    }
+
+    companion object {
+        private const val TAG = "StandaloneAnswerTrampolineActivity"
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneActiveCallNotificationBuilder.kt
@@ -1,0 +1,92 @@
+package com.webtrit.callkeep.notifications
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Person
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.ContextHolder.context
+import com.webtrit.callkeep.managers.NotificationChannelManager.ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+import com.webtrit.callkeep.services.services.connection.StandaloneServiceAction
+
+/**
+ * Builds the ongoing (answered) call notification for the standalone call path - used on devices
+ * that do not expose the [android.software.telecom] system feature.
+ *
+ * Counterpart of [StandaloneIncomingCallNotificationBuilder]: once a call is answered or
+ * established, [StandaloneCallService] replaces its foreground incoming-call notification (which
+ * still carries Answer/Decline actions) with this one, mirroring the Telecom path where the
+ * incoming notification is cancelled on answer and an active-call notification is posted.
+ * The Hang up action is routed directly to [StandaloneCallService] via
+ * [StandaloneServiceAction.HungUpCall]; tapping the notification body opens the app.
+ */
+internal class StandaloneActiveCallNotificationBuilder : NotificationBuilder() {
+    private var callMetaData: CallMetadata? = null
+
+    fun setCallMetaData(callMetaData: CallMetadata) {
+        this.callMetaData = callMetaData
+    }
+
+    private fun createHangUpIntent(metadata: CallMetadata): PendingIntent {
+        val intent =
+            Intent(context, StandaloneCallService::class.java).apply {
+                action = StandaloneServiceAction.HungUpCall.action
+                putExtras(metadata.toBundle())
+            }
+        return PendingIntent.getService(
+            context,
+            // Same request-code scheme as StandaloneIncomingCallNotificationBuilder.createActionIntent:
+            // the action ordinal keeps this PendingIntent distinct from the Answer/Decline ones.
+            StandaloneServiceAction.HungUpCall.ordinal,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    override fun build(): Notification {
+        val meta =
+            requireNotNull(callMetaData) { "Call metadata must be set before building the notification." }
+
+        val callerName = meta.name ?: context.getString(R.string.unknown_caller)
+        val hangUpIntent = createHangUpIntent(meta)
+
+        val builder =
+            Notification.Builder(context, ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID).apply {
+                setSmallIcon(if (meta.hasVideo == true) R.drawable.ic_notification_video else R.drawable.ic_notification)
+                setCategory(NotificationCompat.CATEGORY_CALL)
+                setContentTitle(context.getString(R.string.push_notification_active_call_channel_title))
+                setContentText(callerName)
+                setOngoing(true)
+                setAutoCancel(false)
+                setOnlyAlertOnce(true)
+                setContentIntent(buildOpenAppIntent(context))
+            }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val person =
+                Person
+                    .Builder()
+                    .setName(callerName)
+                    .setImportant(true)
+                    .build()
+            builder
+                .setStyle(Notification.CallStyle.forOngoingCall(person, hangUpIntent))
+                .build()
+        } else {
+            builder
+                .addAction(
+                    Notification.Action
+                        .Builder(
+                            Icon.createWithResource(context, R.drawable.ic_call_hungup),
+                            context.getString(R.string.hang_up_button_text),
+                            hangUpIntent,
+                        ).build(),
+                ).build()
+        }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.webtrit.callkeep.R
+import com.webtrit.callkeep.activities.StandaloneAnswerTrampolineActivity
 import com.webtrit.callkeep.common.ContextHolder.context
 import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.Platform
@@ -52,6 +53,29 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
         )
     }
 
+    /**
+     * Answer must go through [StandaloneAnswerTrampolineActivity] rather than straight to
+     * [StandaloneCallService]: answering has to bring the app UI to the front, and on Android 12+
+     * a service launched from a notification action is not allowed to start activities
+     * (notification trampoline restriction). An activity PendingIntent is exempt; the trampoline
+     * forwards the same action/extras to the service and launches the host app. Decline needs no
+     * UI, so it keeps the direct service PendingIntent from [createActionIntent].
+     */
+    private fun createAnswerActionIntent(metadata: CallMetadata): PendingIntent {
+        val intent =
+            Intent(context, StandaloneAnswerTrampolineActivity::class.java).apply {
+                action = StandaloneServiceAction.AnswerCall.action
+                putExtras(metadata.toBundle())
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+        return PendingIntent.getActivity(
+            context,
+            StandaloneServiceAction.AnswerCall.ordinal,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
     private fun baseBuilder(
         title: String,
         text: String,
@@ -73,7 +97,7 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
         val meta =
             requireNotNull(callMetaData) { "Call metadata must be set before building the notification." }
 
-        val answerIntent = createActionIntent(meta, StandaloneServiceAction.AnswerCall)
+        val answerIntent = createAnswerActionIntent(meta)
         val declineIntent = createActionIntent(meta, StandaloneServiceAction.DeclineCall)
 
         val content = incomingCallContent(meta)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -378,12 +378,13 @@ class StandaloneCallService : Service() {
         fireInitialAudioState(metadata.callId)
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
-        // Mirror PhoneConnection.onAnswer() on the Telecom path, which fires ActivityHolder.start()
-        // after dispatching AnswerCall. Without this, answering from the notification leaves the
-        // CallStyle incoming notification (with its Answer button) on screen and never brings the
-        // app UI to the front - the only visible effect of the tap is the ringtone stopping.
+        // Replace the incoming CallStyle notification (which otherwise keeps its Answer button on
+        // screen for the whole call). Bringing the app UI to the front is NOT done here: on
+        // Android 12+ a service launched from a notification action may not start activities
+        // (notification trampoline restriction - "Indirect notification activity start blocked"),
+        // so the Answer action goes through StandaloneAnswerTrampolineActivity, which starts the
+        // host activity itself before forwarding the answer command to this service.
         showActiveCallNotification(callMetadataMap[metadata.callId]!!)
-        ActivityHolder.start(applicationContext)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -12,6 +12,7 @@ import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
@@ -21,6 +22,7 @@ import com.webtrit.callkeep.models.AudioDevice
 import com.webtrit.callkeep.models.AudioDeviceType
 import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.notifications.StandaloneActiveCallNotificationBuilder
 import com.webtrit.callkeep.notifications.StandaloneIncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
@@ -310,6 +312,21 @@ class StandaloneCallService : Service() {
         startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
     }
 
+    /**
+     * Replaces the foreground incoming-call notification with the ongoing-call variant once the
+     * call is answered or established. The incoming notification is this service's own foreground
+     * notification, so it cannot simply be cancelled (the Telecom path cancels the separate
+     * [com.webtrit.callkeep.services.services.incoming_call.IncomingCallService] notification
+     * instead) - it is re-posted under the same [NOTIFICATION_ID] without Answer/Decline actions.
+     */
+    private fun showActiveCallNotification(metadata: CallMetadata) {
+        val notification =
+            StandaloneActiveCallNotificationBuilder()
+                .apply { setCallMetaData(metadata) }
+                .build()
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+    }
+
     private fun handleOutgoingCall(metadata: CallMetadata) {
         Log.i(TAG, "handleOutgoingCall: callId=${metadata.callId}")
         promoteToForeground()
@@ -334,6 +351,11 @@ class StandaloneCallService : Service() {
         fireInitialAudioState(metadata.callId)
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
+        // Mirror PhoneConnection.establish() on the Telecom path: swap the foreground
+        // notification to the ongoing-call variant and make sure the app UI is visible.
+        showActiveCallNotification(callMetadataMap[metadata.callId]!!)
+        ActivityHolder.start(applicationContext)
+
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
         // mirrors it (replaces the removed markAnswered state-stamping).
@@ -355,6 +377,13 @@ class StandaloneCallService : Service() {
         activateAudio()
         fireInitialAudioState(metadata.callId)
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
+
+        // Mirror PhoneConnection.onAnswer() on the Telecom path, which fires ActivityHolder.start()
+        // after dispatching AnswerCall. Without this, answering from the notification leaves the
+        // CallStyle incoming notification (with its Answer button) on screen and never brings the
+        // app UI to the front - the only visible effect of the tap is the ringtone stopping.
+        showActiveCallNotification(callMetadataMap[metadata.callId]!!)
+        ActivityHolder.start(applicationContext)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow


### PR DESCRIPTION
## Overview

On devices without the `android.software.telecom` feature the calls are managed by `StandaloneCallService` instead of the Telecom-backed `PhoneConnectionService`. On that path, answering an incoming call from the notification was broken in every app state:

- App in foreground: the call was answered, but the CallStyle incoming notification (with its Answer button) stayed on screen for the whole call.
- App in background: the call was answered, but the notification stayed and the app was never brought to the front - the user had to find and reopen the app mid-call.
- App swiped away (cold start via push): tapping Answer only stopped the ringtone. No call was established; repeated taps produced repeated `handleAnswerCall` entries and the call was eventually auto-declined.

Root cause - three Telecom-path responsibilities had no standalone counterpart:

1. Nothing replaced the notification after the answer. On Telecom the incoming notification belongs to `IncomingCallService` and is cancelled on answer, while `PhoneConnection` posts an active-call one. On standalone the incoming notification is the service's own foreground notification, and no code re-posted it.
2. Nothing brought the app UI to the front. On Telecom that is `PhoneConnection.onAnswer()` -> `ActivityHolder.start()` (`ForegroundService.handleCSReportAnswerCall` explicitly relies on it having fired). Doing the same from `StandaloneCallService` is not possible either: on Android 12+ a service launched from a notification action may not start activities (notification trampoline restriction - confirmed on device with "Indirect notification activity start (trampoline) blocked"). The start must come from an activity PendingIntent.
3. In the cold-start case the `AnswerCall` connection event had no consumer at all: `ForegroundService` (main-engine delegate) is not running, and the push-isolate `IncomingCallService` is Telecom-only - it is never started on the standalone path. So the answer never reached Dart/signaling.

## Changes

- New `StandaloneAnswerTrampolineActivity` (invisible: translucent, `noHistory`, `excludeFromRecents`, empty `taskAffinity`, `showWhenLocked`). The Answer action of the standalone incoming-call notification is now an activity PendingIntent to this trampoline - exempt from the trampoline restriction because the notification launches an activity directly. It forwards the answer command to `StandaloneCallService`, brings the host app to the front via `ActivityHolder.start()` (legal - the trampoline itself is the foreground at that point) and finishes. Decline keeps the direct service PendingIntent (no UI needed).
- New `StandaloneActiveCallNotificationBuilder`: ongoing-call notification for the standalone path (`CallStyle.forOngoingCall` on API 31+, plain Hang up action below), with the Hang up action routed to `StandaloneCallService` and the body tap opening the app.
- `StandaloneCallService.handleAnswerCall` and `handleEstablishCall` re-post the foreground notification with the ongoing-call variant under the same notification id (it cannot simply be cancelled - it is the service's own foreground notification; it is removed when the call ends and the service stops). `handleEstablishCall` (Dart-initiated, app in foreground) also calls `ActivityHolder.start()`, mirroring `PhoneConnection.establish()`.
- The cold-start answer needs no new plumbing beyond the trampoline: launching the host activity boots the engine, binds `ForegroundService`, and the existing replay path (`onDelegateSet` -> `ReplayConnectionStates` -> `performAnswerCall`) plus the `callAlreadyAnswered` handling in the app completes the SDP answer once signaling reconnects.

The Telecom path is untouched: the diff only adds standalone-side components and a manifest entry for the new activity.

## Testing

- `./gradlew testDebugUnitTest` passes.
- Verified on a telecom-less tablet (Lenovo TB300FU, Android 13), all three scenarios:
  - Foreground: Answer from the notification answers the call; the incoming notification is replaced by the ongoing-call one with a working Hang up.
  - Background: same, plus the app comes to the foreground via the trampoline (no "Indirect notification activity start blocked" in the log anymore).
  - Swiped away (cold start via push): the tap launches the trampoline, the host activity starts, the notification swaps; after the engine boots, the replay path fires `performAnswerCall`, the redelivered incoming offer is auto-answered (`callAlreadyAnswered=true`) and the call reaches `connected` with ICE up. On this slow tablet tap-to-connected took ~33 s, dominated by the full engine boot; the call keeps ringing meanwhile. A future optimization could answer from a lightweight isolate without booting the full UI engine (standalone counterpart of `IncomingCallService`).

Known adjacent gap, intentionally out of scope: declining a second incoming call while another call is active leaves the stale incoming notification for the declined call (no re-post on `endCall`/decline).
