### PR TITLE
fix: promote standalone call service with phone-call type instead of microphone

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -79,14 +79,24 @@
           permanently marking the process as "bad" and preventing all subsequent service starts.
           Since there is no Telecom framework managing the lifecycle of this service, running in
           the main process is safe and avoids OEM background-start restrictions.
-          Uses microphone foreground service type because phoneCall type requires the Telecom
-          subsystem, which is absent on devices that use this service.
+
+          Foreground service type is two-phase at runtime:
+          - ringing / call setup promotes with phoneCall only. Since Android 14 the microphone
+            type is while-in-use restricted and cannot be started from a background app state
+            (no exemption applies, incl. high-priority FCM), which crashed the service in a loop
+            on every push-delivered incoming call. The phoneCall type is unrestricted; its only
+            runtime prerequisites are the FOREGROUND_SERVICE_PHONE_CALL and MANAGE_OWN_CALLS
+            permissions declared above. Contrary to an earlier assumption recorded here, it does
+            NOT require the android.software.telecom feature or an active Telecom connection.
+          - once the call is answered/established the service re-promotes with
+            phoneCall|microphone (the app has a visible activity at that point) so microphone
+            access survives the app going to background mid-call.
         -->
         <service
             android:name=".services.services.connection.StandaloneCallService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="microphone" />
+            android:foregroundServiceType="phoneCall|microphone" />
 
         <service
             android:name=".services.services.incoming_call.IncomingCallService"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -77,6 +77,18 @@ class StandaloneCallService : Service() {
     // guarantees a visible activity (StandaloneAnswerTrampolineActivity for notification
     // answers, the host activity for Dart-initiated answer/establish).
     //
+    // TODO(standalone-active-call): the active-call phase does not belong to this service.
+    // On the Telecom path it is owned by ActiveCallService (phoneCall|microphone|camera with
+    // permission-aware types and its own notification), started via
+    // NotificationManager.showActiveCallNotification() - which is only ever called from
+    // PhoneConnection, so it never runs on the standalone path. Once the standalone answer/
+    // establish/end handlers drive NotificationManager the same way (and this service demotes
+    // itself after the answer instead of re-posting its own ongoing notification), the
+    // microphone type below and showActiveCallNotification()/
+    // StandaloneActiveCallNotificationBuilder can be removed, returning this service to a pure
+    // phone-call-typed connection host. That also brings the camera type for video calls in
+    // the background, which the current shape does not cover.
+    //
     // On API < 31 both getters return null, selecting the 2-arg startForeground() fallback in
     // startForegroundServiceCompat(): type validation is skipped there and the microphone
     // constant does not exist before API 31.

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -59,15 +59,39 @@ class StandaloneCallService : Service() {
     // notification when there is no call in progress.
     private var isForeground = false
 
-    // FOREGROUND_SERVICE_TYPE_MICROPHONE was introduced in API 31 (Android 12).
-    // On API 29-30 the type is unknown to the framework and startForeground() throws
-    // IllegalArgumentException when the requested type does not match the manifest.
-    // Passing null selects the 2-arg startForeground() fallback in startForegroundServiceCompat(),
-    // which skips type validation on older builds.
-    private val foregroundServiceType: Int?
+    // Foreground service type is two-phase (see the manifest comment on this service):
+    //
+    // Ringing / call setup: FOREGROUND_SERVICE_TYPE_PHONE_CALL only. Since Android 14 the
+    // microphone type is in the while-in-use restricted set and CANNOT be promoted from a
+    // background app state - no exemption applies (high-priority FCM and battery-optimization
+    // whitelisting were both verified to still throw SecurityException), so a push-delivered
+    // incoming call would crash the service in a loop until the OS kills the main process.
+    // The phone-call type is not restricted; its only runtime prerequisites are the
+    // FOREGROUND_SERVICE_PHONE_CALL + MANAGE_OWN_CALLS permissions (both declared by the
+    // plugin manifest). It does NOT require the android.software.telecom feature or an
+    // active Telecom connection.
+    //
+    // Active call (answered/established): PHONE_CALL | MICROPHONE. The microphone type is
+    // added so microphone access survives the app going to background mid-call
+    // (while-in-use restriction). Adding it at that point is legal: the answer flow
+    // guarantees a visible activity (StandaloneAnswerTrampolineActivity for notification
+    // answers, the host activity for Dart-initiated answer/establish).
+    //
+    // On API < 31 both getters return null, selecting the 2-arg startForeground() fallback in
+    // startForegroundServiceCompat(): type validation is skipped there and the microphone
+    // constant does not exist before API 31.
+    private val ringingForegroundServiceType: Int?
         get() =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+            } else {
+                null
+            }
+
+    private val activeCallForegroundServiceType: Int?
+        get() =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
             } else {
                 null
             }
@@ -246,16 +270,15 @@ class StandaloneCallService : Service() {
      * [android.app.Service.startForeground] requirement. Also called from
      * [handleIncomingCall] and [handleOutgoingCall] as a no-op guard once already promoted.
      *
-     * Uses [ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE] on API 31+ because this service
-     * is only active on devices that do NOT have [android.software.telecom], making the
-     * phone-call foreground type inappropriate. Microphone type is semantically correct for
-     * a service that manages audio call sessions.
+     * Promotes with [ringingForegroundServiceType] (phone call): this runs while the app may
+     * still be fully in the background (push-delivered incoming call), where the microphone
+     * type is not allowed since Android 14 - see the field comment.
      *
-     * On API 29-30 the microphone type flag did not exist; passing it to [startForeground]
-     * causes the framework to throw [IllegalArgumentException] because the flag is not
-     * recognised in that API level's manifest type validation. The 2-arg [startForeground]
-     * overload (no type) is used instead, which bypasses the type check entirely and is safe
-     * on all API levels below 31.
+     * A [SecurityException] here must not propagate: the service is (re)started by the system
+     * after a crash and the same throw repeats until ActivityManager kills the whole main
+     * process ("crashed too many times"), taking the Flutter engine and any in-flight app
+     * state with it. Degrade instead: log and stop the service (stopping before the 5-second
+     * window expires also avoids ForegroundServiceDidNotStartInTimeException).
      */
     private fun promoteToForeground() {
         if (isForeground) return
@@ -266,7 +289,13 @@ class StandaloneCallService : Service() {
                 .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setOngoing(true)
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, foregroundServiceType)
+        try {
+            startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, ringingForegroundServiceType)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "promoteToForeground: startForeground rejected, stopping service to avoid a crash loop", e)
+            stopSelf()
+            return
+        }
         isForeground = true
     }
 
@@ -309,7 +338,9 @@ class StandaloneCallService : Service() {
             StandaloneIncomingCallNotificationBuilder()
                 .apply { setCallMetaData(metadata) }
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+        // Still the ringing phase - the app may be in the background, so the type must stay
+        // phone-call only (same restriction as in promoteToForeground).
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, ringingForegroundServiceType)
     }
 
     /**
@@ -324,7 +355,18 @@ class StandaloneCallService : Service() {
             StandaloneActiveCallNotificationBuilder()
                 .apply { setCallMetaData(metadata) }
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+        // The call is answered: re-promote with PHONE_CALL | MICROPHONE so microphone access
+        // survives the app going to background mid-call. The answer flow guarantees a visible
+        // activity at this point, which makes adding the restricted microphone type legal on
+        // Android 14+. If a race still leaves the app ineligible (SecurityException), fall back
+        // to the phone-call type: the call proceeds, the microphone works while the app is in
+        // the foreground, only background microphone access is lost.
+        try {
+            startForegroundServiceCompat(this, NOTIFICATION_ID, notification, activeCallForegroundServiceType)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "showActiveCallNotification: microphone type rejected, falling back to phone-call type", e)
+            startForegroundServiceCompat(this, NOTIFICATION_ID, notification, ringingForegroundServiceType)
+        }
     }
 
     private fun handleOutgoingCall(metadata: CallMetadata) {


### PR DESCRIPTION
## Overview

On Android 14+ (API 34), a push-delivered incoming call on a device without `android.software.telecom` crashed the app: `StandaloneCallService.promoteToForeground()` called `startForeground()` with `FOREGROUND_SERVICE_TYPE_MICROPHONE`, and since Android 14 the microphone type is in the while-in-use restricted set - it cannot be promoted from a background app state, with no applicable exemption (high-priority FCM delivery and battery-optimization whitelisting were both verified to still throw):

```
java.lang.SecurityException: Starting FGS with type microphone ...
  at StandaloneCallService.promoteToForeground
  at StandaloneCallService.onStartCommand
```

The system kept restarting the service into the same throw until ActivityManager killed the whole main process ("crashed too many times, killing!"), losing the call and all in-memory app state. Android 13 and below are unaffected (the restriction does not exist in the OS below API 34).

The microphone type itself was a misdiagnosis: it was introduced together with the standalone mode under the assumption that "the phoneCall type requires the Telecom subsystem". The Android documentation says otherwise - the only runtime prerequisites for `FOREGROUND_SERVICE_TYPE_PHONE_CALL` are the `FOREGROUND_SERVICE_PHONE_CALL` permission plus `MANAGE_OWN_CALLS` (or the dialer role), both already declared by the plugin manifest; there is no dependency on the `android.software.telecom` feature or on an active Telecom connection. The crash that motivated the original type change was the separate `startForeground()`-from-`onCreate()` bug, fixed independently in the same PR back then. The phone-call type is not in the restricted set, which is exactly why the Telecom path never hits this.

## Changes

Two-phase foreground service type on `StandaloneCallService`:

- Ringing / call setup (`promoteToForeground`, incoming notification): `phoneCall` only. Startable from the background under the regular FGS exemption granted by high-priority FCM; the microphone is not used during ringing anyway.
- Answered / established (`showActiveCallNotification`): re-promote with `phoneCall|microphone` so microphone access survives the app going to background mid-call. Legal at that point because the answer flow guarantees a visible activity (the notification-answer trampoline from #341, or the host activity for Dart-initiated answers). If a race still leaves the app ineligible, a `SecurityException` fallback re-promotes with `phoneCall` only - the call proceeds, losing only background microphone access.
- Manifest: `android:foregroundServiceType="phoneCall|microphone"` and the service comment rewritten to document the two-phase scheme and correct the recorded "requires the Telecom subsystem" assumption.
- Defense-in-depth: `promoteToForeground()` catches `SecurityException`, logs and stops the service instead of crash-looping the main process (stopping inside the 5-second window also avoids `ForegroundServiceDidNotStartInTimeException`).

Note: on the standalone path `ActiveCallService` (which already declares `phoneCall|microphone|camera`) is never started - the active-call phase is owned by `StandaloneCallService` itself, hence the microphone type must live here for background mid-call audio.

## Testing

- `./gradlew testDebugUnitTest` passes.
- Verified on an Android 15 (API 35) emulator configured like the affected devices (Pixel Tablet profile, `android.software.telecom` and `android.hardware.telephony*` feature flags stripped, RIL disabled - `pm list features | grep telecom` returns nothing, so `StandaloneCallService` is used), same scenario on both builds:
  - develop (microphone type): background the app, receive a push call - `SecurityException: Starting FGS with type microphone` in `promoteToForeground`, the process dies, the system restarts the service after 1s into the identical crash, crash dialog shown, call lost. Exact reproduction of the reported issue, including the FCM exemption not helping.
  - this branch: same scenario - the service promotes with the phone-call type and rings; Answer re-promotes with `phoneCall|microphone` (accepted - the app is foreground via the answer trampoline), `getUserMedia(audio)` succeeds and the call reaches `connected` with ICE up.
- Remaining manual check: audio continuity after backgrounding the app mid-call (needs a listen test). Regression check on Android 13 (Lenovo TB300FU): incoming/outgoing flows unaffected (the 2-arg `startForeground` fallback below API 31 is unchanged, and API 31-33 accept the phone-call type with the declared permissions).
