### PR TITLE
build: bump version build iteration to 1.3.0+1

### DIFF
--- a/webtrit_callkeep/pubspec.yaml
+++ b/webtrit_callkeep/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webtrit_callkeep
 description: Flutter WebTrit CallKeep plugin
-version: 1.3.0+0
+version: 1.3.0+1
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Overview

Build-iteration bump to `version: 1.3.0+1` for the QA-window patches already on `release/1.3.0` (#343: cherry-picks of #341 and #342). The bump was missed in #343 itself.

## After merge (do not do these before)

- Move the temporary `1.3.0` tag from `40c4968` to the new release tip.
- Re-resolve the callkeep pin in phone `release/1.16.0` `pubspec.lock` (a follow-up phone PR).