### PR TITLE
fix(android): stop ActiveCallService when restarted with no calls metadata

### DIFF
--- a/webtrit_callkeep_android/android/build.gradle
+++ b/webtrit_callkeep_android/android/build.gradle
@@ -68,6 +68,14 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'
     }
+
+    testOptions {
+        unitTests {
+            // Robolectric needs the library's own resources (notification strings/icons)
+            // to build service notifications in unit tests.
+            includeAndroidResources = true
+        }
+    }
 }
 
 kotlin {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/managers/NotificationManager.kt
@@ -46,7 +46,7 @@ class NotificationManager {
         if (activeCalls.isNotEmpty()) {
             val activeCallsBundles = activeCalls.map { it.toBundle() }
             val intent = Intent(context, ActiveCallService::class.java)
-            intent.putExtra("metadata", ArrayList(activeCallsBundles))
+            intent.putExtra(ActiveCallService.EXTRA_CALLS_METADATA, ArrayList(activeCallsBundles))
             context.startService(intent)
         } else {
             context.stopService(Intent(context, ActiveCallService::class.java))

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -35,7 +35,7 @@ class ActiveCallService : Service() {
     ): Int {
         // Handle the hangup action from the notification
         if (NotificationAction.Decline.action == intent?.action) {
-            hungUpCall()
+            hungUpCall(intent.extras?.let(CallMetadata::fromBundleOrNull))
 
             return START_NOT_STICKY
         }
@@ -97,8 +97,11 @@ class ActiveCallService : Service() {
         return START_STICKY
     }
 
-    private fun hungUpCall() {
-        val call = callsMetadata.firstOrNull()
+    private fun hungUpCall(intentMetadata: CallMetadata?) {
+        // The Decline PendingIntent carries the tapped call's bundle in its extras. When the tap
+        // creates a fresh service instance (process death cleared callsMetadata), that is the
+        // only way left to hang up the specific call instead of tearing everything down.
+        val call = callsMetadata.firstOrNull() ?: intentMetadata
         if (call != null) {
             CallkeepCore.instance.startHungUpCall(call)
         } else {

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -42,7 +42,7 @@ class ActiveCallService : Service() {
 
         callsMetadata =
             intent
-                ?.parcelableArrayList<Bundle>("metadata")
+                ?.parcelableArrayList<Bundle>(EXTRA_CALLS_METADATA)
                 ?.map { CallMetadata.fromBundle(it) }
                 ?.toMutableList() ?: mutableListOf()
 
@@ -88,12 +88,7 @@ class ActiveCallService : Service() {
             // this service is still foreground the startService toward the connection services
             // is exempt from background-start restrictions.
             Log.w(TAG, "onStartCommand: no calls metadata (null-intent restart), tearing down and stopping self")
-            CallkeepCore.instance.tearDownService()
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            // stopSelf(startId), not stopSelf(): a newer start with real metadata may already
-            // be queued behind this one (the recovering app re-posting its call list), and an
-            // unconditional stop would cancel it together with its foreground notification.
-            stopSelf(startId)
+            tearDownAndStop(startId)
             return START_NOT_STICKY
         }
 
@@ -112,14 +107,22 @@ class ActiveCallService : Service() {
             CallkeepCore.instance.startHungUpCall(call)
         } else {
             // Hang up tapped on a notification with no known calls (re-posted by a null-intent
-            // restart). tearDownService only tears down the connection services and does not
-            // stop this one, so the notification has to be removed here. stopSelf(startId)
-            // keeps a newer queued start with real metadata alive.
+            // restart).
             Log.w(TAG, "hungUpCall: no calls metadata, tearing down and stopping self")
-            CallkeepCore.instance.tearDownService()
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf(startId)
+            tearDownAndStop(startId)
         }
+    }
+
+    // Tears down the connection services (a call leg may have survived in :callkeep_core),
+    // removes the notification and stops this instance. tearDownService only tears down the
+    // connection services and does not stop this one, so the notification has to be removed
+    // here. stopSelf(startId), not stopSelf(): a newer start with real metadata may already
+    // be queued behind the current command (the recovering app re-posting its call list), and
+    // an unconditional stop would cancel it together with its foreground notification.
+    private fun tearDownAndStop(startId: Int) {
+        CallkeepCore.instance.tearDownService()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf(startId)
     }
 
     private fun getForegroundServiceTypes(callsMetadata: List<CallMetadata>): Int? =
@@ -162,6 +165,10 @@ class ActiveCallService : Service() {
     }
 
     companion object {
+        // Intent extra carrying the ArrayList<Bundle> of active calls; the writing side is
+        // NotificationManager.upsertActiveCallsService.
+        const val EXTRA_CALLS_METADATA = "metadata"
+
         private const val TAG = "ActiveCallService"
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -35,7 +35,7 @@ class ActiveCallService : Service() {
     ): Int {
         // Handle the hangup action from the notification
         if (NotificationAction.Decline.action == intent?.action) {
-            hungUpCall(intent.extras?.let(CallMetadata::fromBundleOrNull))
+            hungUpCall(intent.extras?.let(CallMetadata::fromBundleOrNull), startId)
 
             return START_NOT_STICKY
         }
@@ -90,14 +90,20 @@ class ActiveCallService : Service() {
             Log.w(TAG, "onStartCommand: no calls metadata (null-intent restart), tearing down and stopping self")
             CallkeepCore.instance.tearDownService()
             stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
+            // stopSelf(startId), not stopSelf(): a newer start with real metadata may already
+            // be queued behind this one (the recovering app re-posting its call list), and an
+            // unconditional stop would cancel it together with its foreground notification.
+            stopSelf(startId)
             return START_NOT_STICKY
         }
 
         return START_STICKY
     }
 
-    private fun hungUpCall(intentMetadata: CallMetadata?) {
+    private fun hungUpCall(
+        intentMetadata: CallMetadata?,
+        startId: Int,
+    ) {
         // The Decline PendingIntent carries the tapped call's bundle in its extras. When the tap
         // creates a fresh service instance (process death cleared callsMetadata), that is the
         // only way left to hang up the specific call instead of tearing everything down.
@@ -107,11 +113,12 @@ class ActiveCallService : Service() {
         } else {
             // Hang up tapped on a notification with no known calls (re-posted by a null-intent
             // restart). tearDownService only tears down the connection services and does not
-            // stop this one, so the notification has to be removed here.
+            // stop this one, so the notification has to be removed here. stopSelf(startId)
+            // keeps a newer queued start with real metadata alive.
             Log.w(TAG, "hungUpCall: no calls metadata, tearing down and stopping self")
             CallkeepCore.instance.tearDownService()
             stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
+            stopSelf(startId)
         }
     }
 

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -49,6 +49,9 @@ class ActiveCallService : Service() {
         activeCallNotificationBuilder.setCallsMetaData(callsMetadata)
         val notification = activeCallNotificationBuilder.build()
 
+        // startForeground must be called even when there are no calls to show: the service may
+        // have been (re)started as foreground and skipping the promotion would kill the process
+        // with ForegroundServiceDidNotStartInTimeException.
         startForegroundServiceCompat(
             this,
             ActiveCallNotificationBuilder.NOTIFICATION_ID,
@@ -56,13 +59,34 @@ class ActiveCallService : Service() {
             getForegroundServiceTypes(callsMetadata),
         )
 
+        if (callsMetadata.isEmpty()) {
+            // Empty metadata means a START_STICKY restart delivered a null intent after the
+            // process was killed. NotificationManager tracks active calls in its own static
+            // list, so nothing will ever stop this orphaned instance - an ongoing notification
+            // left here would be undismissable until the user force-stops the app.
+            Log.w(TAG, "onStartCommand: no calls metadata (null-intent restart), stopping self")
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
         return START_STICKY
     }
 
-    private fun hungUpCall() =
-        callsMetadata.firstOrNull()?.let {
-            CallkeepCore.instance.startHungUpCall(it)
-        } ?: CallkeepCore.instance.tearDownService()
+    private fun hungUpCall() {
+        val call = callsMetadata.firstOrNull()
+        if (call != null) {
+            CallkeepCore.instance.startHungUpCall(call)
+        } else {
+            // Hang up tapped on a notification with no known calls (re-posted by a null-intent
+            // restart). tearDownService only tears down the connection services and does not
+            // stop this one, so the notification has to be removed here.
+            Log.w(TAG, "hungUpCall: no calls metadata, tearing down and stopping self")
+            CallkeepCore.instance.tearDownService()
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+    }
 
     private fun getForegroundServiceTypes(callsMetadata: List<CallMetadata>): Int? =
         when {
@@ -101,5 +125,9 @@ class ActiveCallService : Service() {
     override fun onDestroy() {
         stopForeground(STOP_FOREGROUND_REMOVE)
         super.onDestroy()
+    }
+
+    companion object {
+        private const val TAG = "ActiveCallService"
     }
 }

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -52,12 +52,28 @@ class ActiveCallService : Service() {
         // startForeground must be called even when there are no calls to show: the service may
         // have been (re)started as foreground and skipping the promotion would kill the process
         // with ForegroundServiceDidNotStartInTimeException.
-        startForegroundServiceCompat(
-            this,
-            ActiveCallNotificationBuilder.NOTIFICATION_ID,
-            notification,
-            getForegroundServiceTypes(callsMetadata),
-        )
+        //
+        // On Android 14+ the MICROPHONE type is rejected with SecurityException when the
+        // promotion happens from the background - which is exactly the START_STICKY restart
+        // after a process kill. Fall back to the phone-call type (not while-in-use restricted)
+        // so the promotion, and the empty-metadata guard below, run instead of crash-looping
+        // the restart.
+        try {
+            startForegroundServiceCompat(
+                this,
+                ActiveCallNotificationBuilder.NOTIFICATION_ID,
+                notification,
+                getForegroundServiceTypes(callsMetadata),
+            )
+        } catch (e: SecurityException) {
+            Log.w(TAG, "onStartCommand: typed promotion rejected, falling back to phone-call type", e)
+            startForegroundServiceCompat(
+                this,
+                ActiveCallNotificationBuilder.NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL,
+            )
+        }
 
         if (callsMetadata.isEmpty()) {
             // Empty metadata means a START_STICKY restart delivered a null intent after the

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallService.kt
@@ -80,7 +80,15 @@ class ActiveCallService : Service() {
             // process was killed. NotificationManager tracks active calls in its own static
             // list, so nothing will ever stop this orphaned instance - an ongoing notification
             // left here would be undismissable until the user force-stops the app.
-            Log.w(TAG, "onStartCommand: no calls metadata (null-intent restart), stopping self")
+            //
+            // A call leg may have survived in :callkeep_core (Telecom keeps that process alive
+            // via its own binding), and this restart is the last signal the main process gets
+            // about it: tear the connection services down so the device is not left stuck in a
+            // zombie Telecom call with no UI to end it. Must run before stopForeground - while
+            // this service is still foreground the startService toward the connection services
+            // is exempt from background-start restrictions.
+            Log.w(TAG, "onStartCommand: no calls metadata (null-intent restart), tearing down and stopping self")
+            CallkeepCore.instance.tearDownService()
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return START_NOT_STICKY

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/services/services/incoming_call/IncomingCallService.kt
@@ -280,9 +280,9 @@ class IncomingCallService :
         return START_NOT_STICKY
     }
 
-    private fun performAnswerCall(metadata: CallMetadata): Int {
+    // Called from onConnectionEvent only, never from onStartCommand - no start mode to return.
+    private fun performAnswerCall(metadata: CallMetadata) {
         callLifecycleHandler.performAnswerCall(metadata)
-        return START_STICKY
     }
 
     // Launches the service with the LAUNCH action and cancels the timeout

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
@@ -29,6 +29,7 @@ import org.robolectric.annotation.Config
  * cannot be swiped away, and the Hang up action has no visible effect.
  *
  * The guard: after satisfying the startForeground contract, an instance with no calls
+ * tears down the connection services (a call leg may have survived in :callkeep_core),
  * removes its notification and stops itself; the empty branch of hungUpCall does the same
  * on top of the existing tearDownService fallback.
  */

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
@@ -1,0 +1,123 @@
+package com.webtrit.callkeep.services.services.active_call
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import com.webtrit.callkeep.models.CallMetadata
+import com.webtrit.callkeep.models.NotificationAction
+import com.webtrit.callkeep.notifications.ActiveCallNotificationBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for the [ActiveCallService] empty-metadata guard.
+ *
+ * A START_STICKY restart after a process kill delivers a null intent, leaving
+ * [ActiveCallService] with no calls metadata. NotificationManager tracks active calls in its
+ * own static list (reset by the process death), so nothing external ever stops such an
+ * orphaned instance: without the guard its ongoing FGS notification stays in the shade,
+ * cannot be swiped away, and the Hang up action has no visible effect.
+ *
+ * The guard: after satisfying the startForeground contract, an instance with no calls
+ * removes its notification and stops itself; the empty branch of hungUpCall does the same
+ * on top of the existing tearDownService fallback.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class ActiveCallServiceRestartTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun buildService(): ActiveCallService = Robolectric.buildService(ActiveCallService::class.java).create().get()
+
+    private fun metadataIntent(vararg callIds: String): Intent =
+        Intent(context, ActiveCallService::class.java).apply {
+            putParcelableArrayListExtra(
+                "metadata",
+                ArrayList<Bundle>(callIds.map { CallMetadata(callId = it).toBundle() }),
+            )
+        }
+
+    private fun declineIntent(): Intent =
+        Intent(context, ActiveCallService::class.java).apply {
+            action = NotificationAction.Decline.action
+        }
+
+    @Test
+    fun `null-intent restart stops self and removes the notification`() {
+        val service = buildService()
+
+        val result = service.onStartCommand(null, 0, 1)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        val shadow = shadowOf(service)
+        assertTrue("service must stop itself", shadow.isStoppedBySelf)
+        assertTrue("foreground must be stopped", shadow.isForegroundStopped)
+        assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+    }
+
+    @Test
+    fun `start with an explicitly empty metadata list stops self`() {
+        val service = buildService()
+
+        val result = service.onStartCommand(metadataIntent(), 0, 1)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        val shadow = shadowOf(service)
+        assertTrue(shadow.isStoppedBySelf)
+        assertTrue(shadow.isForegroundStopped)
+        assertTrue(shadow.notificationShouldRemoved)
+    }
+
+    @Test
+    fun `start with calls metadata stays foreground and sticky`() {
+        val service = buildService()
+
+        val result = service.onStartCommand(metadataIntent("call-1"), 0, 1)
+
+        assertEquals(Service.START_STICKY, result)
+        val shadow = shadowOf(service)
+        assertFalse("service must keep running", shadow.isStoppedBySelf)
+        assertFalse("foreground must stay", shadow.isForegroundStopped)
+        assertEquals(ActiveCallNotificationBuilder.NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+    }
+
+    @Test
+    fun `hang up with no known calls stops self and removes the notification`() {
+        // Decline tapped on a notification re-posted by a null-intent restart: callsMetadata
+        // is empty, tearDownService alone does not stop this service.
+        val service = buildService()
+
+        val result = service.onStartCommand(declineIntent(), 0, 1)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        val shadow = shadowOf(service)
+        assertTrue("service must stop itself", shadow.isStoppedBySelf)
+        assertTrue("foreground must be stopped", shadow.isForegroundStopped)
+        assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+    }
+
+    @Test
+    fun `hang up with a known call keeps the service running`() {
+        // The normal path: the hangup is routed to the connection service; this service is
+        // stopped later by NotificationManager once the connection reports disconnect.
+        val service = buildService()
+        service.onStartCommand(metadataIntent("call-1"), 0, 1)
+
+        val result = service.onStartCommand(declineIntent(), 0, 2)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        val shadow = shadowOf(service)
+        assertFalse("service must keep running until the connection disconnects", shadow.isStoppedBySelf)
+        assertFalse("foreground must stay", shadow.isForegroundStopped)
+    }
+}

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
@@ -48,9 +48,10 @@ class ActiveCallServiceRestartTest {
             )
         }
 
-    private fun declineIntent(): Intent =
+    private fun declineIntent(metadata: CallMetadata? = null): Intent =
         Intent(context, ActiveCallService::class.java).apply {
             action = NotificationAction.Decline.action
+            metadata?.toBundle()?.let { putExtras(it) }
         }
 
     @Test
@@ -105,6 +106,22 @@ class ActiveCallServiceRestartTest {
         assertTrue("service must stop itself", shadow.isStoppedBySelf)
         assertTrue("foreground must be stopped", shadow.isForegroundStopped)
         assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+    }
+
+    @Test
+    fun `hang up with metadata only in the intent extras hangs up that call and keeps the service`() {
+        // Fresh instance created by the notification's Decline PendingIntent after process
+        // death: the callsMetadata field is empty, but the intent extras carry the tapped
+        // call's bundle (getHungUpCallIntent puts it there). The hangup must be routed to
+        // that call instead of falling into the tear-everything-down branch.
+        val service = buildService()
+
+        val result = service.onStartCommand(declineIntent(CallMetadata(callId = "call-1")), 0, 1)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        val shadow = shadowOf(service)
+        assertFalse("hangup must be routed, not torn down", shadow.isStoppedBySelf)
+        assertFalse("no notification to remove on a fresh instance", shadow.isForegroundStopped)
     }
 
     @Test

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/services/services/active_call/ActiveCallServiceRestartTest.kt
@@ -43,7 +43,7 @@ class ActiveCallServiceRestartTest {
     private fun metadataIntent(vararg callIds: String): Intent =
         Intent(context, ActiveCallService::class.java).apply {
             putParcelableArrayListExtra(
-                "metadata",
+                ActiveCallService.EXTRA_CALLS_METADATA,
                 ArrayList<Bundle>(callIds.map { CallMetadata(callId = it).toBundle() }),
             )
         }
@@ -54,6 +54,13 @@ class ActiveCallServiceRestartTest {
             metadata?.toBundle()?.let { putExtras(it) }
         }
 
+    private fun assertStoppedAndNotificationRemoved(service: ActiveCallService) {
+        val shadow = shadowOf(service)
+        assertTrue("service must stop itself", shadow.isStoppedBySelf)
+        assertTrue("foreground must be stopped", shadow.isForegroundStopped)
+        assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+    }
+
     @Test
     fun `null-intent restart stops self and removes the notification`() {
         val service = buildService()
@@ -61,10 +68,7 @@ class ActiveCallServiceRestartTest {
         val result = service.onStartCommand(null, 0, 1)
 
         assertEquals(Service.START_NOT_STICKY, result)
-        val shadow = shadowOf(service)
-        assertTrue("service must stop itself", shadow.isStoppedBySelf)
-        assertTrue("foreground must be stopped", shadow.isForegroundStopped)
-        assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+        assertStoppedAndNotificationRemoved(service)
     }
 
     @Test
@@ -74,10 +78,7 @@ class ActiveCallServiceRestartTest {
         val result = service.onStartCommand(metadataIntent(), 0, 1)
 
         assertEquals(Service.START_NOT_STICKY, result)
-        val shadow = shadowOf(service)
-        assertTrue(shadow.isStoppedBySelf)
-        assertTrue(shadow.isForegroundStopped)
-        assertTrue(shadow.notificationShouldRemoved)
+        assertStoppedAndNotificationRemoved(service)
     }
 
     @Test
@@ -102,10 +103,7 @@ class ActiveCallServiceRestartTest {
         val result = service.onStartCommand(declineIntent(), 0, 1)
 
         assertEquals(Service.START_NOT_STICKY, result)
-        val shadow = shadowOf(service)
-        assertTrue("service must stop itself", shadow.isStoppedBySelf)
-        assertTrue("foreground must be stopped", shadow.isForegroundStopped)
-        assertTrue("notification must be removed", shadow.notificationShouldRemoved)
+        assertStoppedAndNotificationRemoved(service)
     }
 
     @Test


### PR DESCRIPTION
## Overview

Fixes WT-1139.

A START_STICKY restart after a process kill delivers a null intent, leaving `ActiveCallService` with an empty calls list. `NotificationManager` tracks active calls in its own static list (reset by the process death), so nothing ever stops the orphaned instance: its ongoing FGS notification stays in the shade, cannot be swiped away, and the Hang up action has no visible effect (`tearDownService` tears down the connection services but does not stop this one). The user has to force-stop the app to get rid of the notification.

## Changes

`ActiveCallService`:

- Empty-metadata guard in `onStartCommand`: after satisfying the `startForeground` contract, an instance with no calls metadata logs a WARN, tears down the connection services, removes the notification and stops itself, returning `START_NOT_STICKY`. The teardown matters beyond the notification: if only the main process was killed, a call leg may have survived in `:callkeep_core` (Telecom keeps that process alive via its own binding), and this restart is the last signal the main process gets about it - without the teardown the device stays stuck in a zombie Telecom call with no UI to end it.
- Foreground promotion degrades gracefully on Android 14+: promoting with the MICROPHONE type from the background (exactly the sticky-restart case) throws SecurityException; on that exception the promotion retries with the phone-call type only (not while-in-use restricted), mirroring the existing `StandaloneCallService` fallback, so the guard runs instead of crash-looping the restart.
- `hungUpCall` falls back to the `CallMetadata` carried in the Decline PendingIntent extras: a Hang up tap that creates a fresh service instance (the in-memory list is empty after process death) now hangs up the specific call via the normal SIP BYE flow instead of tearing all connections down. The tear-down branch remains only for the truly unknown case (a notification re-posted by a null-intent restart carries no extras).
- Both stop branches use `stopSelf(startId)` (extracted into a `tearDownAndStop(startId)` helper), so a newer start with real metadata already queued behind the current command (the recovering app re-posting its call list) survives together with its foreground notification.
- The `"metadata"` intent extra key is promoted to `ActiveCallService.EXTRA_CALLS_METADATA`, shared by the writer (`NotificationManager.upsertActiveCallsService`), the reader and the test.

The normal path deliberately stays `START_STICKY`: the sticky restart is now the mechanism that delivers the zombie-leg cleanup above, and the guard's `START_NOT_STICKY` return prevents any restart loop (one restart, one cleanup, done).

Related cleanups:

- `IncomingCallService.performAnswerCall`: dropped the misleading `START_STICKY` return value - the method is called from `onConnectionEvent` only, so the value never reached `onStartCommand` (that service deliberately stays `START_NOT_STICKY` everywhere).
- `build.gradle`: `includeAndroidResources = true` so Robolectric can resolve the library's notification strings/icons in unit tests.

## Tests

6 new Robolectric tests in `ActiveCallServiceRestartTest`:

- null-intent restart stops self and removes the notification
- explicitly empty metadata list stops self
- start with calls metadata stays foreground and sticky
- Hang up with no known calls stops self and removes the notification
- Hang up with metadata only in the intent extras routes the hangup and keeps the service
- Hang up with a known call keeps the service running (normal path)

Full Android native suite: 235 tests, 0 failures.
