### PR TITLE
fix(android): keep emergency-colliding extensions dialable on OEM Telecom forks (WT-1732)

### DIFF
--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/OutgoingCallUri.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/OutgoingCallUri.kt
@@ -1,0 +1,40 @@
+package com.webtrit.callkeep.common
+
+import android.net.Uri
+import android.telecom.PhoneAccount
+
+/**
+ * Single owner of the decoy [Uri] passed to `TelecomManager.placeCall` for outgoing calls.
+ *
+ * The dialled number is carried separately in the call metadata and is never read back from
+ * this Uri, so the user part only has to be a stable, valid placeholder. Some OEM Telecom
+ * forks run a scheme-agnostic emergency-number check on that Uri and silently divert the call
+ * to the system dialer when its user part looks like an emergency number - which breaks
+ * legitimate PBX extensions that collide with a device emergency number (for example an
+ * extension "112"). To avoid that, every digit is masked to a letter (0..9 -> a..j) and any
+ * other character is preserved and percent-encoded; the resulting user part carries no digit
+ * for such a check to match, while the real number keeps flowing unchanged in the metadata.
+ *
+ * Build the Uri only through [of]; never assemble it by hand, otherwise the digit masking can
+ * be forgotten in one place and the call will fail on those devices. The dialled number is
+ * read from the call metadata, never parsed back from this Uri - it is a one-way placeholder.
+ */
+object OutgoingCallUri {
+    // RFC 9476 reserved .internal TLD, guaranteed to never resolve publicly. This host is
+    // never used for actual dialing, only for Telecom bookkeeping.
+    private const val HOST = "portadialer.internal"
+
+    /** The Uri for placing an outgoing call to [number], with its digits masked to letters. */
+    fun of(number: String): Uri =
+        Uri.parse("${PhoneAccount.SCHEME_SIP}:${Uri.encode(maskDigits(number))}@$HOST")
+
+    // Each decimal digit -> the letter at the same offset from a (0 -> a .. 9 -> j).
+    // Every other character is left untouched, so the user part never carries a digit.
+    private fun maskDigits(value: String): String =
+        buildString {
+            for (c in value) {
+                val digit = Character.digit(c, 10)
+                append(if (digit in 0..9) 'a' + digit else c)
+            }
+        }
+}

--- a/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
+++ b/webtrit_callkeep_android/android/src/main/kotlin/com/webtrit/callkeep/common/TelephonyUtils.kt
@@ -90,10 +90,6 @@ class TelephonyUtils(
         // Defined as a local constant to avoid a lint InlinedApi warning on minSdk 26.
         private const val FEATURE_TELECOM = "android.software.telecom"
 
-        // RFC 9476 reserved .internal TLD, guaranteed to never resolve publicly. This host is
-        // never used for actual dialing, only for Telecom's own bookkeeping - see buildOutgoingUri.
-        private const val OUTGOING_URI_HOST = "portadialer.internal"
-
         private val logger = Log(TAG)
 
         /**
@@ -109,14 +105,12 @@ class TelephonyUtils(
          * Telecom bookkeeping; the real number keeps flowing unchanged via CallMetadata into
          * onCreateOutgoingConnection, which never reads request.address.
          *
-         * The number is percent-encoded so URI-reserved characters in it (e.g. "#" in PBX
-         * feature codes) cannot break the Uri structure, while the "@host" delimiter stays
-         * literal - a bare "sip:<number>" (no literal @host) still matches the emergency
-         * check, so the delimiter must not be encoded (Uri.fromParts would encode it too).
-         * Plain digit numbers are unaffected by the encoding, keeping the exact Uri shape
-         * validated on-device.
+         * Digits in the number are additionally masked to letters, and any other character
+         * percent-encoded, by [OutgoingCallUri] - the single owner of this Uri format - so that
+         * OEM Telecom forks which run a scheme-agnostic emergency-number check on the placeCall
+         * Uri find no digit to match and stop diverting these calls to the system dialer.
          */
-        fun buildOutgoingUri(number: String): Uri = Uri.parse("${PhoneAccount.SCHEME_SIP}:${Uri.encode(number)}@$OUTGOING_URI_HOST")
+        fun buildOutgoingUri(number: String): Uri = OutgoingCallUri.of(number)
 
         /**
          * Returns true if the device supports the Android Telecom framework.

--- a/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/OutgoingCallUriTest.kt
+++ b/webtrit_callkeep_android/android/src/test/kotlin/com/webtrit/callkeep/common/OutgoingCallUriTest.kt
@@ -1,0 +1,32 @@
+package com.webtrit.callkeep.common
+
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class OutgoingCallUriTest {
+    @Test
+    fun `user part carries no digit for any number`() {
+        for (number in listOf("112", "911", "999", "0", "1234567890")) {
+            val userPart = OutgoingCallUri.of(number).schemeSpecificPart.substringBefore("@")
+            assertTrue("user part <$userPart> must contain no digit", userPart.none { it.isDigit() })
+        }
+    }
+
+    @Test
+    fun `emergency-colliding extension is masked to letters`() {
+        assertEquals("sip:bbc@portadialer.internal", OutgoingCallUri.of("112").toString())
+    }
+
+    @Test
+    fun `non-digit dial characters are preserved`() {
+        val userPart = OutgoingCallUri.of("+380*100#").schemeSpecificPart.substringBefore("@")
+        assertEquals("+dia*baa#", userPart)
+    }
+}

--- a/webtrit_callkeep_android/docs/call-flows.md
+++ b/webtrit_callkeep_android/docs/call-flows.md
@@ -110,6 +110,12 @@ first call is ACTIVE rather than RINGING.
 
 Triggered when the user initiates a call from the app UI.
 
+> The address passed to Telecom (step 3) is a decoy `sip:` Uri built by
+> `OutgoingCallUri` - digits are masked to letters so that OEM Telecom forks which
+> run an emergency-number check on the placeCall Uri find no number to match and do
+> not divert emergency-colliding extensions (e.g. "112") to the system dialer. The
+> real dialled number travels in the call metadata, never in this Uri.
+
 ```text
 1.  Dart calls PHostApi.startCall(callId, meta)
         |


### PR DESCRIPTION
## Overview

Some phone makers customize their call system to treat any number that looks like an emergency number as an emergency call, even when it is a legitimate internal extension (for example an extension "112"). On those devices such calls were silently taken over by the built-in phone app and never connected.

Outgoing calls now carry a masked placeholder as the call address, so that check finds no number to act on. The placeholder is strictly one-way: the real dialled number always travels alongside the call and is never read back from the address. A dedicated component owns the masking so it can never be forgotten in one of the places the address is built.

Verified with unit tests (full native suite green, 231 tests) and on a real affected device: without the change the call was taken over by the built-in phone app, with it the call goes through and rings normally.
