### PR TITLE
fix: standalone call service patches [release/1.3.0]

### DIFF
--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -101,6 +101,24 @@
         <service android:name=".services.services.foreground.ForegroundService" />
 
         <!--
+          Invisible trampoline behind the Answer action of the standalone incoming-call
+          notification. Android 12+ forbids services launched from a notification action from
+          starting activities (notification trampoline restriction), so the Answer PendingIntent
+          targets this activity instead: it forwards the answer command to StandaloneCallService,
+          brings the host app to the front and finishes. showWhenLocked lets the tap work from the
+          lock-screen notification; the empty taskAffinity keeps this ephemeral activity out of
+          the host app's task.
+        -->
+        <activity
+            android:name=".activities.StandaloneAnswerTrampolineActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:noHistory="true"
+            android:showWhenLocked="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <!--
           [Optional Integration] SMS Fallback Receiver
 
           This receiver is used to trigger the foreground service when an incoming call is announced via SMS,

--- a/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
+++ b/webtrit_callkeep_android/android/src/main/AndroidManifest.xml
@@ -79,14 +79,24 @@
           permanently marking the process as "bad" and preventing all subsequent service starts.
           Since there is no Telecom framework managing the lifecycle of this service, running in
           the main process is safe and avoids OEM background-start restrictions.
-          Uses microphone foreground service type because phoneCall type requires the Telecom
-          subsystem, which is absent on devices that use this service.
+
+          Foreground service type is two-phase at runtime:
+          - ringing / call setup promotes with phoneCall only. Since Android 14 the microphone
+            type is while-in-use restricted and cannot be started from a background app state
+            (no exemption applies, incl. high-priority FCM), which crashed the service in a loop
+            on every push-delivered incoming call. The phoneCall type is unrestricted; its only
+            runtime prerequisites are the FOREGROUND_SERVICE_PHONE_CALL and MANAGE_OWN_CALLS
+            permissions declared above. Contrary to an earlier assumption recorded here, it does
+            NOT require the android.software.telecom feature or an active Telecom connection.
+          - once the call is answered/established the service re-promotes with
+            phoneCall|microphone (the app has a visible activity at that point) so microphone
+            access survives the app going to background mid-call.
         -->
         <service
             android:name=".services.services.connection.StandaloneCallService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="microphone" />
+            android:foregroundServiceType="phoneCall|microphone" />
 
         <service
             android:name=".services.services.incoming_call.IncomingCallService"

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/activities/StandaloneAnswerTrampolineActivity.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/activities/StandaloneAnswerTrampolineActivity.kt
@@ -1,0 +1,42 @@
+package com.webtrit.callkeep.activities
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.webtrit.callkeep.common.ActivityHolder
+import com.webtrit.callkeep.common.Log
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+
+/**
+ * Trampoline for the Answer action of the standalone incoming-call notification.
+ *
+ * Android 12+ blocks activity starts from a service that was launched by a notification
+ * action (notification trampoline restriction). When the Answer PendingIntent targeted
+ * [StandaloneCallService] directly, the ActivityHolder.start() call inside its answer
+ * handler was rejected with "Indirect notification activity start (trampoline) blocked"
+ * whenever the app was in the background. An activity PendingIntent is exempt from that
+ * restriction, so the notification launches this invisible activity instead: it forwards
+ * the answer command to [StandaloneCallService], brings the host app to the front (legal,
+ * because this activity itself is now the foreground) and finishes immediately.
+ */
+class StandaloneAnswerTrampolineActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val forward =
+            Intent(this, StandaloneCallService::class.java).apply {
+                action = intent.action
+                intent.extras?.let { putExtras(it) }
+            }
+        try {
+            startService(forward)
+        } catch (e: Exception) {
+            Log.e(TAG, "onCreate: failed to forward '${intent.action}' to StandaloneCallService", e)
+        }
+        ActivityHolder.start(this)
+        finish()
+    }
+
+    companion object {
+        private const val TAG = "StandaloneAnswerTrampolineActivity"
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneActiveCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneActiveCallNotificationBuilder.kt
@@ -1,0 +1,92 @@
+package com.webtrit.callkeep.notifications
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Person
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.ContextHolder.context
+import com.webtrit.callkeep.managers.NotificationChannelManager.ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.services.services.connection.StandaloneCallService
+import com.webtrit.callkeep.services.services.connection.StandaloneServiceAction
+
+/**
+ * Builds the ongoing (answered) call notification for the standalone call path - used on devices
+ * that do not expose the [android.software.telecom] system feature.
+ *
+ * Counterpart of [StandaloneIncomingCallNotificationBuilder]: once a call is answered or
+ * established, [StandaloneCallService] replaces its foreground incoming-call notification (which
+ * still carries Answer/Decline actions) with this one, mirroring the Telecom path where the
+ * incoming notification is cancelled on answer and an active-call notification is posted.
+ * The Hang up action is routed directly to [StandaloneCallService] via
+ * [StandaloneServiceAction.HungUpCall]; tapping the notification body opens the app.
+ */
+internal class StandaloneActiveCallNotificationBuilder : NotificationBuilder() {
+    private var callMetaData: CallMetadata? = null
+
+    fun setCallMetaData(callMetaData: CallMetadata) {
+        this.callMetaData = callMetaData
+    }
+
+    private fun createHangUpIntent(metadata: CallMetadata): PendingIntent {
+        val intent =
+            Intent(context, StandaloneCallService::class.java).apply {
+                action = StandaloneServiceAction.HungUpCall.action
+                putExtras(metadata.toBundle())
+            }
+        return PendingIntent.getService(
+            context,
+            // Same request-code scheme as StandaloneIncomingCallNotificationBuilder.createActionIntent:
+            // the action ordinal keeps this PendingIntent distinct from the Answer/Decline ones.
+            StandaloneServiceAction.HungUpCall.ordinal,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    override fun build(): Notification {
+        val meta =
+            requireNotNull(callMetaData) { "Call metadata must be set before building the notification." }
+
+        val callerName = meta.name ?: context.getString(R.string.unknown_caller)
+        val hangUpIntent = createHangUpIntent(meta)
+
+        val builder =
+            Notification.Builder(context, ACTIVE_CALL_SERVICE_NOTIFICATION_CHANNEL_ID).apply {
+                setSmallIcon(if (meta.hasVideo == true) R.drawable.ic_notification_video else R.drawable.ic_notification)
+                setCategory(NotificationCompat.CATEGORY_CALL)
+                setContentTitle(context.getString(R.string.push_notification_active_call_channel_title))
+                setContentText(callerName)
+                setOngoing(true)
+                setAutoCancel(false)
+                setOnlyAlertOnce(true)
+                setContentIntent(buildOpenAppIntent(context))
+            }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val person =
+                Person
+                    .Builder()
+                    .setName(callerName)
+                    .setImportant(true)
+                    .build()
+            builder
+                .setStyle(Notification.CallStyle.forOngoingCall(person, hangUpIntent))
+                .build()
+        } else {
+            builder
+                .addAction(
+                    Notification.Action
+                        .Builder(
+                            Icon.createWithResource(context, R.drawable.ic_call_hungup),
+                            context.getString(R.string.hang_up_button_text),
+                            hangUpIntent,
+                        ).build(),
+                ).build()
+        }
+    }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/notifications/StandaloneIncomingCallNotificationBuilder.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.webtrit.callkeep.R
+import com.webtrit.callkeep.activities.StandaloneAnswerTrampolineActivity
 import com.webtrit.callkeep.common.ContextHolder.context
 import com.webtrit.callkeep.common.PermissionsHelper
 import com.webtrit.callkeep.common.Platform
@@ -52,6 +53,29 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
         )
     }
 
+    /**
+     * Answer must go through [StandaloneAnswerTrampolineActivity] rather than straight to
+     * [StandaloneCallService]: answering has to bring the app UI to the front, and on Android 12+
+     * a service launched from a notification action is not allowed to start activities
+     * (notification trampoline restriction). An activity PendingIntent is exempt; the trampoline
+     * forwards the same action/extras to the service and launches the host app. Decline needs no
+     * UI, so it keeps the direct service PendingIntent from [createActionIntent].
+     */
+    private fun createAnswerActionIntent(metadata: CallMetadata): PendingIntent {
+        val intent =
+            Intent(context, StandaloneAnswerTrampolineActivity::class.java).apply {
+                action = StandaloneServiceAction.AnswerCall.action
+                putExtras(metadata.toBundle())
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+        return PendingIntent.getActivity(
+            context,
+            StandaloneServiceAction.AnswerCall.ordinal,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
     private fun baseBuilder(
         title: String,
         text: String,
@@ -73,7 +97,7 @@ internal class StandaloneIncomingCallNotificationBuilder : NotificationBuilder()
         val meta =
             requireNotNull(callMetaData) { "Call metadata must be set before building the notification." }
 
-        val answerIntent = createActionIntent(meta, StandaloneServiceAction.AnswerCall)
+        val answerIntent = createAnswerActionIntent(meta)
         val declineIntent = createActionIntent(meta, StandaloneServiceAction.DeclineCall)
 
         val content = incomingCallContent(meta)

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -59,15 +59,51 @@ class StandaloneCallService : Service() {
     // notification when there is no call in progress.
     private var isForeground = false
 
-    // FOREGROUND_SERVICE_TYPE_MICROPHONE was introduced in API 31 (Android 12).
-    // On API 29-30 the type is unknown to the framework and startForeground() throws
-    // IllegalArgumentException when the requested type does not match the manifest.
-    // Passing null selects the 2-arg startForeground() fallback in startForegroundServiceCompat(),
-    // which skips type validation on older builds.
-    private val foregroundServiceType: Int?
+    // Foreground service type is two-phase (see the manifest comment on this service):
+    //
+    // Ringing / call setup: FOREGROUND_SERVICE_TYPE_PHONE_CALL only. Since Android 14 the
+    // microphone type is in the while-in-use restricted set and CANNOT be promoted from a
+    // background app state - no exemption applies (high-priority FCM and battery-optimization
+    // whitelisting were both verified to still throw SecurityException), so a push-delivered
+    // incoming call would crash the service in a loop until the OS kills the main process.
+    // The phone-call type is not restricted; its only runtime prerequisites are the
+    // FOREGROUND_SERVICE_PHONE_CALL + MANAGE_OWN_CALLS permissions (both declared by the
+    // plugin manifest). It does NOT require the android.software.telecom feature or an
+    // active Telecom connection.
+    //
+    // Active call (answered/established): PHONE_CALL | MICROPHONE. The microphone type is
+    // added so microphone access survives the app going to background mid-call
+    // (while-in-use restriction). Adding it at that point is legal: the answer flow
+    // guarantees a visible activity (StandaloneAnswerTrampolineActivity for notification
+    // answers, the host activity for Dart-initiated answer/establish).
+    //
+    // TODO(standalone-active-call): the active-call phase does not belong to this service.
+    // On the Telecom path it is owned by ActiveCallService (phoneCall|microphone|camera with
+    // permission-aware types and its own notification), started via
+    // NotificationManager.showActiveCallNotification() - which is only ever called from
+    // PhoneConnection, so it never runs on the standalone path. Once the standalone answer/
+    // establish/end handlers drive NotificationManager the same way (and this service demotes
+    // itself after the answer instead of re-posting its own ongoing notification), the
+    // microphone type below and showActiveCallNotification()/
+    // StandaloneActiveCallNotificationBuilder can be removed, returning this service to a pure
+    // phone-call-typed connection host. That also brings the camera type for video calls in
+    // the background, which the current shape does not cover.
+    //
+    // On API < 31 both getters return null, selecting the 2-arg startForeground() fallback in
+    // startForegroundServiceCompat(): type validation is skipped there and the microphone
+    // constant does not exist before API 31.
+    private val ringingForegroundServiceType: Int?
         get() =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+            } else {
+                null
+            }
+
+    private val activeCallForegroundServiceType: Int?
+        get() =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
             } else {
                 null
             }
@@ -246,16 +282,15 @@ class StandaloneCallService : Service() {
      * [android.app.Service.startForeground] requirement. Also called from
      * [handleIncomingCall] and [handleOutgoingCall] as a no-op guard once already promoted.
      *
-     * Uses [ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE] on API 31+ because this service
-     * is only active on devices that do NOT have [android.software.telecom], making the
-     * phone-call foreground type inappropriate. Microphone type is semantically correct for
-     * a service that manages audio call sessions.
+     * Promotes with [ringingForegroundServiceType] (phone call): this runs while the app may
+     * still be fully in the background (push-delivered incoming call), where the microphone
+     * type is not allowed since Android 14 - see the field comment.
      *
-     * On API 29-30 the microphone type flag did not exist; passing it to [startForeground]
-     * causes the framework to throw [IllegalArgumentException] because the flag is not
-     * recognised in that API level's manifest type validation. The 2-arg [startForeground]
-     * overload (no type) is used instead, which bypasses the type check entirely and is safe
-     * on all API levels below 31.
+     * A [SecurityException] here must not propagate: the service is (re)started by the system
+     * after a crash and the same throw repeats until ActivityManager kills the whole main
+     * process ("crashed too many times"), taking the Flutter engine and any in-flight app
+     * state with it. Degrade instead: log and stop the service (stopping before the 5-second
+     * window expires also avoids ForegroundServiceDidNotStartInTimeException).
      */
     private fun promoteToForeground() {
         if (isForeground) return
@@ -266,7 +301,13 @@ class StandaloneCallService : Service() {
                 .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setOngoing(true)
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, foregroundServiceType)
+        try {
+            startForegroundServiceCompat(this, NOTIFICATION_ID, placeholder, ringingForegroundServiceType)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "promoteToForeground: startForeground rejected, stopping service to avoid a crash loop", e)
+            stopSelf()
+            return
+        }
         isForeground = true
     }
 
@@ -309,7 +350,9 @@ class StandaloneCallService : Service() {
             StandaloneIncomingCallNotificationBuilder()
                 .apply { setCallMetaData(metadata) }
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+        // Still the ringing phase - the app may be in the background, so the type must stay
+        // phone-call only (same restriction as in promoteToForeground).
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, ringingForegroundServiceType)
     }
 
     /**
@@ -324,7 +367,18 @@ class StandaloneCallService : Service() {
             StandaloneActiveCallNotificationBuilder()
                 .apply { setCallMetaData(metadata) }
                 .build()
-        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+        // The call is answered: re-promote with PHONE_CALL | MICROPHONE so microphone access
+        // survives the app going to background mid-call. The answer flow guarantees a visible
+        // activity at this point, which makes adding the restricted microphone type legal on
+        // Android 14+. If a race still leaves the app ineligible (SecurityException), fall back
+        // to the phone-call type: the call proceeds, the microphone works while the app is in
+        // the foreground, only background microphone access is lost.
+        try {
+            startForegroundServiceCompat(this, NOTIFICATION_ID, notification, activeCallForegroundServiceType)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "showActiveCallNotification: microphone type rejected, falling back to phone-call type", e)
+            startForegroundServiceCompat(this, NOTIFICATION_ID, notification, ringingForegroundServiceType)
+        }
     }
 
     private fun handleOutgoingCall(metadata: CallMetadata) {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/connection/StandaloneCallService.kt
@@ -12,6 +12,7 @@ import androidx.annotation.Keep
 import androidx.core.app.NotificationCompat
 import com.webtrit.callkeep.PIncomingCallError
 import com.webtrit.callkeep.R
+import com.webtrit.callkeep.common.ActivityHolder
 import com.webtrit.callkeep.common.AssetCacheManager
 import com.webtrit.callkeep.common.ContextHolder
 import com.webtrit.callkeep.common.Log
@@ -21,6 +22,7 @@ import com.webtrit.callkeep.models.AudioDevice
 import com.webtrit.callkeep.models.AudioDeviceType
 import com.webtrit.callkeep.models.CallConnectionState
 import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.notifications.StandaloneActiveCallNotificationBuilder
 import com.webtrit.callkeep.notifications.StandaloneIncomingCallNotificationBuilder
 import com.webtrit.callkeep.services.broadcaster.CallCommandEvent
 import com.webtrit.callkeep.services.broadcaster.CallLifecycleEvent
@@ -310,6 +312,21 @@ class StandaloneCallService : Service() {
         startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
     }
 
+    /**
+     * Replaces the foreground incoming-call notification with the ongoing-call variant once the
+     * call is answered or established. The incoming notification is this service's own foreground
+     * notification, so it cannot simply be cancelled (the Telecom path cancels the separate
+     * [com.webtrit.callkeep.services.services.incoming_call.IncomingCallService] notification
+     * instead) - it is re-posted under the same [NOTIFICATION_ID] without Answer/Decline actions.
+     */
+    private fun showActiveCallNotification(metadata: CallMetadata) {
+        val notification =
+            StandaloneActiveCallNotificationBuilder()
+                .apply { setCallMetaData(metadata) }
+                .build()
+        startForegroundServiceCompat(this, NOTIFICATION_ID, notification, foregroundServiceType)
+    }
+
     private fun handleOutgoingCall(metadata: CallMetadata) {
         Log.i(TAG, "handleOutgoingCall: callId=${metadata.callId}")
         promoteToForeground()
@@ -334,6 +351,11 @@ class StandaloneCallService : Service() {
         fireInitialAudioState(metadata.callId)
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
 
+        // Mirror PhoneConnection.establish() on the Telecom path: swap the foreground
+        // notification to the ongoing-call variant and make sure the app UI is visible.
+        showActiveCallNotification(callMetadataMap[metadata.callId]!!)
+        ActivityHolder.start(applicationContext)
+
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow
         // mirrors it (replaces the removed markAnswered state-stamping).
@@ -355,6 +377,14 @@ class StandaloneCallService : Service() {
         activateAudio()
         fireInitialAudioState(metadata.callId)
         promoteRemainingRingingToCallWaitingTone(metadata.callId)
+
+        // Replace the incoming CallStyle notification (which otherwise keeps its Answer button on
+        // screen for the whole call). Bringing the app UI to the front is NOT done here: on
+        // Android 12+ a service launched from a notification action may not start activities
+        // (notification trampoline restriction - "Indirect notification activity start blocked"),
+        // so the Answer action goes through StandaloneAnswerTrampolineActivity, which starts the
+        // host activity itself before forwarding the answer command to this service.
+        showActiveCallNotification(callMetadataMap[metadata.callId]!!)
 
         core.notifyConnectionEvent(CallLifecycleEvent.AnswerCall, callMetadataMap[metadata.callId]!!.toBundle())
         // No onStateChanged here (no telecom Connection) — emit the state explicitly so the shadow


### PR DESCRIPTION
## Overview

Cherry-picks of #341 and #342 onto `release/1.3.0`:

- #341 - open the app UI and swap the notification when a standalone call is answered.
- #342 - promote the standalone call service with the phone-call foreground-service type instead of microphone.

After merge the temporary `1.3.0` tag is moved to the release tip so the phone `release/1.16.0` git pin picks up the patches.