### PR TITLE
docs: declare iOS simulator not supported (WT-689)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This is a federated plugin. Each package has its own README and `docs/` director
 | Android | API 26 (Android 8.0) |
 | iOS | iOS 11 |
 
+> **Note:** CallKit and PushKit are only available on real devices — this plugin will not work
+> on iOS simulators. See [iOS Simulator](webtrit_callkeep_ios/README.md#ios-simulator).
+
 ---
 
 ## Installation

--- a/webtrit_callkeep_ios/README.md
+++ b/webtrit_callkeep_ios/README.md
@@ -21,6 +21,21 @@ CallKit / PushKit.
 
 ---
 
+## iOS Simulator
+
+CallKit and PushKit are only available on real devices — this plugin will not work on iOS
+simulators. Test on a physical device.
+
+- Incoming calls: the simulator never receives a PushKit VoIP token and cannot receive VoIP
+  pushes ([`xcrun simctl push` supports application pushes only](https://www.avanderlee.com/workflow/testing-push-notifications-ios-simulator/)).
+- Outgoing calls: depending on the simulator runtime, CallKit either never delivers
+  `performStartCallAction` or tears the call down ~2 s after start
+  ([Apple Developer Forums 749657](https://developer.apple.com/forums/thread/749657)).
+- Audio: `didActivateAudioSession` does not fire on the simulator, so call audio never starts
+  ([Apple Developer Forums 711956](https://developer.apple.com/forums/thread/711956)).
+
+---
+
 ## Package structure
 
 ```text


### PR DESCRIPTION
## Overview

States explicitly that the plugin does not work on iOS simulators, mirroring the disclaimer
react-native-callkeep carries in its README.

- Root README: a note in Platform support linking to the details.
- iOS package README: a new "iOS Simulator" section with the three concrete failure modes and
  sources - no PushKit VoIP token/pushes on the simulator, CallKit start-call callback not
  delivered or the call torn down ~2 s after start, and `didActivateAudioSession` never firing
  (so call audio never starts).
