### PR TITLE
feat(ios): play call-waiting tone on second incoming call during active call

### DIFF
--- a/docs/ios-call-waiting-tone.md
+++ b/docs/ios-call-waiting-tone.md
@@ -1,0 +1,103 @@
+# iOS call-waiting tone: design notes
+
+## Purpose
+
+When a second incoming call arrives while another call is already active, iOS gives the user no audible
+indication: CallKit does not auto-play a call-waiting tone for VoIP calls (that beep on cellular calls is
+a carrier feature), and it also suppresses the regular ringtone for the second call. Android handles the
+same scenario natively in the connection service - a soft tone instead of the full ringtone. This document
+explains how the iOS side works and, more importantly, why it is built this way, because most of the
+"obvious" alternatives fail in non-obvious ways.
+
+Implementation: `CallWaitingTonePlayer` (playback) plus the `CXCallObserverDelegate` sync in
+`WebtritCallkeepPlugin` (detection). Everything is native to this plugin: no Dart API, no app involvement,
+no dependency on any other plugin.
+
+## The core problem: audio playback during a live call
+
+During a VoIP call the audio session runs `playAndRecord` with mode `voiceChat`, and the call audio flows
+through the voice-processing I/O unit (VPIO - the one doing echo cancellation and noise suppression).
+Apple treats every audio stream that is not rendered through the voice-processing unit - including streams
+from the SAME app - as "other audio" (WWDC23 session 10235, "What's new in voice processing").
+
+Two distinct mechanisms then affect that "other audio":
+
+1. **Documented ducking** (`AVAudioVoiceProcessingOtherAudioDuckingConfiguration`, iOS 17+). Mild by
+   itself; the WebRTC stack used with this plugin already configures `duckingLevel = .min`. This is NOT
+   what makes other audio inaudible.
+2. **An undocumented, long-standing behavior** (Apple developer forums thread 721535, reproduced across
+   iOS 13-26): audio sources STARTED AFTER the voice-processing unit is running play near-silent, as if
+   not routed to the output. This affects `AVAudioPlayer`, `AVPlayer` and additional `AVAudioEngine`
+   instances alike. Two things counter it:
+   - sources set up BEFORE voice processing starts keep full volume;
+   - re-issuing `setCategory` with the current values (an idempotent no-op configuration-wise) restores
+     full volume for late-started sources without changing the route or the session mode.
+
+`CallWaitingTonePlayer` is therefore a plain `AVAudioPlayer` (an in-memory synthesized WAV, looped) with
+both mitigations applied:
+
+- **Pre-warm ordering.** The player is created and `prepareToPlay`-ed inside the native
+  `CXProviderDelegate provider:didActivateAudioSession:` callback. This callback is the earliest audio
+  moment of a call and it reaches the plugin natively BEFORE the app-side (Dart) roundtrip that starts the
+  WebRTC voice-processing engine - so the playback source predates VP by construction. Keep it that way:
+  moving player creation to first-play would land in the near-silent case above.
+- **Category re-assert.** After each actual playback start, the current session category and options are
+  re-asserted. It is guarded to run only on a real stop-to-play transition (not on every call-state
+  event), because each `setCategory` is a synchronous audio-server call.
+
+The tone is heard locally only: everything the device plays is part of the voice-processing
+echo-cancellation reference and is subtracted from the microphone signal, so the remote side does not
+hear the beep.
+
+## Rejected alternatives (and why)
+
+| Approach | Why not |
+|---|---|
+| `AVAudioPlayer` without the two mitigations | Near-silent during a live call (behavior 2 above). |
+| `AudioServicesPlaySystemSound` | System (UI) sounds are hard-disabled during calls by a separate mechanism; no workaround. |
+| Custom `CXProviderConfiguration.ringtoneSound` | The second call's ringtone is suppressed during an active call; and if it did play, it would be ringer-volume - the exact problem the soft tone solves. |
+| A player node inside WebRTC's own `AVAudioEngine` | Works and is fully duck-proof (it IS the call audio path), but the engine is owned by the WebRTC plugin and is recreated per call and on every route change - hosting the tone there either puts telephony logic into a transport plugin or requires fragile cross-plugin lifecycle contracts. Only worth revisiting if the mitigations above ever stop working. |
+| A separate app-owned `AVAudioEngine` | Same "other audio" class as `AVAudioPlayer` (no ducking advantage), plus engine lifecycle/config-change handling for nothing. |
+| Ducking configuration tweaks | `duckingLevel` is already `.min` in this stack; `enableAdvancedDucking` ducks MORE while speech is present. |
+| `overrideOutputAudioPort(.speaker)` (also restores volume) | Moves the whole call from the earpiece to the speaker - unacceptable. |
+
+## Detection
+
+The plugin observes `CXCallObserver` and plays the tone while at least one call is connected (or held)
+and at least one incoming call is ringing, stopping as soon as that state ends. Design points:
+
+- **Native, not app-driven.** Mirrors the Android connection-service logic, works even when the Dart side
+  is busy or not running, and requires no API surface.
+- **Own calls only (default).** `CXCallObserver` reports every CallKit call on the device - cellular,
+  other VoIP apps - so unfiltered detection would beep on top of foreign calls (or double up with the
+  carrier's own call-waiting tone). The plugin tracks the UUIDs of calls it reported/started and counts
+  only those. `CallkeepIOSOptions.callWaitingToneOwnCallsOnly = false` widens detection to all calls if a
+  product ever wants the beep while the user is on a cellular call.
+- **Answer suppression.** A `CXCall` keeps looking "ringing" until the answer action is fulfilled, which
+  includes an app roundtrip and SIP signaling (seconds on a slow network). The UUID is excluded from the
+  ringing set the moment the user accepts, so the beep does not bleed into the answered conversation.
+- **No playback decisions from the provider queue.** `didActivateAudioSession` arrives on the provider's
+  private queue; acting on cached state there can resume a tone that the (main-queue) call-state sync has
+  already ended. The callback only pre-warms; play/stop decisions are made exclusively by the sync running
+  on the observer's queue.
+- **Scope boundary.** An outgoing call that is still dialing has `hasConnected == NO`, so a second
+  incoming call during it produces no tone - intentionally the same as Android, where the connection
+  service plays the full ringtone in that case.
+
+## Tone pattern
+
+A single 440 Hz, 300 ms beep on a 3-second cadence - matching what Android produces
+(`ToneGenerator.TONE_SUP_CALL_WAITING` is a 440 Hz / 300 ms beep, re-fired by the connection service
+every 3 s), so both platforms sound identical. The WAV is synthesized in memory (`initWithData:`); do not
+switch to a temp-file URL - `AVAudioPlayer initWithContentsOfURL:` has been observed returning nil for
+freshly written temp WAVs on device.
+
+## Maintenance gotchas
+
+- Native ObjC changes require a full rebuild; Flutter hot reload/restart swaps only Dart. When a change
+  "has no effect", check the built product first (e.g. `strings <app>/Runner.debug.dylib | grep <marker>`).
+- `NSLog` from the plugin is not visible in `flutter run` output - use Console.app. The detection sync
+  logs `[CallWaitingTone] sync: ...` in DEBUG builds.
+- The pre-warm-before-voice-processing ordering is the load-bearing invariant of the playback path. Any
+  refactor that delays player creation past the start of the call's audio engine reintroduces the
+  near-silence failure, and nothing will crash or log - it will just be quiet.

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
@@ -2,10 +2,12 @@
 
 // AVAudioPlayer-based call-waiting tone - see the header for the VP-timing mitigations.
 
+// Mirrors the Android call-waiting tone: ToneGenerator TONE_SUP_CALL_WAITING is a
+// 440 Hz, 300 ms beep, and the connection service re-fires it every 3 seconds -
+// so both platforms produce a single 440 Hz beep with a 3 s cadence.
 static const double kToneFrequencyHz = 440.0;
-static const double kToneOnSec = 0.20;
-static const double kToneGapSec = 0.15;
-static const double kToneTailSec = 2.0;
+static const double kToneOnSec = 0.30;
+static const double kToneTailSec = 2.70;
 static const double kSampleRate = 16000.0;
 static const float kAmplitude = 0.4f;
 
@@ -103,21 +105,19 @@ static const float kAmplitude = 0.4f;
   _player.volume = 1.0;
 }
 
-// 440 Hz "beep-beep" then ~2 s silence, looped: 16-bit PCM mono WAV built in memory.
+// A single 440 Hz beep then silence to a 3 s loop period: 16-bit PCM mono WAV in memory.
 - (NSData *)toneWavData {
   const uint32_t sr = (uint32_t)kSampleRate;
   const uint32_t toneN = (uint32_t)(kSampleRate * kToneOnSec);
-  const uint32_t gapN = (uint32_t)(kSampleRate * kToneGapSec);
   const uint32_t tailN = (uint32_t)(kSampleRate * kToneTailSec);
-  const uint32_t total = toneN + gapN + toneN + tailN;
+  const uint32_t total = toneN + tailN;
 
   NSMutableData *pcm = [NSMutableData dataWithLength:total * sizeof(int16_t)];
   int16_t *samples = (int16_t *)pcm.mutableBytes;
   for (uint32_t i = 0; i < toneN; i++) {
     samples[i] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
   }
-  // The gap and the tail are zero-initialized; the second beep is a copy of the first.
-  memcpy(samples + toneN + gapN, samples, toneN * sizeof(int16_t));
+  // The tail is zero-initialized.
 
   const uint32_t dataLen = (uint32_t)pcm.length;
   const uint32_t byteRate = sr * 2;  // mono, 16-bit

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
@@ -11,14 +11,12 @@ static const float kAmplitude = 0.4f;
 
 @implementation CallWaitingTonePlayer {
   AVAudioPlayer *_player;
-  BOOL _active;
 }
 
 #pragma mark - Public
 
 - (void)play {
   @synchronized(self) {
-    _active = YES;
     [self ensurePlayer];
     [self startPlaybackLocked];
   }
@@ -26,11 +24,7 @@ static const float kAmplitude = 0.4f;
 
 - (void)stop {
   @synchronized(self) {
-    _active = NO;
-    if (_player != nil && _player.isPlaying) {
-      [_player stop];
-      _player.currentTime = 0;
-    }
+    [self haltPlaybackLocked];
   }
 }
 
@@ -38,21 +32,19 @@ static const float kAmplitude = 0.4f;
   @synchronized(self) {
     // Pre-warm BEFORE the app starts WebRTC's voice-processing engine (this callback
     // is delivered natively first; the engine starts only after the Dart roundtrip).
+    // Playback itself is never resumed from here: whether the tone should play is
+    // decided solely by the owner's call-state sync.
     [self ensurePlayer];
     [_player prepareToPlay];
-    NSLog(@"[CallWaitingTone] pre-warmed on session activation (active=%d)", _active);
-    if (_active) {
-      [self startPlaybackLocked];
-    }
+#ifdef DEBUG
+    NSLog(@"[CallWaitingTone] pre-warmed on session activation");
+#endif
   }
 }
 
 - (void)onAudioSessionDeactivated {
   @synchronized(self) {
-    if (_player != nil && _player.isPlaying) {
-      [_player stop];
-      _player.currentTime = 0;
-    }
+    [self haltPlaybackLocked];
   }
 }
 
@@ -60,8 +52,13 @@ static const float kAmplitude = 0.4f;
 
 - (void)startPlaybackLocked {
   if (_player == nil) {
+#ifdef DEBUG
     NSLog(@"[CallWaitingTone] no player - tone skipped");
+#endif
     return;
+  }
+  if (_player.isPlaying) {
+    return;  // already looping; replaying would re-run the session re-assert for nothing
   }
   BOOL ok = [_player play];
   // Mitigation 2 (Apple forums 721535): sources started while voice processing runs play
@@ -72,11 +69,20 @@ static const float kAmplitude = 0.4f;
   BOOL reasserted = [session setCategory:session.category
                              withOptions:session.categoryOptions
                                    error:&error];
-  if (!reasserted || error != nil) {
-    NSLog(@"[CallWaitingTone] category re-assert failed: %@", error);
-  }
+#ifdef DEBUG
   NSLog(@"[CallWaitingTone] play=%d reassert=%d category=%@ mode=%@",
         ok, reasserted, session.category, session.mode);
+#else
+  (void)ok;
+  (void)reasserted;
+#endif
+}
+
+- (void)haltPlaybackLocked {
+  if (_player != nil && _player.isPlaying) {
+    [_player stop];
+    _player.currentTime = 0;
+  }
 }
 
 - (void)ensurePlayer {
@@ -87,7 +93,9 @@ static const float kAmplitude = 0.4f;
   // initWithData (not a temp file: contents-of-URL on a temp WAV returned nil on device).
   _player = [[AVAudioPlayer alloc] initWithData:[self toneWavData] error:&error];
   if (_player == nil || error != nil) {
+#ifdef DEBUG
     NSLog(@"[CallWaitingTone] player init failed: %@", error);
+#endif
     _player = nil;
     return;
   }
@@ -105,14 +113,11 @@ static const float kAmplitude = 0.4f;
 
   NSMutableData *pcm = [NSMutableData dataWithLength:total * sizeof(int16_t)];
   int16_t *samples = (int16_t *)pcm.mutableBytes;
-  uint32_t idx = 0;
-  for (uint32_t i = 0; i < toneN; i++, idx++) {
-    samples[idx] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
+  for (uint32_t i = 0; i < toneN; i++) {
+    samples[i] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
   }
-  idx += gapN;  // zero-initialized
-  for (uint32_t i = 0; i < toneN; i++, idx++) {
-    samples[(uint32_t)(toneN + gapN) + i] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
-  }
+  // The gap and the tail are zero-initialized; the second beep is a copy of the first.
+  memcpy(samples + toneN + gapN, samples, toneN * sizeof(int16_t));
 
   const uint32_t dataLen = (uint32_t)pcm.length;
   const uint32_t byteRate = sr * 2;  // mono, 16-bit

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/CallWaitingTonePlayer.m
@@ -1,0 +1,147 @@
+#import "CallWaitingTonePlayer.h"
+
+// AVAudioPlayer-based call-waiting tone - see the header for the VP-timing mitigations.
+
+static const double kToneFrequencyHz = 440.0;
+static const double kToneOnSec = 0.20;
+static const double kToneGapSec = 0.15;
+static const double kToneTailSec = 2.0;
+static const double kSampleRate = 16000.0;
+static const float kAmplitude = 0.4f;
+
+@implementation CallWaitingTonePlayer {
+  AVAudioPlayer *_player;
+  BOOL _active;
+}
+
+#pragma mark - Public
+
+- (void)play {
+  @synchronized(self) {
+    _active = YES;
+    [self ensurePlayer];
+    [self startPlaybackLocked];
+  }
+}
+
+- (void)stop {
+  @synchronized(self) {
+    _active = NO;
+    if (_player != nil && _player.isPlaying) {
+      [_player stop];
+      _player.currentTime = 0;
+    }
+  }
+}
+
+- (void)onAudioSessionActivated {
+  @synchronized(self) {
+    // Pre-warm BEFORE the app starts WebRTC's voice-processing engine (this callback
+    // is delivered natively first; the engine starts only after the Dart roundtrip).
+    [self ensurePlayer];
+    [_player prepareToPlay];
+    NSLog(@"[CallWaitingTone] pre-warmed on session activation (active=%d)", _active);
+    if (_active) {
+      [self startPlaybackLocked];
+    }
+  }
+}
+
+- (void)onAudioSessionDeactivated {
+  @synchronized(self) {
+    if (_player != nil && _player.isPlaying) {
+      [_player stop];
+      _player.currentTime = 0;
+    }
+  }
+}
+
+#pragma mark - Internals
+
+- (void)startPlaybackLocked {
+  if (_player == nil) {
+    NSLog(@"[CallWaitingTone] no player - tone skipped");
+    return;
+  }
+  BOOL ok = [_player play];
+  // Mitigation 2 (Apple forums 721535): sources started while voice processing runs play
+  // near-silent; an idempotent category re-assert restores their volume. It does not
+  // change the route or the session mode.
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  NSError *error = nil;
+  BOOL reasserted = [session setCategory:session.category
+                             withOptions:session.categoryOptions
+                                   error:&error];
+  if (!reasserted || error != nil) {
+    NSLog(@"[CallWaitingTone] category re-assert failed: %@", error);
+  }
+  NSLog(@"[CallWaitingTone] play=%d reassert=%d category=%@ mode=%@",
+        ok, reasserted, session.category, session.mode);
+}
+
+- (void)ensurePlayer {
+  if (_player != nil) {
+    return;
+  }
+  NSError *error = nil;
+  // initWithData (not a temp file: contents-of-URL on a temp WAV returned nil on device).
+  _player = [[AVAudioPlayer alloc] initWithData:[self toneWavData] error:&error];
+  if (_player == nil || error != nil) {
+    NSLog(@"[CallWaitingTone] player init failed: %@", error);
+    _player = nil;
+    return;
+  }
+  _player.numberOfLoops = -1;
+  _player.volume = 1.0;
+}
+
+// 440 Hz "beep-beep" then ~2 s silence, looped: 16-bit PCM mono WAV built in memory.
+- (NSData *)toneWavData {
+  const uint32_t sr = (uint32_t)kSampleRate;
+  const uint32_t toneN = (uint32_t)(kSampleRate * kToneOnSec);
+  const uint32_t gapN = (uint32_t)(kSampleRate * kToneGapSec);
+  const uint32_t tailN = (uint32_t)(kSampleRate * kToneTailSec);
+  const uint32_t total = toneN + gapN + toneN + tailN;
+
+  NSMutableData *pcm = [NSMutableData dataWithLength:total * sizeof(int16_t)];
+  int16_t *samples = (int16_t *)pcm.mutableBytes;
+  uint32_t idx = 0;
+  for (uint32_t i = 0; i < toneN; i++, idx++) {
+    samples[idx] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
+  }
+  idx += gapN;  // zero-initialized
+  for (uint32_t i = 0; i < toneN; i++, idx++) {
+    samples[(uint32_t)(toneN + gapN) + i] = (int16_t)(kAmplitude * 32767.0f * sinf(2.0f * (float)M_PI * kToneFrequencyHz * i / sr));
+  }
+
+  const uint32_t dataLen = (uint32_t)pcm.length;
+  const uint32_t byteRate = sr * 2;  // mono, 16-bit
+  NSMutableData *wav = [NSMutableData dataWithCapacity:44 + dataLen];
+
+  void (^appendU32)(uint32_t) = ^(uint32_t v) {
+    uint32_t le = CFSwapInt32HostToLittle(v);
+    [wav appendBytes:&le length:4];
+  };
+  void (^appendU16)(uint16_t) = ^(uint16_t v) {
+    uint16_t le = CFSwapInt16HostToLittle(v);
+    [wav appendBytes:&le length:2];
+  };
+
+  [wav appendBytes:"RIFF" length:4];
+  appendU32(36 + dataLen);
+  [wav appendBytes:"WAVE" length:4];
+  [wav appendBytes:"fmt " length:4];
+  appendU32(16);         // fmt chunk size
+  appendU16(1);          // PCM
+  appendU16(1);          // mono
+  appendU32(sr);
+  appendU32(byteRate);
+  appendU16(2);          // block align
+  appendU16(16);         // bits per sample
+  [wav appendBytes:"data" length:4];
+  appendU32(dataLen);
+  [wav appendData:pcm];
+  return wav;
+}
+
+@end

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Converters.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Converters.m
@@ -162,6 +162,7 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
   id supportsVideo = dict[@"supportsVideo"];
   id includesCallsInRecents = dict[@"includesCallsInRecents"];
   id driveIdleTimerDisabled = dict[@"driveIdleTimerDisabled"];
+  id callWaitingToneOwnCallsOnly = dict[@"callWaitingToneOwnCallsOnly"];
 
   return [WTPIOSOptions makeWithLocalizedName:localizedName
                                 ringtoneSound:(ringtoneSound == [NSNull null]) ? nil : ringtoneSound
@@ -174,7 +175,8 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
                supportsHandleTypeEmailAddress:(supportsHandleTypeEmailAddress == [NSNull null]) ? nil : supportsHandleTypeEmailAddress
                                 supportsVideo:[supportsVideo boolValue]
                        includesCallsInRecents:[includesCallsInRecents boolValue]
-                       driveIdleTimerDisabled:[driveIdleTimerDisabled boolValue]];
+                       driveIdleTimerDisabled:[driveIdleTimerDisabled boolValue]
+                  callWaitingToneOwnCallsOnly:(callWaitingToneOwnCallsOnly == [NSNull null]) ? nil : callWaitingToneOwnCallsOnly];
 }
 - (NSDictionary *)toMap {
   return @{
@@ -190,6 +192,7 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
     @"supportsVideo": @(self.supportsVideo),
     @"includesCallsInRecents": @(self.includesCallsInRecents),
     @"driveIdleTimerDisabled": @(self.driveIdleTimerDisabled),
+    @"callWaitingToneOwnCallsOnly": (self.callWaitingToneOwnCallsOnly ?: [NSNull null]),
   };
 }
 - (CXProviderConfiguration *)toCallKitWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
@@ -221,7 +221,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     supportsHandleTypeEmailAddress:(nullable NSNumber *)supportsHandleTypeEmailAddress
     supportsVideo:(BOOL )supportsVideo
     includesCallsInRecents:(BOOL )includesCallsInRecents
-    driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled {
+    driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled
+    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly {
   WTPIOSOptions* pigeonResult = [[WTPIOSOptions alloc] init];
   pigeonResult.localizedName = localizedName;
   pigeonResult.ringtoneSound = ringtoneSound;
@@ -235,6 +236,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.supportsVideo = supportsVideo;
   pigeonResult.includesCallsInRecents = includesCallsInRecents;
   pigeonResult.driveIdleTimerDisabled = driveIdleTimerDisabled;
+  pigeonResult.callWaitingToneOwnCallsOnly = callWaitingToneOwnCallsOnly;
   return pigeonResult;
 }
 + (WTPIOSOptions *)fromList:(NSArray<id> *)list {
@@ -251,6 +253,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.supportsVideo = [GetNullableObjectAtIndex(list, 9) boolValue];
   pigeonResult.includesCallsInRecents = [GetNullableObjectAtIndex(list, 10) boolValue];
   pigeonResult.driveIdleTimerDisabled = [GetNullableObjectAtIndex(list, 11) boolValue];
+  pigeonResult.callWaitingToneOwnCallsOnly = list.count > 12 ? GetNullableObjectAtIndex(list, 12) : nil;
   return pigeonResult;
 }
 + (nullable WTPIOSOptions *)nullableFromList:(NSArray<id> *)list {
@@ -270,6 +273,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     @(self.supportsVideo),
     @(self.includesCallsInRecents),
     @(self.driveIdleTimerDisabled),
+    self.callWaitingToneOwnCallsOnly ?: [NSNull null],
   ];
 }
 - (BOOL)isEqual:(id)object {
@@ -280,7 +284,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     return NO;
   }
   WTPIOSOptions *other = (WTPIOSOptions *)object;
-  return FLTPigeonDeepEquals(self.localizedName, other.localizedName) && FLTPigeonDeepEquals(self.ringtoneSound, other.ringtoneSound) && FLTPigeonDeepEquals(self.ringbackSound, other.ringbackSound) && FLTPigeonDeepEquals(self.iconTemplateImageAssetName, other.iconTemplateImageAssetName) && self.maximumCallGroups == other.maximumCallGroups && self.maximumCallsPerCallGroup == other.maximumCallsPerCallGroup && FLTPigeonDeepEquals(self.supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && FLTPigeonDeepEquals(self.supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && FLTPigeonDeepEquals(self.supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && self.supportsVideo == other.supportsVideo && self.includesCallsInRecents == other.includesCallsInRecents && self.driveIdleTimerDisabled == other.driveIdleTimerDisabled;
+  return FLTPigeonDeepEquals(self.localizedName, other.localizedName) && FLTPigeonDeepEquals(self.ringtoneSound, other.ringtoneSound) && FLTPigeonDeepEquals(self.ringbackSound, other.ringbackSound) && FLTPigeonDeepEquals(self.iconTemplateImageAssetName, other.iconTemplateImageAssetName) && self.maximumCallGroups == other.maximumCallGroups && self.maximumCallsPerCallGroup == other.maximumCallsPerCallGroup && FLTPigeonDeepEquals(self.supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && FLTPigeonDeepEquals(self.supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && FLTPigeonDeepEquals(self.supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && self.supportsVideo == other.supportsVideo && self.includesCallsInRecents == other.includesCallsInRecents && self.driveIdleTimerDisabled == other.driveIdleTimerDisabled && FLTPigeonDeepEquals(self.callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly);
 }
 
 - (NSUInteger)hash {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -24,6 +24,9 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
   CallWaitingTonePlayer *_callWaitingTone;
+  NSMutableSet<NSUUID *> *_ownCallUuids;
+  NSMutableSet<NSUUID *> *_answeringCallUuids;
+  BOOL _callWaitingToneOwnCallsOnly;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -48,9 +51,12 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _delegateFlutterApi = [[WTPDelegateFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
     SetUpWTPHostApi(binaryMessenger, self);
     SetUpWTPHostSoundApi(binaryMessenger, self);
-    // Created eagerly: it has to observe the call engine's lifecycle notifications
-    // from the very first call, not from the first play request.
+    // Created eagerly so it can be pre-warmed from the very first
+    // didActivateAudioSession callback, not from the first play request.
     _callWaitingTone = [[CallWaitingTonePlayer alloc] init];
+    _ownCallUuids = [NSMutableSet set];
+    _answeringCallUuids = [NSMutableSet set];
+    _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
 }
@@ -94,6 +100,10 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 
     _callController = [[CXCallController alloc] init];
     [_callController.callObserver setDelegate:self queue:dispatch_get_main_queue()];
+    [self syncCallWaitingTone:_callController.callObserver];
+
+    _callWaitingToneOwnCallsOnly =
+        iosOptions.callWaitingToneOwnCallsOnly == nil || iosOptions.callWaitingToneOwnCallsOnly.boolValue;
 
     if (iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
@@ -151,7 +161,10 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     if (_callController == nil) {
       _callController = [[CXCallController alloc] init];
       [_callController.callObserver setDelegate:self queue:dispatch_get_main_queue()];
+      [self syncCallWaitingTone:_callController.callObserver];
     }
+    _callWaitingToneOwnCallsOnly =
+        iosOptions.callWaitingToneOwnCallsOnly == nil || iosOptions.callWaitingToneOwnCallsOnly.boolValue;
     
     if (_ringback == nil && iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
@@ -175,6 +188,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _callController = nil;
   }
   [_callWaitingTone stop];
+  [_ownCallUuids removeAllObjects];
+  [_answeringCallUuids removeAllObjects];
   if (_provider != nil) {
     [_provider invalidate];
     _provider = nil;
@@ -203,7 +218,11 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   callUpdate.supportsUngrouping = NO;
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
-  [_provider reportNewIncomingCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  NSUUID *callUuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  if (callUuid != nil) {
+    [_ownCallUuids addObject:callUuid];
+  }
+  [_provider reportNewIncomingCallWithUUID:callUuid
                                     update:callUpdate
                                 completion:^(NSError *error) {
                                   if (error == nil) {
@@ -577,6 +596,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     NSUUID *uuid = [[NSUUID alloc] init];
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
 
+    [_ownCallUuids addObject:uuid];
     [_provider reportNewIncomingCallWithUUID:uuid
                                       update:callUpdate
                                   completion:^(NSError *error) {
@@ -628,6 +648,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   callUpdate.supportsUngrouping = NO;
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
+  [_ownCallUuids addObject:uuid];
   [_provider reportNewIncomingCallWithUUID:uuid
                                     update:callUpdate
                                 completion:^(NSError *error) {
@@ -693,16 +714,28 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 /// Mirrors the Android connection-service behavior: a soft call-waiting beep plays
 /// while one call is connected (or held) and another incoming call is ringing, and
 /// stops as soon as that state ends (answered, declined, hung up on either side).
+/// With callWaitingToneOwnCallsOnly (default) only this app's own calls are counted -
+/// CXCallObserver reports every CallKit call on the device, including cellular and
+/// other VoIP apps. Known scope boundary: an outgoing call that is still dialing has
+/// hasConnected == NO, so a second incoming call during it produces no tone (same as
+/// the Android connection-service logic, which plays the full ringtone there).
 - (void)syncCallWaitingTone:(CXCallObserver *)callObserver {
   BOOL hasConnected = NO;
   BOOL hasRingingIncoming = NO;
   for (CXCall *call in callObserver.calls) {
+    if (call.hasEnded || call.hasConnected) {
+      [_answeringCallUuids removeObject:call.UUID];
+    }
     if (call.hasEnded) {
+      [_ownCallUuids removeObject:call.UUID];
       continue;
+    }
+    if (_callWaitingToneOwnCallsOnly && ![_ownCallUuids containsObject:call.UUID]) {
+      continue;  // a foreign CallKit call (cellular / another VoIP app)
     }
     if (call.hasConnected) {
       hasConnected = YES;
-    } else if (!call.outgoing) {
+    } else if (!call.outgoing && ![_answeringCallUuids containsObject:call.UUID]) {
       hasRingingIncoming = YES;
     }
   }
@@ -722,6 +755,8 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   NSLog(@"[Callkeep][CXProviderDelegate][providerDidReset:]");
 #endif
   [_callWaitingTone stop];
+  [_ownCallUuids removeAllObjects];
+  [_answeringCallUuids removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -729,6 +764,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performStartCallAction:]");
 #endif
+  [_ownCallUuids addObject:action.callUUID];
   [_delegateFlutterApi performStartCall:action.callUUID.UUIDString
                                  handle:[action.handle toPigeon]
          displayNameOrContactIdentifier:action.contactIdentifier
@@ -747,9 +783,13 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performAnswerCallAction:]");
 #endif
+  // Suppress the call-waiting tone from the moment the user accepts: the CXCall stays
+  // "ringing" until the answer roundtrip fulfills the action, which can take seconds.
+  [_answeringCallUuids addObject:action.callUUID];
   [_delegateFlutterApi performAnswerCall:action.callUUID.UUIDString
                               completion:^(NSNumber *fulfill, FlutterError *error) {
                                 if (error != nil || [fulfill boolValue] != YES) {
+                                  [self->_answeringCallUuids removeObject:action.callUUID];
                                   [action fail];
                                 } else {
                                   [action fulfill];
@@ -841,6 +881,14 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   // Pre-warm the call-waiting tone player before the Dart side starts the WebRTC
   // voice-processing engine (playback sources created after it are near-silent).
   [_callWaitingTone onAudioSessionActivated];
+  // Re-evaluate the tone on the observer's queue: this callback runs on the provider's
+  // private queue and must not resume playback from stale state on its own.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    CXCallController *controller = self->_callController;
+    if (controller != nil) {
+      [self syncCallWaitingTone:controller.callObserver];
+    }
+  });
   [_delegateFlutterApi didActivateAudioSession:^(FlutterError *error) {}];
 }
 

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -9,10 +9,11 @@
 #import "Generated.h"
 #import "Converters.h"
 #import "NSUUID+v5.h"
+#import "CallWaitingTonePlayer.h"
 
 static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 
-@interface WebtritCallkeepPlugin ()<PKPushRegistryDelegate, CXProviderDelegate, WTPPushRegistryHostApi, WTPHostApi, WTPHostSoundApi>
+@interface WebtritCallkeepPlugin ()<PKPushRegistryDelegate, CXProviderDelegate, CXCallObserverDelegate, WTPPushRegistryHostApi, WTPHostApi, WTPHostSoundApi>
 @end
 
 @implementation WebtritCallkeepPlugin {
@@ -22,6 +23,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   WTPDelegateFlutterApi *_delegateFlutterApi;
   CXProvider *_provider;
   AVAudioPlayer *_ringback;
+  CallWaitingTonePlayer *_callWaitingTone;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
 }
@@ -46,6 +48,9 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _delegateFlutterApi = [[WTPDelegateFlutterApi alloc] initWithBinaryMessenger:binaryMessenger];
     SetUpWTPHostApi(binaryMessenger, self);
     SetUpWTPHostSoundApi(binaryMessenger, self);
+    // Created eagerly: it has to observe the call engine's lifecycle notifications
+    // from the very first call, not from the first play request.
+    _callWaitingTone = [[CallWaitingTonePlayer alloc] init];
   }
   return self;
 }
@@ -88,7 +93,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     [_provider setDelegate:self queue:nil];
 
     _callController = [[CXCallController alloc] init];
-      
+    [_callController.callObserver setDelegate:self queue:dispatch_get_main_queue()];
+
     if (iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
     }
@@ -144,6 +150,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     }
     if (_callController == nil) {
       _callController = [[CXCallController alloc] init];
+      [_callController.callObserver setDelegate:self queue:dispatch_get_main_queue()];
     }
     
     if (_ringback == nil && iosOptions.ringbackSound != nil) {
@@ -164,8 +171,10 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   NSLog(@"[Callkeep][tearDown]");
 #endif
   if (_callController != nil) {
+    [_callController.callObserver setDelegate:nil queue:nil];
     _callController = nil;
   }
+  [_callWaitingTone stop];
   if (_provider != nil) {
     [_provider invalidate];
     _provider = nil;
@@ -449,9 +458,9 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     completion(nil);
 }
 
-- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{ 
+- (void)stopRingbackSound:(void (^)(FlutterError * _Nullable))completion{
     if(_ringback != nil)[_ringback pause];
-    
+
     completion(nil);
 }
 
@@ -675,10 +684,44 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 
 #pragma mark - CXProviderDelegate
 
+#pragma mark - CXCallObserverDelegate
+
+- (void)callObserver:(CXCallObserver *)callObserver callChanged:(CXCall *)call {
+  [self syncCallWaitingTone:callObserver];
+}
+
+/// Mirrors the Android connection-service behavior: a soft call-waiting beep plays
+/// while one call is connected (or held) and another incoming call is ringing, and
+/// stops as soon as that state ends (answered, declined, hung up on either side).
+- (void)syncCallWaitingTone:(CXCallObserver *)callObserver {
+  BOOL hasConnected = NO;
+  BOOL hasRingingIncoming = NO;
+  for (CXCall *call in callObserver.calls) {
+    if (call.hasEnded) {
+      continue;
+    }
+    if (call.hasConnected) {
+      hasConnected = YES;
+    } else if (!call.outgoing) {
+      hasRingingIncoming = YES;
+    }
+  }
+#ifdef DEBUG
+  NSLog(@"[CallWaitingTone] sync: calls=%lu connected=%d ringingIncoming=%d",
+        (unsigned long)callObserver.calls.count, hasConnected, hasRingingIncoming);
+#endif
+  if (hasConnected && hasRingingIncoming) {
+    [_callWaitingTone play];
+  } else {
+    [_callWaitingTone stop];
+  }
+}
+
 - (void)providerDidReset:(CXProvider *)provider {
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][providerDidReset:]");
 #endif
+  [_callWaitingTone stop];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -795,6 +838,9 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[CallKeep][CXProviderDelegate][provider:didActivateAudioSession:]");
 #endif
+  // Pre-warm the call-waiting tone player before the Dart side starts the WebRTC
+  // voice-processing engine (playback sources created after it are near-silent).
+  [_callWaitingTone onAudioSessionActivated];
   [_delegateFlutterApi didActivateAudioSession:^(FlutterError *error) {}];
 }
 
@@ -802,6 +848,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[CallKeep][CXProviderDelegate][provider:didDeactivateAudioSession:]");
 #endif
+  [_callWaitingTone onAudioSessionDeactivated];
   [_delegateFlutterApi didDeactivateAudioSession:^(FlutterError *error) {}];
 }
 

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/CallWaitingTonePlayer.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/CallWaitingTonePlayer.h
@@ -1,0 +1,34 @@
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Plays a soft, looping call-waiting beep over the active call audio.
+///
+/// A plain AVAudioPlayer with two mitigations for the iOS quirk where playback sources
+/// started after voice processing enables play near-silent (Apple forums thread 721535):
+/// 1. The player is created and pre-warmed in the CallKit `didActivateAudioSession`
+///    callback - callkeep receives it natively BEFORE the app starts WebRTC's
+///    voice-processing engine, so the playback source exists before VP enables.
+/// 2. After every `play`, the audio session category is re-asserted idempotently
+///    (the documented workaround that restores full volume for late-started sources).
+///
+/// The tone stays local-only: everything the device plays is part of the
+/// voice-processing echo-cancellation reference and is subtracted from the mic.
+@interface CallWaitingTonePlayer : NSObject
+
+/// Starts the looping beep. Safe to call repeatedly.
+- (void)play;
+
+/// Stops the beep. Safe to call repeatedly.
+- (void)stop;
+
+/// Must be called from `CXProviderDelegate provider:didActivateAudioSession:`.
+/// Pre-warms the player before the call's voice-processing engine starts.
+- (void)onAudioSessionActivated;
+
+/// Must be called from `CXProviderDelegate provider:didDeactivateAudioSession:`.
+- (void)onAudioSessionDeactivated;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
@@ -103,7 +103,8 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
     supportsHandleTypeEmailAddress:(nullable NSNumber *)supportsHandleTypeEmailAddress
     supportsVideo:(BOOL )supportsVideo
     includesCallsInRecents:(BOOL )includesCallsInRecents
-    driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled;
+    driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled
+    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly;
 @property(nonatomic, copy) NSString * localizedName;
 @property(nonatomic, copy, nullable) NSString * ringtoneSound;
 @property(nonatomic, copy, nullable) NSString * ringbackSound;
@@ -116,6 +117,7 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
 @property(nonatomic, assign) BOOL  supportsVideo;
 @property(nonatomic, assign) BOOL  includesCallsInRecents;
 @property(nonatomic, assign) BOOL  driveIdleTimerDisabled;
+@property(nonatomic, strong, nullable) NSNumber * callWaitingToneOwnCallsOnly;
 @end
 
 @interface WTPAndroidOptions : NSObject

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -162,6 +162,7 @@ class PIOSOptions {
     required this.supportsVideo,
     required this.includesCallsInRecents,
     required this.driveIdleTimerDisabled,
+    this.callWaitingToneOwnCallsOnly,
   });
 
   String localizedName;
@@ -188,6 +189,8 @@ class PIOSOptions {
 
   bool driveIdleTimerDisabled;
 
+  bool? callWaitingToneOwnCallsOnly;
+
   List<Object?> _toList() {
     return <Object?>[
       localizedName,
@@ -202,6 +205,7 @@ class PIOSOptions {
       supportsVideo,
       includesCallsInRecents,
       driveIdleTimerDisabled,
+      callWaitingToneOwnCallsOnly,
     ];
   }
 
@@ -223,6 +227,7 @@ class PIOSOptions {
       supportsVideo: result[9]! as bool,
       includesCallsInRecents: result[10]! as bool,
       driveIdleTimerDisabled: result[11]! as bool,
+      callWaitingToneOwnCallsOnly: result.length > 12 ? result[12] as bool? : null,
     );
   }
 
@@ -235,7 +240,7 @@ class PIOSOptions {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(localizedName, other.localizedName) && _deepEquals(ringtoneSound, other.ringtoneSound) && _deepEquals(ringbackSound, other.ringbackSound) && _deepEquals(iconTemplateImageAssetName, other.iconTemplateImageAssetName) && _deepEquals(maximumCallGroups, other.maximumCallGroups) && _deepEquals(maximumCallsPerCallGroup, other.maximumCallsPerCallGroup) && _deepEquals(supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && _deepEquals(supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && _deepEquals(supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && _deepEquals(supportsVideo, other.supportsVideo) && _deepEquals(includesCallsInRecents, other.includesCallsInRecents) && _deepEquals(driveIdleTimerDisabled, other.driveIdleTimerDisabled);
+    return _deepEquals(localizedName, other.localizedName) && _deepEquals(ringtoneSound, other.ringtoneSound) && _deepEquals(ringbackSound, other.ringbackSound) && _deepEquals(iconTemplateImageAssetName, other.iconTemplateImageAssetName) && _deepEquals(maximumCallGroups, other.maximumCallGroups) && _deepEquals(maximumCallsPerCallGroup, other.maximumCallsPerCallGroup) && _deepEquals(supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && _deepEquals(supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && _deepEquals(supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && _deepEquals(supportsVideo, other.supportsVideo) && _deepEquals(includesCallsInRecents, other.includesCallsInRecents) && _deepEquals(driveIdleTimerDisabled, other.driveIdleTimerDisabled) && _deepEquals(callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly);
   }
 
   @override

--- a/webtrit_callkeep_ios/lib/src/common/converters.dart
+++ b/webtrit_callkeep_ios/lib/src/common/converters.dart
@@ -124,6 +124,7 @@ extension CallkeepIOSOptionsConverter on CallkeepIOSOptions {
       supportsVideo: supportsVideo,
       includesCallsInRecents: includesCallsInRecents,
       driveIdleTimerDisabled: driveIdleTimerDisabled,
+      callWaitingToneOwnCallsOnly: callWaitingToneOwnCallsOnly,
     );
   }
 }

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -24,6 +24,7 @@ class PIOSOptions {
   late bool supportsVideo;
   late bool includesCallsInRecents;
   late bool driveIdleTimerDisabled;
+  late bool? callWaitingToneOwnCallsOnly;
 }
 
 class PAndroidOptions {

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -23,6 +23,7 @@ class CallkeepIOSOptions extends Equatable {
     this.supportsVideo = false,
     this.includesCallsInRecents = true,
     this.driveIdleTimerDisabled = true,
+    this.callWaitingToneOwnCallsOnly = true,
   });
 
   final String localizedName;
@@ -36,6 +37,11 @@ class CallkeepIOSOptions extends Equatable {
   final bool includesCallsInRecents;
   final bool driveIdleTimerDisabled;
 
+  /// iOS only: when true (default), the call-waiting tone detection considers only
+  /// this app's own CallKit calls; when false, calls from other apps (cellular,
+  /// other VoIP apps) also count towards the connected/ringing combination.
+  final bool callWaitingToneOwnCallsOnly;
+
   @override
   List<Object?> get props => [
     localizedName,
@@ -48,6 +54,7 @@ class CallkeepIOSOptions extends Equatable {
     supportsVideo,
     includesCallsInRecents,
     driveIdleTimerDisabled,
+    callWaitingToneOwnCallsOnly,
   ];
 }
 


### PR DESCRIPTION
## Overview

WT-1415. A second incoming call during an active call has no audible indication on iOS: CallKit does not auto-play a call-waiting tone for VoIP calls, and playback sources started after the voice-processing engine enables play near-silent (a long-standing iOS quirk). Android already handles this scenario natively in the connection service (soft tone instead of the full ringtone); this PR brings iOS to the same fully-native model - **no sound API, no app involvement, each platform decides on its own**.

Design rationale (the quirk, the mitigations, the rejected alternatives, maintenance invariants) is documented in `docs/ios-call-waiting-tone.md` (part of this PR).

### Detection

The plugin observes `CXCallObserver`: the tone plays while one call is connected (or held) and another incoming call is ringing, and stops as soon as that state ends - mirroring the Android connection-service logic. Hardening on top:

- **Own calls only (default).** `CXCallObserver` reports every CallKit call on the device (cellular, other VoIP apps), so unfiltered detection would beep over foreign calls. The plugin tracks the UUIDs of calls it reported/started and counts only those; `CallkeepIOSOptions.callWaitingToneOwnCallsOnly = false` widens detection to all calls.
- **Answer suppression.** A `CXCall` keeps looking "ringing" until the answer action is fulfilled (app roundtrip + SIP signaling), so the accepted call's UUID is excluded from the moment the user taps Accept - the beep does not bleed into the answered conversation.
- Play/stop decisions are made only by the call-state sync on the observer queue; the session-activation callback (provider's private queue) never resumes playback from cached state.
- Scope boundary: an outgoing call that is still dialing has `hasConnected == NO`, so a second incoming call during it produces no tone - intentionally the same as Android.

### Playback

`CallWaitingTonePlayer` is a plain `AVAudioPlayer` (in-memory WAV; a single 440 Hz / 300 ms beep on a 3 s cadence - the same pattern Android plays via `ToneGenerator.TONE_SUP_CALL_WAITING`) with two mitigations for the voice-processing quirk:

1. the player is created and pre-warmed in the native `CXProvider didActivateAudioSession` callback - before the app starts the voice-processing engine;
2. the audio session category is re-asserted idempotently on each real playback start (does not change the route or the session mode).

The tone stays local-only: device playback is part of the voice-processing echo-cancellation reference, so the remote side does not hear it.

## Scope

iOS-only. New `CallWaitingTonePlayer` + detection wiring in the plugin + the `callWaitingToneOwnCallsOnly` iOS option (pigeon files hand-extended additively with the one field; no new methods) + design doc. Android behavior untouched; no dependencies on other plugins.

## Testing

- iOS device (iPhone, iOS 26.4): full flow verified - beep audible over the live call when the second call rings, silent with a single call, stops on accept/decline/hangup; detection sync observable via `[CallWaitingTone] sync: ...` DEBUG logs.
- `flutter analyze` clean across packages; `./gradlew testDebugUnitTest` green; `clang -fsyntax-only` clean.