### PR TITLE
feat: keep the iOS system call screen from taking over on simultaneous incoming calls (WT-1678)

### DIFF
--- a/docs/ios-deferred-callkit-registration.md
+++ b/docs/ios-deferred-callkit-registration.md
@@ -1,0 +1,136 @@
+# iOS deferred CallKit registration: design notes
+
+## Purpose
+
+When two incoming calls ring at the same time on iOS and the user answers one of them, the system
+takes over with its full-screen call-waiting prompt ("End & Accept / Decline / Hold & Accept") for
+the other call, and the decision has to be made there instead of in the app. In the worst cases that
+prompt hangs on a dead call, or iOS parks the user on its own in-call screen and the app cannot get
+the foreground back. And when the app is in the background, the system incoming-call UI shows only
+ONE of the two ringing calls - the second is invisible system-wide and its ringtone is suppressed.
+
+The goal of this mechanism is that the app owns the whole multi-call experience: the system UI never
+takes over, and every ringing call is visible and answerable inside the app.
+
+Implementation: entirely native, in `WebtritCallkeepPlugin.m`. No Dart API changes, no app
+involvement - the Flutter side keeps talking to the plugin exactly as before.
+
+## The platform rules this is built on
+
+These are not app bugs; they are CallKit platform behavior, verified on a real device:
+
+1. **A call registered with CallKit belongs to the system.** How it is presented - banner, lock
+   screen, full-screen prompt - is decided by iOS. There is no API to style or suppress it.
+2. **The registry configuration "connected (or held) + ringing" automatically summons the system
+   call-waiting screen.** It is not tied to any event: the prompt appears the instant that
+   combination exists among the app's calls and disappears the instant it stops existing. This is
+   why the bug fires at the moment of ANSWER - answering call B turns the registry into
+   "active + ringing(A)". Two purely ringing calls coexist without conflict.
+3. **Every VoIP push MUST be reported to CallKit** (iOS 13+, otherwise the app is terminated), and
+   the backend sends a push for every incoming call as a fallback against dead sockets. So "just do
+   not register the call" is not an option: the push path has to be handled too.
+
+On top of that, one limitation with no lever at all: the system UI shows only one ringing call.
+The only way to keep the second call visible and audible is to keep it out of the system world
+entirely and present it in the app.
+
+## Registry combination matrix
+
+The system call UI is a pure function of the system-wide call registry (callservicesd): the app
+influences it only by changing what the registry contains. The tables below enumerate the registry
+combinations exercised on a real device (iOS 26). "Own calls" means calls this app reported; the
+registry also holds cellular and other VoIP calls, which are out of scope here.
+
+### Safe combinations (no system takeover)
+
+| # | Registry state (own calls) | System behavior |
+|---|---------------------------|-----------------|
+| S1 | empty -> one incoming reported, app foreground | Compact banner on top; app stays interactive; system ringtone plays |
+| S2 | one incoming ringing, app background / locked | Full-screen incoming UI (expected platform behavior, not a takeover of the app) |
+| S3 | two incoming ringing, app foreground | No takeover: banner(s) only, the app keeps the screen; both calls can sit in the registry for seconds without conflict |
+| S4 | connected + outgoing-dialing (CXStartCallAction) -> connected + connected | No system UI at any point: an outgoing call goes active silently; the user never leaves the app |
+| S5 | connected + connected (two active calls after both answered) | No prompt; the system in-call UI exists but does not cover the app |
+| S6 | ringing -> removed via reportCall(ended, answeredElsewhere) while another call is being answered | The ringing entry silently disappears; no missed-call prompt; the full-screen prompt never forms |
+| S7 | incoming reported + ended immediately (the PushKit-mandated report of a deferred call) | At most a sub-second flash; no lasting UI |
+
+### Problem combinations (system takes over or breaks)
+
+| # | Registry state (own calls) | System behavior |
+|---|---------------------------|-----------------|
+| P1 | connected + ringing (answer one of two ringing calls; the other stays registered) | Full-screen call-waiting prompt covers the app REGARDLESS of foreground state; the app goes paused about half a second after the answer |
+| P2 | connected + new incoming reported (second call arrives during an active conversation) | The same full-screen call-waiting prompt; standard iOS call waiting, but it violates the "app owns the UX" goal |
+| P3 | held + ringing | Same family as P1: held counts as connected for the prompt logic |
+| P4 | two incoming ringing, app background | The full-screen incoming UI shows only ONE call; the second is invisible system-wide and its ringtone is suppressed; no lever exists to show both |
+| P5 | UUID reported ended earlier -> reportNewIncomingCall with the SAME UUID | The report "succeeds" (the UI even renders) but the call object is a zombie: CXAnswerCallAction fails with InvalidAction (code 6) or silently never performs, on roughly half of the attempts; the ringing UI then hangs until the call times out |
+| P6 | connected + fresh-UUID INCOMING re-report (re-attach of a deferred call as incoming) | The call-waiting prompt appears for the re-reported call and, after answering, iOS parks the user on its own in-call screen; the app cannot force itself back to the foreground |
+
+### Rules distilled from the matrix
+
+1. The trigger is never an event - it is a REGISTRY CONFIGURATION (P1/P2/P3 vs S3/S5).
+2. Ringing entries are only dangerous NEXT TO a connected one; any number of pure-ringing entries
+   is safe in the foreground (S3) but under-displayed in the background (P4).
+3. A CallKit UUID is single-use: once reported ended, never report it as incoming again (P5).
+   Use a fresh UUID for any re-entry.
+4. Re-entering the registry as INCOMING always risks the prompt (P6); re-entering as OUTGOING is
+   silent (S4). Outgoing-dialing next to a connected call is the only combination that adds a call
+   to an active conversation without any system UI.
+5. Report-plus-instant-end is tolerated by the system (S7) - this is how the mandated PushKit
+   report of a call the app wants to keep out of the registry is satisfied.
+
+## The mechanism
+
+One sentence: **iOS sees at most ONE call; all the others live only in the app and enter the system
+world at the moment they are answered - silently, as outgoing calls.** (This mirrors the
+telecom-deferred direction on Android, so both platforms converge on the same semantics.)
+
+Four pillars, each mapping onto the matrix:
+
+1. **Defer at answer** (turns an imminent P1/P3 into S6). At the moment of answering, every other
+   ringing own call is removed from CallKit (`reportCall:endedAtDate:` with reason
+   answeredElsewhere) and marked deferred. This fires on both entry points - the in-app answer and
+   the lock-screen answer (`performAnswerCallAction`).
+2. **Defer on arrival** (turns P2 into "registry untouched", and its PushKit branch into S7). A new
+   incoming call while a live call is already in CallKit is not registered at all: the signaling
+   path stays silent; the push path does the mandated report followed by an immediate end. One
+   native choke point instead of guards scattered across the app layers. The "is there a live
+   call" predicate reads the live CXCallObserver list, not accumulated bookkeeping (see pitfall 4).
+3. **Fresh UUID + alias translation** (avoids P5 entirely). A deferred call re-enters CallKit under
+   a new NSUUID. Original-to-current maps at the plugin boundary translate every action coming from
+   Dart and every perform callback going back, so the Dart side keeps living in its stable
+   deterministic-UUID world and knows nothing about the aliasing.
+4. **Re-attach as outgoing** (turns P6 into S4). The re-attach is done via CXStartCallAction: the
+   call becomes active silently, with no system screen. The start action is fulfilled natively and
+   reaches Flutter as a regular answer of the original call.
+
+## Platform pitfalls encoded in the implementation
+
+Hard-won behaviors that are not in Apple's documentation:
+
+1. **Zombie UUID.** A call removed from CallKit and then re-reported as incoming with the same UUID
+   is accepted (the UI even renders), but the call object is dead inside: answering fails with
+   InvalidAction or silently never performs, non-deterministically. The plugin's deterministic
+   UUIDs made every naive re-attach hit a burned UUID. Hence pillar 3.
+2. **Incoming re-report summons the system.** Even with a fresh UUID, re-reporting as incoming
+   during an active conversation draws the call-waiting prompt, and after answering iOS keeps the
+   user on its own in-call screen. Hence pillar 4.
+3. **Threading.** The completion of `reportNewIncomingCall` can arrive off the main thread;
+   mutating the plugin's non-thread-safe state from there is a segfault. Everything touching
+   plugin state is confined to the main thread.
+4. **The observer forgets the past.** CXCallObserver can drop an ended call from its list before
+   the app's cleanup sees it, so bookkeeping accumulated from its callbacks goes stale. Decisions
+   that depend on "are there live calls right now" must read the observer's live `calls` list.
+
+## Accepted trade-offs
+
+- A deferred call is invisible and silent outside the app: not in CallKit means no lock-screen
+  presence and no system ringtone (the mirror of the Android trade-off).
+- A re-attached call appears in the system call log as outgoing.
+- A call removed from CallKit at answer time is logged as "answered elsewhere" rather than
+  "missed", even if nobody answers it afterwards.
+
+## What this mechanism does not solve
+
+- Visibility of the second call while the app is backgrounded (P4 in its pure form) is consciously
+  traded away by the at-most-one-call policy. If the product ever wants a mitigation, that is a
+  separate work item (a local notification or an audible cue, in the spirit of
+  `ios-call-waiting-tone.md`).

--- a/docs/ios-deferred-callkit-registration.md
+++ b/docs/ios-deferred-callkit-registration.md
@@ -119,6 +119,15 @@ Hard-won behaviors that are not in Apple's documentation:
 4. **The observer forgets the past.** CXCallObserver can drop an ended call from its list before
    the app's cleanup sees it, so bookkeeping accumulated from its callbacks goes stale. Decisions
    that depend on "are there live calls right now" must read the observer's live `calls` list.
+5. **A call can race itself.** The signaling and push paths both report the same call (the push is
+   the fallback for a dead socket; the deterministic UUID dedups them). Whichever path arrives
+   second sees "an own call already lives in CallKit" - but that live call is this very call. A
+   deferral check that does not exclude the call's own registry entry marks a really-registered
+   call deferred, and both exits then break: decline takes the no-CallKit shortcut and leaves the
+   entry ringing as a ghost, and answer re-attaches a second entry next to the still-ringing
+   original, which summons the call-waiting prompt. Every deferral decision must first ask "is
+   this UUID itself already live in CallKit?", and the action paths (answer, end, report-end)
+   heal a stale deferred mark the same way before trusting it.
 
 ## Accepted trade-offs
 

--- a/docs/ios-deferred-callkit-registration.md
+++ b/docs/ios-deferred-callkit-registration.md
@@ -83,6 +83,10 @@ One sentence: **iOS sees at most ONE call; all the others live only in the app a
 world at the moment they are answered - silently, as outgoing calls.** (This mirrors the
 telecom-deferred direction on Android, so both platforms converge on the same semantics.)
 
+The mechanism is opt-in: an app enables it via `deferredCallKitRegistration` in
+`CallkeepIOSOptions`. With the flag off (the default) every incoming call registers with CallKit
+as before and the standard iOS call-waiting behavior applies.
+
 Four pillars, each mapping onto the matrix:
 
 1. **Defer at answer** (turns an imminent P1/P3 into S6). At the moment of answering, every other
@@ -101,6 +105,20 @@ Four pillars, each mapping onto the matrix:
 4. **Re-attach as outgoing** (turns P6 into S4). The re-attach is done via CXStartCallAction: the
    call becomes active silently, with no system screen. The start action is fulfilled natively and
    reaches Flutter as a regular answer of the original call.
+
+Three companion behaviors keep the deferred call a first-class citizen:
+
+- **Audible cue.** A deferred call has no CallKit entry, so during a conversation neither the
+  system nor the registry-driven call-waiting tone would announce it. The tone player counts
+  deferred calls as ringing, so the in-call call-waiting tone (see `ios-call-waiting-tone.md`)
+  still plays.
+- **Missed-call trace.** A deferred call that ends unanswered (timeout or the caller giving up)
+  is flash-reported under a throwaway UUID and ended immediately - the S7 pattern - so the system
+  journal records the missed call; the local missed-call notification fires as usual.
+- **Promotion on vacancy.** When the registry loses its last own live call while a deferred call
+  still rings (e.g. the visible call was declined), the deferred call is re-reported as incoming
+  under a fresh alias. The registry is empty at that point, so this is the safe S1/S2 shape - the
+  remaining call regains its ringtone and lock-screen presence.
 
 ## Platform pitfalls encoded in the implementation
 
@@ -143,7 +161,7 @@ Hard-won behaviors that are not in Apple's documentation:
 
 ## What this mechanism does not solve
 
-- Visibility of the second call while the app is backgrounded (P4 in its pure form) is consciously
-  traded away by the at-most-one-call policy. If the product ever wants a mitigation, that is a
-  separate work item (a local notification or an audible cue, in the spirit of
-  `ios-call-waiting-tone.md`).
+- Visibility of the second call while the app is backgrounded and the first is still ringing (P4
+  in its pure form) is consciously traded away by the at-most-one-call policy. Promotion on
+  vacancy softens it - the moment the first call ends or is declined the second one surfaces -
+  but while both ring only one is visible outside the app.

--- a/docs/ios-deferred-callkit-registration.md
+++ b/docs/ios-deferred-callkit-registration.md
@@ -116,9 +116,13 @@ Hard-won behaviors that are not in Apple's documentation:
 3. **Threading.** The completion of `reportNewIncomingCall` can arrive off the main thread;
    mutating the plugin's non-thread-safe state from there is a segfault. Everything touching
    plugin state is confined to the main thread.
-4. **The observer forgets the past.** CXCallObserver can drop an ended call from its list before
-   the app's cleanup sees it, so bookkeeping accumulated from its callbacks goes stale. Decisions
-   that depend on "are there live calls right now" must read the observer's live `calls` list.
+4. **The observer forgets the past - and lags the present.** CXCallObserver can drop an ended call
+   from its list before the app's cleanup sees it, so bookkeeping accumulated from its callbacks
+   goes stale - decisions that depend on "are there live calls right now" must read the observer's
+   live `calls` list. The inverse is also true: for a beat after the plugin reports a call ended,
+   the observer still lists it as live. A liveness check that trusts the raw list in that window
+   mistakes the fading entry for a real registration. The plugin therefore remembers every UUID it
+   has reported ended until the observer confirms the end, and all liveness decisions skip them.
 5. **A call can race itself.** The signaling and push paths both report the same call (the push is
    the fallback for a dead socket; the deterministic UUID dedups them). Whichever path arrives
    second sees "an own call already lives in CallKit" - but that live call is this very call. A

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Converters.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Converters.m
@@ -163,6 +163,7 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
   id includesCallsInRecents = dict[@"includesCallsInRecents"];
   id driveIdleTimerDisabled = dict[@"driveIdleTimerDisabled"];
   id callWaitingToneOwnCallsOnly = dict[@"callWaitingToneOwnCallsOnly"];
+  id deferredCallKitRegistration = dict[@"deferredCallKitRegistration"];
 
   return [WTPIOSOptions makeWithLocalizedName:localizedName
                                 ringtoneSound:(ringtoneSound == [NSNull null]) ? nil : ringtoneSound
@@ -176,7 +177,8 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
                                 supportsVideo:[supportsVideo boolValue]
                        includesCallsInRecents:[includesCallsInRecents boolValue]
                        driveIdleTimerDisabled:[driveIdleTimerDisabled boolValue]
-                  callWaitingToneOwnCallsOnly:(callWaitingToneOwnCallsOnly == [NSNull null]) ? nil : callWaitingToneOwnCallsOnly];
+                  callWaitingToneOwnCallsOnly:(callWaitingToneOwnCallsOnly == [NSNull null]) ? nil : callWaitingToneOwnCallsOnly
+                  deferredCallKitRegistration:(deferredCallKitRegistration == [NSNull null]) ? nil : deferredCallKitRegistration];
 }
 - (NSDictionary *)toMap {
   return @{
@@ -193,6 +195,7 @@ extern CXHandleType WTPHandleTypeEnumToCallKit(WTPHandleTypeEnum value) {
     @"includesCallsInRecents": @(self.includesCallsInRecents),
     @"driveIdleTimerDisabled": @(self.driveIdleTimerDisabled),
     @"callWaitingToneOwnCallsOnly": (self.callWaitingToneOwnCallsOnly ?: [NSNull null]),
+    @"deferredCallKitRegistration": (self.deferredCallKitRegistration ?: [NSNull null]),
   };
 }
 - (CXProviderConfiguration *)toCallKitWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/Generated.m
@@ -222,7 +222,8 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     supportsVideo:(BOOL )supportsVideo
     includesCallsInRecents:(BOOL )includesCallsInRecents
     driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled
-    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly {
+    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly
+    deferredCallKitRegistration:(nullable NSNumber *)deferredCallKitRegistration {
   WTPIOSOptions* pigeonResult = [[WTPIOSOptions alloc] init];
   pigeonResult.localizedName = localizedName;
   pigeonResult.ringtoneSound = ringtoneSound;
@@ -237,6 +238,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.includesCallsInRecents = includesCallsInRecents;
   pigeonResult.driveIdleTimerDisabled = driveIdleTimerDisabled;
   pigeonResult.callWaitingToneOwnCallsOnly = callWaitingToneOwnCallsOnly;
+  pigeonResult.deferredCallKitRegistration = deferredCallKitRegistration;
   return pigeonResult;
 }
 + (WTPIOSOptions *)fromList:(NSArray<id> *)list {
@@ -254,6 +256,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   pigeonResult.includesCallsInRecents = [GetNullableObjectAtIndex(list, 10) boolValue];
   pigeonResult.driveIdleTimerDisabled = [GetNullableObjectAtIndex(list, 11) boolValue];
   pigeonResult.callWaitingToneOwnCallsOnly = list.count > 12 ? GetNullableObjectAtIndex(list, 12) : nil;
+  pigeonResult.deferredCallKitRegistration = list.count > 13 ? GetNullableObjectAtIndex(list, 13) : nil;
   return pigeonResult;
 }
 + (nullable WTPIOSOptions *)nullableFromList:(NSArray<id> *)list {
@@ -274,6 +277,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     @(self.includesCallsInRecents),
     @(self.driveIdleTimerDisabled),
     self.callWaitingToneOwnCallsOnly ?: [NSNull null],
+    self.deferredCallKitRegistration ?: [NSNull null],
   ];
 }
 - (BOOL)isEqual:(id)object {
@@ -284,7 +288,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
     return NO;
   }
   WTPIOSOptions *other = (WTPIOSOptions *)object;
-  return FLTPigeonDeepEquals(self.localizedName, other.localizedName) && FLTPigeonDeepEquals(self.ringtoneSound, other.ringtoneSound) && FLTPigeonDeepEquals(self.ringbackSound, other.ringbackSound) && FLTPigeonDeepEquals(self.iconTemplateImageAssetName, other.iconTemplateImageAssetName) && self.maximumCallGroups == other.maximumCallGroups && self.maximumCallsPerCallGroup == other.maximumCallsPerCallGroup && FLTPigeonDeepEquals(self.supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && FLTPigeonDeepEquals(self.supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && FLTPigeonDeepEquals(self.supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && self.supportsVideo == other.supportsVideo && self.includesCallsInRecents == other.includesCallsInRecents && self.driveIdleTimerDisabled == other.driveIdleTimerDisabled && FLTPigeonDeepEquals(self.callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly);
+  return FLTPigeonDeepEquals(self.localizedName, other.localizedName) && FLTPigeonDeepEquals(self.ringtoneSound, other.ringtoneSound) && FLTPigeonDeepEquals(self.ringbackSound, other.ringbackSound) && FLTPigeonDeepEquals(self.iconTemplateImageAssetName, other.iconTemplateImageAssetName) && self.maximumCallGroups == other.maximumCallGroups && self.maximumCallsPerCallGroup == other.maximumCallsPerCallGroup && FLTPigeonDeepEquals(self.supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && FLTPigeonDeepEquals(self.supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && FLTPigeonDeepEquals(self.supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && self.supportsVideo == other.supportsVideo && self.includesCallsInRecents == other.includesCallsInRecents && self.driveIdleTimerDisabled == other.driveIdleTimerDisabled && FLTPigeonDeepEquals(self.callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly) && FLTPigeonDeepEquals(self.deferredCallKitRegistration, other.deferredCallKitRegistration);
 }
 
 - (NSUInteger)hash {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -449,19 +449,24 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     [_provider reportNewIncomingCallWithUUID:uuid
                                       update:callUpdate
                                   completion:^(NSError *error) {
-                                    if (error != nil && !([error.domain isEqualToString:CXErrorDomainIncomingCall] &&
-                                                          error.code == CXErrorCodeIncomingCallErrorCallUUIDAlreadyExists)) {
-                                      NSLog(@"[Callkeep][answerCall] deferred re-report failed: domain=%@ code=%ld (%@)",
-                                            error.domain, (long)error.code, error.localizedDescription);
-                                      completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
-                                      return;
-                                    }
-                                    NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@), requesting answer", uuid.UUIDString);
-                                    [self->_deferredCallUuids removeObject:uuid];
-                                    [self->_ownCallUuids addObject:uuid];
-                                    CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
-                                    CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
-                                    [self requestTransaction:transaction completion:completion];
+                                    // The report completion arrives on the provider's private queue;
+                                    // all plugin state is main-thread-confined (delegate and observer
+                                    // callbacks run on main), so hop before touching it.
+                                    dispatch_async(dispatch_get_main_queue(), ^{
+                                      if (error != nil && !([error.domain isEqualToString:CXErrorDomainIncomingCall] &&
+                                                            error.code == CXErrorCodeIncomingCallErrorCallUUIDAlreadyExists)) {
+                                        NSLog(@"[Callkeep][answerCall] deferred re-report failed: domain=%@ code=%ld (%@)",
+                                              error.domain, (long)error.code, error.localizedDescription);
+                                        completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
+                                        return;
+                                      }
+                                      NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@), requesting answer", uuid.UUIDString);
+                                      [self->_deferredCallUuids removeObject:uuid];
+                                      [self->_ownCallUuids addObject:uuid];
+                                      CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
+                                      CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
+                                      [self requestTransaction:transaction completion:completion];
+                                    });
                                   }];
     return;
   }

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -58,6 +58,18 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // must treat these as gone, or they mistake a just-ended flash for a real
   // registration and un-defer a legitimately deferred call.
   NSMutableSet<NSUUID *> *_pendingCallKitEndUuids;
+  // Originals deferred AT ANSWER TIME: unlike arrival-deferred calls they
+  // already had a CallKit life and were journaled (answeredElsewhere) when
+  // taken out, so a later missed-call journal entry would duplicate them.
+  NSMutableSet<NSUUID *> *_answerDeferredUuids;
+  // Missed deferred calls waiting for their journal entry. The entry is a
+  // report+instant-end flash, which must not run next to a live call (the
+  // ringing flash would summon the call-waiting prompt) - so it queues here
+  // and flushes when the registry is empty.
+  NSMutableArray<CXCallUpdate *> *_pendingMissedJournalUpdates;
+  // Throwaway UUIDs of in-flight journal flashes: never answerable, and their
+  // CX actions must not reach the Flutter side.
+  NSMutableSet<NSUUID *> *_journalFlashUuids;
   // Master switch of the deferred-registration mechanism (an app opts in via
   // CallkeepIOSOptions). Off by default: every incoming call is registered
   // with CallKit as before and the system call-waiting behavior applies.
@@ -95,6 +107,9 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _originalUuidByCurrent = [NSMutableDictionary dictionary];
     _outgoingReattachUuids = [NSMutableSet set];
     _pendingCallKitEndUuids = [NSMutableSet set];
+    _answerDeferredUuids = [NSMutableSet set];
+    _pendingMissedJournalUpdates = [NSMutableArray array];
+    _journalFlashUuids = [NSMutableSet set];
     _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
@@ -234,6 +249,14 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   [_ownCallUuids removeAllObjects];
   [_answeringCallUuids removeAllObjects];
   [_pendingCallKitEndUuids removeAllObjects];
+  [_deferredCallUuids removeAllObjects];
+  [_incomingCallUpdates removeAllObjects];
+  [_currentUuidByOriginal removeAllObjects];
+  [_originalUuidByCurrent removeAllObjects];
+  [_outgoingReattachUuids removeAllObjects];
+  [_answerDeferredUuids removeAllObjects];
+  [_pendingMissedJournalUpdates removeAllObjects];
+  [_journalFlashUuids removeAllObjects];
   if (_provider != nil) {
     [_provider invalidate];
     _provider = nil;
@@ -294,14 +317,23 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     completion(nil, nil);
     return;
   }
+  // When the call already lives in CallKit its registry entry may be a
+  // promoted ALIAS: the dedup report must target that alias, or CallKit sees
+  // a brand-new UUID and registers a duplicate ringing entry.
+  NSUUID *reportUuid = alreadyLive ? [self currentUuidFor:callUuid] : callUuid;
   if (callUuid != nil) {
-    [_ownCallUuids addObject:callUuid];
+    [_ownCallUuids addObject:reportUuid];
     _incomingCallUpdates[callUuid] = callUpdate;
   }
-  [_provider reportNewIncomingCallWithUUID:callUuid
+  [_provider reportNewIncomingCallWithUUID:reportUuid
                                     update:callUpdate
                                 completion:^(NSError *error) {
                                   if (error == nil) {
+                                    dispatch_async(dispatch_get_main_queue(), ^{
+                                      // A fresh registration supersedes any unconfirmed end of
+                                      // this UUID from an earlier call with the same callId.
+                                      [self->_pendingCallKitEndUuids removeObject:reportUuid];
+                                    });
                                     [self assignIdleTimerDisabled:callUpdate.hasVideo];
                                     completion(nil, nil);
                                   } else if ([error.domain isEqualToString:CXErrorDomainIncomingCall]) {
@@ -363,7 +395,18 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
      }
   }
     
-  [_provider reportCallWithUUID:[self currentUuidFor:[[NSUUID alloc] initWithUUIDString:uuidString]]
+  NSUUID *updateUuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  // Keep the cached registration metadata in sync: deferred-call re-entry
+  // (answer re-attach, promotion, missed-call journaling) re-reports from the
+  // cache, and without the merge it would show arrival-time data (e.g. a bare
+  // number instead of the later-resolved contact name).
+  CXCallUpdate *cached = updateUuid != nil ? _incomingCallUpdates[updateUuid] : nil;
+  if (cached != nil) {
+    if (handle != nil) cached.remoteHandle = callUpdate.remoteHandle;
+    if (displayName != nil) cached.localizedCallerName = displayName;
+    if (hasVideo != nil) cached.hasVideo = callUpdate.hasVideo;
+  }
+  [_provider reportCallWithUUID:[self currentUuidFor:updateUuid]
                         updated:callUpdate];
   [self assignIdleTimerDisabled:callUpdate.hasVideo];
   completion(nil);
@@ -384,29 +427,25 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
     // The deferred call is not in CallKit, so there is no entry to end. A call
     // the user never got to answer must still leave a missed-call trace in the
-    // system journal: flash-report it under a throwaway UUID and end it right
-    // away (the same report+instant-end the push path uses); the sub-second
-    // banner is the price of the journal record. Other reasons just forget
-    // the call. Execution falls through to the shared missed-call
-    // notification below either way.
+    // system journal - but only an ARRIVAL-deferred one: a call deferred at
+    // answer time was already journaled (answeredElsewhere) when its CallKit
+    // entry was ended, and a second entry would contradict it. The journal
+    // flash itself is queued and runs only once the registry is empty (see
+    // flushPendingMissedJournalIfIdle) - flashing a ringing entry next to a
+    // live call would summon the very call-waiting prompt this mechanism
+    // exists to prevent. The shared missed-call notification below fires
+    // either way.
     NSLog(@"[Callkeep][reportEndCall] clearing deferred call %@", uuidString);
     [_deferredCallUuids removeObject:uuid];
+    BOOL journaledAlready = [_answerDeferredUuids containsObject:uuid];
+    [_answerDeferredUuids removeObject:uuid];
     CXCallUpdate *lastUpdate = _incomingCallUpdates[uuid];
     [_incomingCallUpdates removeObjectForKey:uuid];
     CXCallEndedReason endReason = [reason toCallKit];
     BOOL missed = endReason == CXCallEndedReasonUnanswered || endReason == CXCallEndedReasonRemoteEnded;
-    if (missed && lastUpdate != nil) {
-      NSUUID *flashUuid = [NSUUID UUID];
-      NSLog(@"[Callkeep][reportEndCall] journaling missed deferred call %@ as %@", uuidString, flashUuid.UUIDString);
-      [_provider reportNewIncomingCallWithUUID:flashUuid
-                                        update:lastUpdate
-                                    completion:^(NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-          if (error == nil) {
-            [self reportCallKitEndOf:flashUuid reason:endReason];
-          }
-        });
-      }];
+    if (missed && !journaledAlready && lastUpdate != nil) {
+      [_pendingMissedJournalUpdates addObject:lastUpdate];
+      [self flushPendingMissedJournalIfIdle];
     }
   } else {
     if (uuid != nil) {
@@ -561,6 +600,9 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   if (!_deferredCallKitRegistration) return;
   for (CXCall *call in _callController.callObserver.calls) {
     if (call.hasEnded || call.hasConnected || call.outgoing) continue;
+    // Already reported ended by us; the observer just has not confirmed yet.
+    // Deferring the fading entry would strand a dead call in the deferred set.
+    if ([_pendingCallKitEndUuids containsObject:call.UUID]) continue;
     if ([call.UUID isEqual:answeredUuid]) continue;
     if (![_ownCallUuids containsObject:call.UUID]) continue;
     if ([_answeringCallUuids containsObject:call.UUID]) continue;
@@ -570,6 +612,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     NSUUID *original = [self originalUuidFor:call.UUID];
     if (![_deferredCallUuids containsObject:original]) {
       [_deferredCallUuids addObject:original];
+      [_answerDeferredUuids addObject:original];
       NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", original.UUIDString);
       [self reportCallKitEndOf:call.UUID reason:CXCallEndedReasonAnsweredElsewhere];
     }
@@ -604,6 +647,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     CXHandle *handle = callUpdate.remoteHandle
         ?: [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
     [_deferredCallUuids removeObject:uuid];
+    [_answerDeferredUuids removeObject:uuid];
     _currentUuidByOriginal[uuid] = freshUuid;
     _originalUuidByCurrent[freshUuid] = uuid;
     [_outgoingReattachUuids addObject:freshUuid];
@@ -611,14 +655,42 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     CXStartCallAction *startAction = [[CXStartCallAction alloc] initWithCallUUID:freshUuid handle:handle];
     startAction.contactIdentifier = callUpdate.localizedCallerName;
     CXTransaction *startTransaction = [[CXTransaction alloc] initWithAction:startAction];
-    [self requestTransaction:startTransaction completion:completion];
+    // The alias state was committed above so the perform callback can already
+    // translate; if CallKit refuses the transaction that state must be undone,
+    // or the call becomes unanswerable (retries would target an alias CallKit
+    // never created) and the in-flight re-attach mark blocks promotion for
+    // the rest of the session.
+    [self requestTransaction:startTransaction completion:^(WTPCallRequestError *err, FlutterError *ferr) {
+      if (err != nil || ferr != nil) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          NSLog(@"[Callkeep][answerCall] re-attach start failed - rolling back to deferred %@", uuidString);
+          [self->_outgoingReattachUuids removeObject:freshUuid];
+          [self->_ownCallUuids removeObject:freshUuid];
+          if ([self->_currentUuidByOriginal[uuid] isEqual:freshUuid]) {
+            [self->_currentUuidByOriginal removeObjectForKey:uuid];
+          }
+          [self->_originalUuidByCurrent removeObjectForKey:freshUuid];
+          [self->_deferredCallUuids addObject:uuid];
+        });
+      }
+      completion(err, ferr);
+    }];
     return;
   }
 
   CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:[self currentUuidFor:uuid]];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
-  [self requestTransaction:transaction completion:completion];
+  // If the answer transaction is refused, the calls deferred for it were
+  // pulled out of the system UI for nothing - bring them back.
+  [self requestTransaction:transaction completion:^(WTPCallRequestError *err, FlutterError *ferr) {
+    if (err != nil || ferr != nil) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self restoreAnswerDeferredCallsAfterFailedAnswer];
+      });
+    }
+    completion(err, ferr);
+  }];
 }
 
 - (void)setSpeaker:(NSString *)uuidString
@@ -646,6 +718,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     // the Flutter side terminates the call exactly as usual.
     NSLog(@"[Callkeep][endCall] ending deferred call %@ locally", uuidString);
     [_deferredCallUuids removeObject:uuid];
+    [_answerDeferredUuids removeObject:uuid];
     [_incomingCallUpdates removeObjectForKey:uuid];
     [_delegateFlutterApi performEndCall:uuidString
                              completion:^(NSNumber *fulfill, FlutterError *error) {}];
@@ -919,23 +992,34 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   // under a fresh UUID when answered.
   BOOL isDeferred = _deferredCallKitRegistration && !alreadyLive &&
       ([_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall]);
+  // When the call already lives in CallKit its registry entry may be a
+  // promoted ALIAS: the dedup report must target that alias, or CallKit sees
+  // a brand-new UUID and registers a duplicate ringing entry.
+  NSUUID *reportUuid = alreadyLive ? [self currentUuidFor:uuid] : uuid;
   if (isDeferred) {
     [_deferredCallUuids addObject:uuid];
     _incomingCallUpdates[uuid] = callUpdate;
   } else {
-    [_ownCallUuids addObject:uuid];
+    [_ownCallUuids addObject:reportUuid];
     _incomingCallUpdates[uuid] = callUpdate;
   }
-  [_provider reportNewIncomingCallWithUUID:uuid
+  [_provider reportNewIncomingCallWithUUID:reportUuid
                                     update:callUpdate
                                 completion:^(NSError *error) {
-                                  if (isDeferred && error == nil) {
-                                    // PushKit obliges reporting every VoIP push, but this call is
-                                    // deferred (rings app-side only) - take it right back out so
-                                    // the system UI does not resurrect it.
-                                    NSLog(@"[Callkeep][didReceiveIncomingPushWithPayloadForPushTypeVoIP] re-ending deferred call %@", uuid.UUIDString);
-                                    [self reportCallKitEndOf:uuid reason:CXCallEndedReasonAnsweredElsewhere];
-                                  }
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                    if (error == nil) {
+                                      // A fresh registration supersedes any unconfirmed end of
+                                      // this UUID from an earlier call with the same callId.
+                                      [self->_pendingCallKitEndUuids removeObject:reportUuid];
+                                    }
+                                    if (isDeferred && error == nil) {
+                                      // PushKit obliges reporting every VoIP push, but this call is
+                                      // deferred (rings app-side only) - take it right back out so
+                                      // the system UI does not resurrect it.
+                                      NSLog(@"[Callkeep][didReceiveIncomingPushWithPayloadForPushTypeVoIP] re-ending deferred call %@", reportUuid.UUIDString);
+                                      [self reportCallKitEndOf:reportUuid reason:CXCallEndedReasonAnsweredElsewhere];
+                                    }
+                                  });
                                   WTPIncomingCallError *incomingCallError = nil;
                                   if (error != nil) {
                                     if ([error.domain isEqualToString:CXErrorDomainIncomingCall]) {
@@ -994,6 +1078,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 - (void)callObserver:(CXCallObserver *)callObserver callChanged:(CXCall *)call {
   [self syncCallWaitingTone:callObserver];
   [self promoteDeferredCallIfRegistryVacant];
+  [self flushPendingMissedJournalIfIdle];
 }
 
 /// Re-enters a still-ringing deferred call into CallKit when the registry has
@@ -1008,13 +1093,25 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   if (_deferredCallUuids.count == 0) return;
   if (_outgoingReattachUuids.count > 0 || _answeringCallUuids.count > 0) return;
   if ([self hasOwnLiveCallKitCall]) return;
-  NSUUID *original = [_deferredCallUuids anyObject];
+  // Only an entry with cached metadata can be re-reported meaningfully; a
+  // metadata-less one must not block eligible entries behind it.
+  NSUUID *original = nil;
+  for (NSUUID *candidate in _deferredCallUuids) {
+    if (_incomingCallUpdates[candidate] != nil) { original = candidate; break; }
+  }
+  if (original == nil) return;
+  NSLog(@"[Callkeep][promoteDeferredCall] registry vacant - promoting %@", original.UUIDString);
+  [self reenterDeferredCallIntoCallKit:original];
+}
+
+/// Re-reports the deferred [original] as an incoming call under a fresh alias
+/// and rolls the alias state back if CallKit refuses the report.
+- (void)reenterDeferredCallIntoCallKit:(NSUUID *)original {
   CXCallUpdate *lastUpdate = _incomingCallUpdates[original];
   if (lastUpdate == nil) return;
   NSUUID *freshUuid = [NSUUID UUID];
-  NSLog(@"[Callkeep][promoteDeferredCall] registry vacant - promoting %@ as %@",
-        original.UUIDString, freshUuid.UUIDString);
   [_deferredCallUuids removeObject:original];
+  [_answerDeferredUuids removeObject:original];
   _currentUuidByOriginal[original] = freshUuid;
   _originalUuidByCurrent[freshUuid] = original;
   [_ownCallUuids addObject:freshUuid];
@@ -1023,7 +1120,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                 completion:^(NSError *error) {
     dispatch_async(dispatch_get_main_queue(), ^{
       if (error != nil) {
-        NSLog(@"[Callkeep][promoteDeferredCall] promotion failed (%@) - back to deferred", error);
+        NSLog(@"[Callkeep][reenterDeferredCall] re-entry failed (%@) - back to deferred", error);
         [self->_ownCallUuids removeObject:freshUuid];
         if ([self->_currentUuidByOriginal[original] isEqual:freshUuid]) {
           [self->_currentUuidByOriginal removeObjectForKey:original];
@@ -1035,6 +1132,56 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   }];
 }
 
+/// After a failed answer the calls deferred for it were pulled out of the
+/// system UI for nothing - re-enter them so they ring visibly again. Skipped
+/// while an own call is connected: an incoming re-report next to a connected
+/// call summons the system prompt, and the in-call tone still announces them.
+- (void)restoreAnswerDeferredCallsAfterFailedAnswer {
+  if (_answerDeferredUuids.count == 0) return;
+  for (CXCall *call in _callController.callObserver.calls) {
+    if (!call.hasEnded && call.hasConnected && [_ownCallUuids containsObject:call.UUID]) return;
+  }
+  for (NSUUID *original in [_answerDeferredUuids allObjects]) {
+    if (![_deferredCallUuids containsObject:original]) {
+      [_answerDeferredUuids removeObject:original];
+      continue;
+    }
+    NSLog(@"[Callkeep][restoreAnswerDeferred] answer failed - restoring %@", original.UUIDString);
+    [self reenterDeferredCallIntoCallKit:original];
+  }
+}
+
+/// Writes the queued missed-call journal entries (report + instant end under
+/// a throwaway UUID) once no call - own or foreign - is live: flashing a
+/// ringing entry next to a live call would summon the system call-waiting
+/// prompt. Flash UUIDs are guarded in the perform callbacks so a tap on the
+/// sub-second banner never reaches the Flutter side.
+- (void)flushPendingMissedJournalIfIdle {
+  if (_pendingMissedJournalUpdates.count == 0) return;
+  if (_outgoingReattachUuids.count > 0 || _answeringCallUuids.count > 0) return;
+  for (CXCall *call in _callController.callObserver.calls) {
+    if (!call.hasEnded) return;
+  }
+  NSArray<CXCallUpdate *> *entries = [_pendingMissedJournalUpdates copy];
+  [_pendingMissedJournalUpdates removeAllObjects];
+  for (CXCallUpdate *entry in entries) {
+    NSUUID *flashUuid = [NSUUID UUID];
+    [_journalFlashUuids addObject:flashUuid];
+    NSLog(@"[Callkeep][missedJournal] flash-reporting missed deferred call as %@", flashUuid.UUIDString);
+    [_provider reportNewIncomingCallWithUUID:flashUuid
+                                      update:entry
+                                  completion:^(NSError *error) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (error == nil) {
+          [self reportCallKitEndOf:flashUuid reason:CXCallEndedReasonUnanswered];
+        } else {
+          [self->_journalFlashUuids removeObject:flashUuid];
+        }
+      });
+    }];
+  }
+}
+
 /// Mirrors the Android connection-service behavior: a soft call-waiting beep plays
 /// while one call is connected (or held) and another incoming call is ringing, and
 /// stops as soon as that state ends (answered, declined, hung up on either side).
@@ -1044,6 +1191,17 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 /// hasConnected == NO, so a second incoming call during it produces no tone (same as
 /// the Android connection-service logic, which plays the full ringtone there).
 - (void)syncCallWaitingTone:(CXCallObserver *)callObserver {
+  // An end we reported for a UUID that is not (or no longer) in the registry
+  // never gets an observer confirmation - prune pending-end entries whose
+  // UUID has left the observer's list entirely, or they accumulate and shadow
+  // later genuine registrations of the same deterministic UUID.
+  if (_pendingCallKitEndUuids.count > 0) {
+    NSMutableSet<NSUUID *> *listedUuids = [NSMutableSet set];
+    for (CXCall *call in callObserver.calls) {
+      [listedUuids addObject:call.UUID];
+    }
+    [_pendingCallKitEndUuids intersectSet:listedUuids];
+  }
   BOOL hasConnected = NO;
   BOOL hasRingingIncoming = NO;
   for (CXCall *call in callObserver.calls) {
@@ -1052,6 +1210,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     }
     if (call.hasEnded) {
       [_pendingCallKitEndUuids removeObject:call.UUID];
+      [_journalFlashUuids removeObject:call.UUID];
       [_ownCallUuids removeObject:call.UUID];
       // Keep the update of a deferred call - it is needed for the re-report at
       // answer time; any other ended call's metadata is no longer useful.
@@ -1112,6 +1271,9 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   [_originalUuidByCurrent removeAllObjects];
   [_outgoingReattachUuids removeAllObjects];
   [_pendingCallKitEndUuids removeAllObjects];
+  [_answerDeferredUuids removeAllObjects];
+  [_pendingMissedJournalUpdates removeAllObjects];
+  [_journalFlashUuids removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -1160,6 +1322,12 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performAnswerCallAction:]");
 #endif
+  // A journal-only flash entry (a missed-call record being written) is dead
+  // app-side and must never be answerable.
+  if ([_journalFlashUuids containsObject:action.callUUID]) {
+    [action fail];
+    return;
+  }
   // Covers answers coming through CallKit's own UI (lock screen, banner) as
   // well - by this point no Dart code has run yet, so the deferral must happen
   // here to keep the remaining ringing call from raising the system prompt.
@@ -1172,6 +1340,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                 if (error != nil || [fulfill boolValue] != YES) {
                                   [self->_answeringCallUuids removeObject:action.callUUID];
                                   [action fail];
+                                  [self restoreAnswerDeferredCallsAfterFailedAnswer];
                                 } else {
                                   [action fulfill];
                                 }
@@ -1182,6 +1351,12 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performEndCallAction:]");
 #endif
+  // A journal-only flash entry ends by itself; the Flutter side knows nothing
+  // about its throwaway UUID.
+  if ([_journalFlashUuids containsObject:action.callUUID]) {
+    [action fulfill];
+    return;
+  }
   [_delegateFlutterApi performEndCall:[self originalUuidFor:action.callUUID].UUIDString
                            completion:^(NSNumber *fulfill, FlutterError *error) {
                              if (error != nil || [fulfill boolValue] != YES) {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -51,6 +51,13 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // action is fulfilled natively and surfaces to Flutter as a plain
   // performAnswerCall; this set marks the in-flight ones.
   NSMutableSet<NSUUID *> *_outgoingReattachUuids;
+  // UUIDs this plugin has reported ended but whose end CXCallObserver has not
+  // confirmed yet. The observer's list lags a reportCall:ended by a beat, so
+  // right after a defer (or the report+instant-end a push mandates for a
+  // deferred call) the ended entry still reads as "live". Liveness predicates
+  // must treat these as gone, or they mistake a just-ended flash for a real
+  // registration and un-defer a legitimately deferred call.
+  NSMutableSet<NSUUID *> *_pendingCallKitEndUuids;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -83,6 +90,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _currentUuidByOriginal = [NSMutableDictionary dictionary];
     _originalUuidByCurrent = [NSMutableDictionary dictionary];
     _outgoingReattachUuids = [NSMutableSet set];
+    _pendingCallKitEndUuids = [NSMutableSet set];
     _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
@@ -217,6 +225,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   [_callWaitingTone stop];
   [_ownCallUuids removeAllObjects];
   [_answeringCallUuids removeAllObjects];
+  [_pendingCallKitEndUuids removeAllObjects];
   if (_provider != nil) {
     [_provider invalidate];
     _provider = nil;
@@ -377,9 +386,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     [_incomingCallUpdates removeObjectForKey:uuid];
   }
 
-  [_provider reportCallWithUUID:[self currentUuidFor:uuid]
-                    endedAtDate:nil
-                         reason:[reason toCallKit]];
+  [self reportCallKitEndOf:[self currentUuidFor:uuid] reason:[reason toCallKit]];
   [self assignIdleTimerDisabled:NO];
     
     if ([reason toCallKit] == CXCallEndedReasonUnanswered) {
@@ -473,9 +480,19 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 - (BOOL)hasOwnLiveCallKitCall {
   for (CXCall *call in _callController.callObserver.calls) {
     if (call.hasEnded) continue;
+    if ([_pendingCallKitEndUuids containsObject:call.UUID]) continue;
     if ([_ownCallUuids containsObject:call.UUID]) return YES;
   }
   return NO;
+}
+
+/// Reports [uuid] ended to CallKit and remembers it as pending-end until the
+/// observer confirms, so the liveness predicates stop counting it immediately
+/// instead of a beat later.
+- (void)reportCallKitEndOf:(NSUUID *)uuid reason:(CXCallEndedReason)reason {
+  if (uuid == nil) return;
+  [_pendingCallKitEndUuids addObject:uuid];
+  [_provider reportCallWithUUID:uuid endedAtDate:nil reason:reason];
 }
 
 /// Whether [uuid] itself is currently represented in CallKit as a live call.
@@ -490,6 +507,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 /// into "ringing + active" and summons the system call-waiting screen.
 - (BOOL)isLiveCallKitCallWithUuid:(NSUUID *)uuid {
   if (uuid == nil) return NO;
+  if ([_pendingCallKitEndUuids containsObject:uuid]) return NO;
   for (CXCall *call in _callController.callObserver.calls) {
     if (call.hasEnded) continue;
     if ([call.UUID isEqual:uuid]) return YES;
@@ -521,9 +539,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     if (![_deferredCallUuids containsObject:call.UUID]) {
       [_deferredCallUuids addObject:call.UUID];
       NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", call.UUID.UUIDString);
-      [_provider reportCallWithUUID:call.UUID
-                        endedAtDate:nil
-                             reason:CXCallEndedReasonAnsweredElsewhere];
+      [self reportCallKitEndOf:call.UUID reason:CXCallEndedReasonAnsweredElsewhere];
     }
   }
 }
@@ -813,9 +829,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                       NSLog(@"[Callkeep][didReceiveIncomingPushWithPayloadForPushTypeVoIP:withCompletionHandler:][reportNewIncomingCallWithUUID] payload wrong format error = %@",
                                             error);
                                     } else {
-                                      [_provider reportCallWithUUID:uuid
-                                                        endedAtDate:nil
-                                                             reason:CXCallEndedReasonFailed];
+                                      [self reportCallKitEndOf:uuid reason:CXCallEndedReasonFailed];
                                     }
                                     completion();
                                   }];
@@ -887,9 +901,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                     // deferred (rings app-side only) - take it right back out so
                                     // the system UI does not resurrect it.
                                     NSLog(@"[Callkeep][didReceiveIncomingPushWithPayloadForPushTypeVoIP] re-ending deferred call %@", uuid.UUIDString);
-                                    [self->_provider reportCallWithUUID:uuid
-                                                            endedAtDate:nil
-                                                                 reason:CXCallEndedReasonAnsweredElsewhere];
+                                    [self reportCallKitEndOf:uuid reason:CXCallEndedReasonAnsweredElsewhere];
                                   }
                                   WTPIncomingCallError *incomingCallError = nil;
                                   if (error != nil) {
@@ -966,6 +978,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
       [_answeringCallUuids removeObject:call.UUID];
     }
     if (call.hasEnded) {
+      [_pendingCallKitEndUuids removeObject:call.UUID];
       [_ownCallUuids removeObject:call.UUID];
       // Keep the update of a deferred call - it is needed for the re-report at
       // answer time; any other ended call's metadata is no longer useful.
@@ -1012,6 +1025,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   [_currentUuidByOriginal removeAllObjects];
   [_originalUuidByCurrent removeAllObjects];
   [_outgoingReattachUuids removeAllObjects];
+  [_pendingCallKitEndUuids removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -1033,9 +1047,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                                   if (error != nil || [fulfill boolValue] != YES) {
                                     NSLog(@"[Callkeep][performStartCallAction] re-attach answer failed, ending %@",
                                           action.callUUID.UUIDString);
-                                    [self->_provider reportCallWithUUID:action.callUUID
-                                                            endedAtDate:nil
-                                                                 reason:CXCallEndedReasonFailed];
+                                    [self reportCallKitEndOf:action.callUUID reason:CXCallEndedReasonFailed];
                                   } else {
                                     [self->_provider reportOutgoingCallWithUUID:action.callUUID
                                                                 connectedAtDate:nil];

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -58,6 +58,10 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // must treat these as gone, or they mistake a just-ended flash for a real
   // registration and un-defer a legitimately deferred call.
   NSMutableSet<NSUUID *> *_pendingCallKitEndUuids;
+  // Master switch of the deferred-registration mechanism (an app opts in via
+  // CallkeepIOSOptions). Off by default: every incoming call is registered
+  // with CallKit as before and the system call-waiting behavior applies.
+  BOOL _deferredCallKitRegistration;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -139,6 +143,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 
     _callWaitingToneOwnCallsOnly =
         iosOptions.callWaitingToneOwnCallsOnly == nil || iosOptions.callWaitingToneOwnCallsOnly.boolValue;
+    _deferredCallKitRegistration =
+        iosOptions.deferredCallKitRegistration != nil && iosOptions.deferredCallKitRegistration.boolValue;
 
     if (iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
@@ -200,6 +206,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     }
     _callWaitingToneOwnCallsOnly =
         iosOptions.callWaitingToneOwnCallsOnly == nil || iosOptions.callWaitingToneOwnCallsOnly.boolValue;
+    _deferredCallKitRegistration =
+        iosOptions.deferredCallKitRegistration != nil && iosOptions.deferredCallKitRegistration.boolValue;
     
     if (_ringback == nil && iosOptions.ringbackSound != nil) {
       _ringback = [self createRingbackPlayer:iosOptions.ringbackSound];
@@ -275,7 +283,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     completion(nil, nil);
     return;
   }
-  if (!alreadyLive && callUuid != nil && [self hasOwnLiveCallKitCall]) {
+  if (_deferredCallKitRegistration && !alreadyLive && callUuid != nil && [self hasOwnLiveCallKitCall]) {
     // At most one call is represented in CallKit: an incoming call arriving
     // while any own call already lives there (ringing or active) is deferred
     // right away - it rings app-side only and enters CallKit when answered.
@@ -374,19 +382,38 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // the registry entry ringing as a ghost.
   [self healStaleDeferredMark:uuid];
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
-    // The deferred call is not in CallKit - nothing to report, just forget it
-    // (remote hangup / cancel of a call that was ringing app-side only).
+    // The deferred call is not in CallKit, so there is no entry to end. A call
+    // the user never got to answer must still leave a missed-call trace in the
+    // system journal: flash-report it under a throwaway UUID and end it right
+    // away (the same report+instant-end the push path uses); the sub-second
+    // banner is the price of the journal record. Other reasons just forget
+    // the call. Execution falls through to the shared missed-call
+    // notification below either way.
     NSLog(@"[Callkeep][reportEndCall] clearing deferred call %@", uuidString);
     [_deferredCallUuids removeObject:uuid];
+    CXCallUpdate *lastUpdate = _incomingCallUpdates[uuid];
     [_incomingCallUpdates removeObjectForKey:uuid];
-    completion(nil);
-    return;
+    CXCallEndedReason endReason = [reason toCallKit];
+    BOOL missed = endReason == CXCallEndedReasonUnanswered || endReason == CXCallEndedReasonRemoteEnded;
+    if (missed && lastUpdate != nil) {
+      NSUUID *flashUuid = [NSUUID UUID];
+      NSLog(@"[Callkeep][reportEndCall] journaling missed deferred call %@ as %@", uuidString, flashUuid.UUIDString);
+      [_provider reportNewIncomingCallWithUUID:flashUuid
+                                        update:lastUpdate
+                                    completion:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          if (error == nil) {
+            [self reportCallKitEndOf:flashUuid reason:endReason];
+          }
+        });
+      }];
+    }
+  } else {
+    if (uuid != nil) {
+      [_incomingCallUpdates removeObjectForKey:uuid];
+    }
+    [self reportCallKitEndOf:[self currentUuidFor:uuid] reason:[reason toCallKit]];
   }
-  if (uuid != nil) {
-    [_incomingCallUpdates removeObjectForKey:uuid];
-  }
-
-  [self reportCallKitEndOf:[self currentUuidFor:uuid] reason:[reason toCallKit]];
   [self assignIdleTimerDisabled:NO];
     
     if ([reason toCallKit] == CXCallEndedReasonUnanswered) {
@@ -531,14 +558,19 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 /// answer flips CallKit into "active + ringing" and iOS covers the app with
 /// its full-screen call-waiting prompt for the remaining call.
 - (void)deferOtherRingingOwnCallsForAnswerOf:(NSUUID *)answeredUuid {
+  if (!_deferredCallKitRegistration) return;
   for (CXCall *call in _callController.callObserver.calls) {
     if (call.hasEnded || call.hasConnected || call.outgoing) continue;
     if ([call.UUID isEqual:answeredUuid]) continue;
     if (![_ownCallUuids containsObject:call.UUID]) continue;
     if ([_answeringCallUuids containsObject:call.UUID]) continue;
-    if (![_deferredCallUuids containsObject:call.UUID]) {
-      [_deferredCallUuids addObject:call.UUID];
-      NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", call.UUID.UUIDString);
+    // The deferred set lives in the Flutter side's stable UUID space: a call
+    // that re-entered CallKit under a fresh alias (a promoted one) must be
+    // marked by its original UUID or later lookups by the Dart side miss it.
+    NSUUID *original = [self originalUuidFor:call.UUID];
+    if (![_deferredCallUuids containsObject:original]) {
+      [_deferredCallUuids addObject:original];
+      NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", original.UUIDString);
       [self reportCallKitEndOf:call.UUID reason:CXCallEndedReasonAnsweredElsewhere];
     }
   }
@@ -885,7 +917,8 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   // represented there). PushKit still obliges reporting, so the call is
   // reported and taken right back out; it rings app-side and enters CallKit
   // under a fresh UUID when answered.
-  BOOL isDeferred = !alreadyLive && ([_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall]);
+  BOOL isDeferred = _deferredCallKitRegistration && !alreadyLive &&
+      ([_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall]);
   if (isDeferred) {
     [_deferredCallUuids addObject:uuid];
     _incomingCallUpdates[uuid] = callUpdate;
@@ -960,6 +993,46 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 
 - (void)callObserver:(CXCallObserver *)callObserver callChanged:(CXCall *)call {
   [self syncCallWaitingTone:callObserver];
+  [self promoteDeferredCallIfRegistryVacant];
+}
+
+/// Re-enters a still-ringing deferred call into CallKit when the registry has
+/// no own live call left (e.g. the visible call was declined while the
+/// deferred one keeps ringing app-side). Without this the remaining call is
+/// invisible and silent outside the app and just times out. Re-reporting as
+/// incoming is safe here - the call-waiting prompt needs a connected call
+/// next to the ringing one, and the registry is empty. Skipped while an
+/// answer is in flight: the registry is momentarily empty mid-transition and
+/// promoting then would race the re-attach.
+- (void)promoteDeferredCallIfRegistryVacant {
+  if (_deferredCallUuids.count == 0) return;
+  if (_outgoingReattachUuids.count > 0 || _answeringCallUuids.count > 0) return;
+  if ([self hasOwnLiveCallKitCall]) return;
+  NSUUID *original = [_deferredCallUuids anyObject];
+  CXCallUpdate *lastUpdate = _incomingCallUpdates[original];
+  if (lastUpdate == nil) return;
+  NSUUID *freshUuid = [NSUUID UUID];
+  NSLog(@"[Callkeep][promoteDeferredCall] registry vacant - promoting %@ as %@",
+        original.UUIDString, freshUuid.UUIDString);
+  [_deferredCallUuids removeObject:original];
+  _currentUuidByOriginal[original] = freshUuid;
+  _originalUuidByCurrent[freshUuid] = original;
+  [_ownCallUuids addObject:freshUuid];
+  [_provider reportNewIncomingCallWithUUID:freshUuid
+                                    update:lastUpdate
+                                completion:^(NSError *error) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (error != nil) {
+        NSLog(@"[Callkeep][promoteDeferredCall] promotion failed (%@) - back to deferred", error);
+        [self->_ownCallUuids removeObject:freshUuid];
+        if ([self->_currentUuidByOriginal[original] isEqual:freshUuid]) {
+          [self->_currentUuidByOriginal removeObjectForKey:original];
+        }
+        [self->_originalUuidByCurrent removeObjectForKey:freshUuid];
+        [self->_deferredCallUuids addObject:original];
+      }
+    });
+  }];
 }
 
 /// Mirrors the Android connection-service behavior: a soft call-waiting beep plays
@@ -987,8 +1060,15 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
       }
       NSUUID *original = _originalUuidByCurrent[call.UUID];
       if (original != nil) {
-        [_incomingCallUpdates removeObjectForKey:original];
-        [_currentUuidByOriginal removeObjectForKey:original];
+        // A re-deferred call keeps its metadata and its NEWER alias: this end
+        // may be the confirmation of an OLD alias reported ended when the call
+        // went back to deferred, arriving after a fresh alias already exists.
+        if (![_deferredCallUuids containsObject:original]) {
+          [_incomingCallUpdates removeObjectForKey:original];
+        }
+        if ([_currentUuidByOriginal[original] isEqual:call.UUID]) {
+          [_currentUuidByOriginal removeObjectForKey:original];
+        }
         [_originalUuidByCurrent removeObjectForKey:call.UUID];
       }
       continue;
@@ -1001,6 +1081,12 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     } else if (!call.outgoing && ![_answeringCallUuids containsObject:call.UUID]) {
       hasRingingIncoming = YES;
     }
+  }
+  // A deferred incoming call has no CallKit entry, so the loop above cannot
+  // see it - but it IS a ringing incoming call, and during a conversation the
+  // tone is the only audible cue it exists.
+  if (_deferredCallUuids.count > 0) {
+    hasRingingIncoming = YES;
   }
 #ifdef DEBUG
   NSLog(@"[CallWaitingTone] sync: calls=%lu connected=%d ringingIncoming=%d",

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -236,9 +236,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     // UI, but remember the freshest metadata for the re-report at answer time.
     // The caller is told "success" - on the Flutter side the call is alive and
     // proceeds exactly as if it were registered.
-#ifdef DEBUG
     NSLog(@"[Callkeep][reportNewIncomingCall] suppressed for deferred call %@", uuidString);
-#endif
     _incomingCallUpdates[callUuid] = callUpdate;
     completion(nil, nil);
     return;
@@ -329,9 +327,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
     // The deferred call is not in CallKit - nothing to report, just forget it
     // (remote hangup / cancel of a call that was ringing app-side only).
-#ifdef DEBUG
     NSLog(@"[Callkeep][reportEndCall] clearing deferred call %@", uuidString);
-#endif
     [_deferredCallUuids removeObject:uuid];
     [_incomingCallUpdates removeObjectForKey:uuid];
     completion(nil);
@@ -427,9 +423,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     if ([_answeringCallUuids containsObject:call.UUID]) continue;
     if (![_deferredCallUuids containsObject:call.UUID]) {
       [_deferredCallUuids addObject:call.UUID];
-#ifdef DEBUG
       NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", call.UUID.UUIDString);
-#endif
       [_provider reportCallWithUUID:call.UUID
                         endedAtDate:nil
                              reason:CXCallEndedReasonAnsweredElsewhere];
@@ -450,19 +444,19 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     // with its remembered metadata and request the answer straight from the
     // report completion, so the ringing state exists for the shortest possible
     // moment and the system prompt has no time to take over.
-#ifdef DEBUG
     NSLog(@"[Callkeep][answerCall] re-reporting deferred call %@", uuidString);
-#endif
     CXCallUpdate *callUpdate = _incomingCallUpdates[uuid] ?: [[CXCallUpdate alloc] init];
     [_provider reportNewIncomingCallWithUUID:uuid
                                       update:callUpdate
                                   completion:^(NSError *error) {
                                     if (error != nil && !([error.domain isEqualToString:CXErrorDomainIncomingCall] &&
                                                           error.code == CXErrorCodeIncomingCallErrorCallUUIDAlreadyExists)) {
-                                      NSLog(@"[Callkeep][answerCall] deferred re-report failed: %@", error);
+                                      NSLog(@"[Callkeep][answerCall] deferred re-report failed: domain=%@ code=%ld (%@)",
+                                            error.domain, (long)error.code, error.localizedDescription);
                                       completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
                                       return;
                                     }
+                                    NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@), requesting answer", uuid.UUIDString);
                                     [self->_deferredCallUuids removeObject:uuid];
                                     [self->_ownCallUuids addObject:uuid];
                                     CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
@@ -496,9 +490,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     // A deferred call has no CallKit representation to end - clean up locally
     // and drive the same delegate path a fulfilled CXEndCallAction would, so
     // the Flutter side terminates the call exactly as usual.
-#ifdef DEBUG
     NSLog(@"[Callkeep][endCall] ending deferred call %@ locally", uuidString);
-#endif
     [_deferredCallUuids removeObject:uuid];
     [_incomingCallUpdates removeObjectForKey:uuid];
     [_delegateFlutterApi performEndCall:uuidString
@@ -556,6 +548,10 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 
 - (void)requestTransaction:(CXTransaction *)transaction completion:(void (^)(WTPCallRequestError *, FlutterError *))completion {
   [_callController requestTransaction:transaction completion:^(NSError *error) {
+    if (error != nil) {
+      NSLog(@"[Callkeep][requestTransaction] %@ failed: domain=%@ code=%ld (%@)",
+            [[transaction.actions firstObject] class], error.domain, (long)error.code, error.localizedDescription);
+    }
     if (error == nil) {
       completion(nil, nil);
     } else if ([error.domain isEqualToString:CXErrorDomainRequestTransaction]) {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -29,6 +29,15 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   BOOL _callWaitingToneOwnCallsOnly;
   CXCallController *_callController;
   BOOL _driveIdleTimerDisabled;
+  // Deferred CallKit registration: when one incoming call is answered, the other
+  // still-ringing own calls are taken out of CallKit (reported ended) so the
+  // "active + ringing" state never forms and the system call-waiting screen does
+  // not cover the app. A deferred call keeps living on the Flutter side; it
+  // re-enters CallKit the moment it is answered (report + answer in one go).
+  NSMutableSet<NSUUID *> *_deferredCallUuids;
+  // Last CXCallUpdate per incoming call, kept so a deferred call can be
+  // re-reported with its original handle/name when answered.
+  NSMutableDictionary<NSUUID *, CXCallUpdate *> *_incomingCallUpdates;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -56,6 +65,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _callWaitingTone = [[CallWaitingTonePlayer alloc] init];
     _ownCallUuids = [NSMutableSet set];
     _answeringCallUuids = [NSMutableSet set];
+    _deferredCallUuids = [NSMutableSet set];
+    _incomingCallUpdates = [NSMutableDictionary dictionary];
     _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
@@ -219,8 +230,22 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
   NSUUID *callUuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  if (callUuid != nil && [_deferredCallUuids containsObject:callUuid]) {
+    // The call is deferred (kept out of CallKit while another call was being
+    // answered). Swallow the registration so it does not resurrect the system
+    // UI, but remember the freshest metadata for the re-report at answer time.
+    // The caller is told "success" - on the Flutter side the call is alive and
+    // proceeds exactly as if it were registered.
+#ifdef DEBUG
+    NSLog(@"[Callkeep][reportNewIncomingCall] suppressed for deferred call %@", uuidString);
+#endif
+    _incomingCallUpdates[callUuid] = callUpdate;
+    completion(nil, nil);
+    return;
+  }
   if (callUuid != nil) {
     [_ownCallUuids addObject:callUuid];
+    _incomingCallUpdates[callUuid] = callUpdate;
   }
   [_provider reportNewIncomingCallWithUUID:callUuid
                                     update:callUpdate
@@ -300,8 +325,23 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
 #ifdef DEBUG
   NSLog(@"[Callkeep][reportEndCall] uuidString = %@", uuidString);
 #endif
-    
-  [_provider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
+    // The deferred call is not in CallKit - nothing to report, just forget it
+    // (remote hangup / cancel of a call that was ringing app-side only).
+#ifdef DEBUG
+    NSLog(@"[Callkeep][reportEndCall] clearing deferred call %@", uuidString);
+#endif
+    [_deferredCallUuids removeObject:uuid];
+    [_incomingCallUpdates removeObjectForKey:uuid];
+    completion(nil);
+    return;
+  }
+  if (uuid != nil) {
+    [_incomingCallUpdates removeObjectForKey:uuid];
+  }
+
+  [_provider reportCallWithUUID:uuid
                     endedAtDate:nil
                          reason:[reason toCallKit]];
   [self assignIdleTimerDisabled:NO];
@@ -375,12 +415,64 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   }];
 }
 
+/// Takes every other still-ringing own incoming call out of CallKit right
+/// before [answeredUuid] goes active, marking them deferred. Without this the
+/// answer flips CallKit into "active + ringing" and iOS covers the app with
+/// its full-screen call-waiting prompt for the remaining call.
+- (void)deferOtherRingingOwnCallsForAnswerOf:(NSUUID *)answeredUuid {
+  for (CXCall *call in _callController.callObserver.calls) {
+    if (call.hasEnded || call.hasConnected || call.outgoing) continue;
+    if ([call.UUID isEqual:answeredUuid]) continue;
+    if (![_ownCallUuids containsObject:call.UUID]) continue;
+    if ([_answeringCallUuids containsObject:call.UUID]) continue;
+    if (![_deferredCallUuids containsObject:call.UUID]) {
+      [_deferredCallUuids addObject:call.UUID];
+#ifdef DEBUG
+      NSLog(@"[Callkeep][deferOtherRingingOwnCalls] deferring %@", call.UUID.UUIDString);
+#endif
+      [_provider reportCallWithUUID:call.UUID
+                        endedAtDate:nil
+                             reason:CXCallEndedReasonAnsweredElsewhere];
+    }
+  }
+}
+
 - (void)answerCall:(NSString *)uuidString
         completion:(void (^)(WTPCallRequestError *, FlutterError *))completion {
 #ifdef DEBUG
   NSLog(@"[Callkeep][answerCall] uuidString = %@", uuidString);
 #endif
-  CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:[[NSUUID alloc] initWithUUIDString:uuidString]];
+  NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  [self deferOtherRingingOwnCallsForAnswerOf:uuid];
+
+  if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
+    // A deferred call re-enters CallKit only now, at answer time: re-report it
+    // with its remembered metadata and request the answer straight from the
+    // report completion, so the ringing state exists for the shortest possible
+    // moment and the system prompt has no time to take over.
+#ifdef DEBUG
+    NSLog(@"[Callkeep][answerCall] re-reporting deferred call %@", uuidString);
+#endif
+    CXCallUpdate *callUpdate = _incomingCallUpdates[uuid] ?: [[CXCallUpdate alloc] init];
+    [_provider reportNewIncomingCallWithUUID:uuid
+                                      update:callUpdate
+                                  completion:^(NSError *error) {
+                                    if (error != nil && !([error.domain isEqualToString:CXErrorDomainIncomingCall] &&
+                                                          error.code == CXErrorCodeIncomingCallErrorCallUUIDAlreadyExists)) {
+                                      NSLog(@"[Callkeep][answerCall] deferred re-report failed: %@", error);
+                                      completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
+                                      return;
+                                    }
+                                    [self->_deferredCallUuids removeObject:uuid];
+                                    [self->_ownCallUuids addObject:uuid];
+                                    CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
+                                    CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
+                                    [self requestTransaction:transaction completion:completion];
+                                  }];
+    return;
+  }
+
+  CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
   [self requestTransaction:transaction completion:completion];
@@ -399,7 +491,22 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 #ifdef DEBUG
   NSLog(@"[Callkeep][endCall] uuidString = %@", uuidString);
 #endif
-  CXEndCallAction *action = [[CXEndCallAction alloc] initWithCallUUID:[[NSUUID alloc] initWithUUIDString:uuidString]];
+  NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
+    // A deferred call has no CallKit representation to end - clean up locally
+    // and drive the same delegate path a fulfilled CXEndCallAction would, so
+    // the Flutter side terminates the call exactly as usual.
+#ifdef DEBUG
+    NSLog(@"[Callkeep][endCall] ending deferred call %@ locally", uuidString);
+#endif
+    [_deferredCallUuids removeObject:uuid];
+    [_incomingCallUpdates removeObjectForKey:uuid];
+    [_delegateFlutterApi performEndCall:uuidString
+                             completion:^(NSNumber *fulfill, FlutterError *error) {}];
+    completion(nil, nil);
+    return;
+  }
+  CXEndCallAction *action = [[CXEndCallAction alloc] initWithCallUUID:uuid];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
   [self requestTransaction:transaction completion:completion];
@@ -648,10 +755,23 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   callUpdate.supportsUngrouping = NO;
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
-  [_ownCallUuids addObject:uuid];
+  BOOL isDeferred = [_deferredCallUuids containsObject:uuid];
+  if (!isDeferred) {
+    [_ownCallUuids addObject:uuid];
+    _incomingCallUpdates[uuid] = callUpdate;
+  }
   [_provider reportNewIncomingCallWithUUID:uuid
                                     update:callUpdate
                                 completion:^(NSError *error) {
+                                  if (isDeferred && error == nil) {
+                                    // PushKit obliges reporting every VoIP push, but this call is
+                                    // deferred (rings app-side only) - take it right back out so
+                                    // the system UI does not resurrect it.
+                                    NSLog(@"[Callkeep][didReceiveIncomingPushWithPayloadForPushTypeVoIP] re-ending deferred call %@", uuid.UUIDString);
+                                    [self->_provider reportCallWithUUID:uuid
+                                                            endedAtDate:nil
+                                                                 reason:CXCallEndedReasonAnsweredElsewhere];
+                                  }
                                   WTPIncomingCallError *incomingCallError = nil;
                                   if (error != nil) {
                                     if ([error.domain isEqualToString:CXErrorDomainIncomingCall]) {
@@ -728,6 +848,11 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     }
     if (call.hasEnded) {
       [_ownCallUuids removeObject:call.UUID];
+      // Keep the update of a deferred call - it is needed for the re-report at
+      // answer time; any other ended call's metadata is no longer useful.
+      if (![_deferredCallUuids containsObject:call.UUID]) {
+        [_incomingCallUpdates removeObjectForKey:call.UUID];
+      }
       continue;
     }
     if (_callWaitingToneOwnCallsOnly && ![_ownCallUuids containsObject:call.UUID]) {
@@ -757,6 +882,8 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   [_callWaitingTone stop];
   [_ownCallUuids removeAllObjects];
   [_answeringCallUuids removeAllObjects];
+  [_deferredCallUuids removeAllObjects];
+  [_incomingCallUpdates removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -783,6 +910,10 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performAnswerCallAction:]");
 #endif
+  // Covers answers coming through CallKit's own UI (lock screen, banner) as
+  // well - by this point no Dart code has run yet, so the deferral must happen
+  // here to keep the remaining ringing call from raising the system prompt.
+  [self deferOtherRingingOwnCallsForAnswerOf:action.callUUID];
   // Suppress the call-waiting tone from the moment the user accepts: the CXCall stays
   // "ringing" until the answer roundtrip fulfills the action, which can take seconds.
   [_answeringCallUuids addObject:action.callUUID];

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -45,6 +45,12 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // original UUID; these two maps translate at the plugin boundary.
   NSMutableDictionary<NSUUID *, NSUUID *> *_currentUuidByOriginal;
   NSMutableDictionary<NSUUID *, NSUUID *> *_originalUuidByCurrent;
+  // Deferred calls re-enter CallKit as OUTGOING (CXStartCallAction): an
+  // incoming re-report raises the system incoming UI over the app and iOS
+  // keeps the user on its own in-call screen after the answer. The start
+  // action is fulfilled natively and surfaces to Flutter as a plain
+  // performAnswerCall; this set marks the in-flight ones.
+  NSMutableSet<NSUUID *> *_outgoingReattachUuids;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -76,6 +82,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _incomingCallUpdates = [NSMutableDictionary dictionary];
     _currentUuidByOriginal = [NSMutableDictionary dictionary];
     _originalUuidByCurrent = [NSMutableDictionary dictionary];
+    _outgoingReattachUuids = [NSMutableSet set];
     _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
@@ -487,39 +494,27 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   [self deferOtherRingingOwnCallsForAnswerOf:[self currentUuidFor:uuid]];
 
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
-    // A deferred call re-enters CallKit only now, at answer time, and under a
-    // FRESH UUID: re-reporting the original (already reported-ended) UUID makes
-    // CallKit hand back a zombie whose answer transaction fails. The alias maps
-    // keep the Flutter side on the stable original UUID. The answer is
-    // requested straight from the report completion, so the ringing state
-    // exists for the shortest possible moment.
+    // A deferred call re-enters CallKit only now, at answer time, under a
+    // FRESH UUID (re-reporting the original reported-ended UUID hands back a
+    // zombie whose answer fails) and as an OUTGOING call: an incoming
+    // re-report raises the system incoming UI over the app and iOS keeps the
+    // user on its own in-call screen after answering. The start action never
+    // reaches Flutter as a start - performStartCallAction fulfills it
+    // natively and drives performAnswerCall for the original UUID instead.
     NSUUID *freshUuid = [NSUUID UUID];
-    NSLog(@"[Callkeep][answerCall] re-reporting deferred call %@ as %@", uuidString, freshUuid.UUIDString);
+    NSLog(@"[Callkeep][answerCall] re-attaching deferred call %@ as outgoing %@", uuidString, freshUuid.UUIDString);
     CXCallUpdate *callUpdate = _incomingCallUpdates[uuid] ?: [[CXCallUpdate alloc] init];
-    [_provider reportNewIncomingCallWithUUID:freshUuid
-                                      update:callUpdate
-                                  completion:^(NSError *error) {
-                                    // The report completion arrives on the provider's private queue;
-                                    // all plugin state is main-thread-confined (delegate and observer
-                                    // callbacks run on main), so hop before touching it.
-                                    dispatch_async(dispatch_get_main_queue(), ^{
-                                      if (error != nil) {
-                                        NSLog(@"[Callkeep][answerCall] deferred re-report failed: domain=%@ code=%ld (%@)",
-                                              error.domain, (long)error.code, error.localizedDescription);
-                                        completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
-                                        return;
-                                      }
-                                      NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@ -> %@), requesting answer",
-                                            uuid.UUIDString, freshUuid.UUIDString);
-                                      [self->_deferredCallUuids removeObject:uuid];
-                                      self->_currentUuidByOriginal[uuid] = freshUuid;
-                                      self->_originalUuidByCurrent[freshUuid] = uuid;
-                                      [self->_ownCallUuids addObject:freshUuid];
-                                      CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:freshUuid];
-                                      CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
-                                      [self requestTransaction:transaction completion:completion];
-                                    });
-                                  }];
+    CXHandle *handle = callUpdate.remoteHandle
+        ?: [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
+    [_deferredCallUuids removeObject:uuid];
+    _currentUuidByOriginal[uuid] = freshUuid;
+    _originalUuidByCurrent[freshUuid] = uuid;
+    [_outgoingReattachUuids addObject:freshUuid];
+    [_ownCallUuids addObject:freshUuid];
+    CXStartCallAction *startAction = [[CXStartCallAction alloc] initWithCallUUID:freshUuid handle:handle];
+    startAction.contactIdentifier = callUpdate.localizedCallerName;
+    CXTransaction *startTransaction = [[CXTransaction alloc] initWithAction:startAction];
+    [self requestTransaction:startTransaction completion:completion];
     return;
   }
 
@@ -953,6 +948,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   [_incomingCallUpdates removeAllObjects];
   [_currentUuidByOriginal removeAllObjects];
   [_originalUuidByCurrent removeAllObjects];
+  [_outgoingReattachUuids removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -960,6 +956,30 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performStartCallAction:]");
 #endif
+  if ([_outgoingReattachUuids containsObject:action.callUUID]) {
+    // A deferred call re-entering CallKit as outgoing: fulfill natively and
+    // surface to Flutter as the answer of the original incoming call.
+    [_outgoingReattachUuids removeObject:action.callUUID];
+    NSUUID *original = [self originalUuidFor:action.callUUID];
+    NSLog(@"[Callkeep][performStartCallAction] outgoing re-attach %@ -> answering %@",
+          action.callUUID.UUIDString, original.UUIDString);
+    [action fulfill];
+    [_provider reportOutgoingCallWithUUID:action.callUUID startedConnectingAtDate:nil];
+    [_delegateFlutterApi performAnswerCall:original.UUIDString
+                                completion:^(NSNumber *fulfill, FlutterError *error) {
+                                  if (error != nil || [fulfill boolValue] != YES) {
+                                    NSLog(@"[Callkeep][performStartCallAction] re-attach answer failed, ending %@",
+                                          action.callUUID.UUIDString);
+                                    [self->_provider reportCallWithUUID:action.callUUID
+                                                            endedAtDate:nil
+                                                                 reason:CXCallEndedReasonFailed];
+                                  } else {
+                                    [self->_provider reportOutgoingCallWithUUID:action.callUUID
+                                                                connectedAtDate:nil];
+                                  }
+                                }];
+    return;
+  }
   [_ownCallUuids addObject:action.callUUID];
   [_delegateFlutterApi performStartCall:action.callUUID.UUIDString
                                  handle:[action.handle toPigeon]

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -38,6 +38,13 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   // Last CXCallUpdate per incoming call, kept so a deferred call can be
   // re-reported with its original handle/name when answered.
   NSMutableDictionary<NSUUID *, CXCallUpdate *> *_incomingCallUpdates;
+  // A deferred call re-enters CallKit under a FRESH UUID: re-reporting the
+  // original (already reported-ended) UUID makes CallKit accept the report but
+  // yield a zombie call whose answer transaction fails (InvalidAction) about
+  // half the time. The Flutter side keeps addressing the call by its stable
+  // original UUID; these two maps translate at the plugin boundary.
+  NSMutableDictionary<NSUUID *, NSUUID *> *_currentUuidByOriginal;
+  NSMutableDictionary<NSUUID *, NSUUID *> *_originalUuidByCurrent;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -67,6 +74,8 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     _answeringCallUuids = [NSMutableSet set];
     _deferredCallUuids = [NSMutableSet set];
     _incomingCallUpdates = [NSMutableDictionary dictionary];
+    _currentUuidByOriginal = [NSMutableDictionary dictionary];
+    _originalUuidByCurrent = [NSMutableDictionary dictionary];
     _callWaitingToneOwnCallsOnly = YES;
   }
   return self;
@@ -241,6 +250,18 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     completion(nil, nil);
     return;
   }
+  if (callUuid != nil && _ownCallUuids.count > 0) {
+    // At most one call is represented in CallKit: an incoming call arriving
+    // while any own call already lives there (ringing or active) is deferred
+    // right away - it rings app-side only and enters CallKit when answered.
+    // Registering it would raise the system call-waiting screen over the app.
+    NSLog(@"[Callkeep][reportNewIncomingCall] deferring on arrival %@ (own calls in CallKit: %lu)",
+          uuidString, (unsigned long)_ownCallUuids.count);
+    [_deferredCallUuids addObject:callUuid];
+    _incomingCallUpdates[callUuid] = callUpdate;
+    completion(nil, nil);
+    return;
+  }
   if (callUuid != nil) {
     [_ownCallUuids addObject:callUuid];
     _incomingCallUpdates[callUuid] = callUpdate;
@@ -310,7 +331,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
      }
   }
     
-  [_provider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  [_provider reportCallWithUUID:[self currentUuidFor:[[NSUUID alloc] initWithUUIDString:uuidString]]
                         updated:callUpdate];
   [self assignIdleTimerDisabled:callUpdate.hasVideo];
   completion(nil);
@@ -337,7 +358,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     [_incomingCallUpdates removeObjectForKey:uuid];
   }
 
-  [_provider reportCallWithUUID:uuid
+  [_provider reportCallWithUUID:[self currentUuidFor:uuid]
                     endedAtDate:nil
                          reason:[reason toCallKit]];
   [self assignIdleTimerDisabled:NO];
@@ -411,6 +432,21 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   }];
 }
 
+/// The CallKit-side UUID for a call the Flutter side addresses by [uuid]:
+/// the fresh alias when the call re-entered CallKit after a deferral, the
+/// same UUID otherwise.
+- (NSUUID *)currentUuidFor:(NSUUID *)uuid {
+  if (uuid == nil) return nil;
+  return _currentUuidByOriginal[uuid] ?: uuid;
+}
+
+/// The stable Flutter-side UUID for a CallKit call [uuid] (reverse of
+/// [currentUuidFor:]).
+- (NSUUID *)originalUuidFor:(NSUUID *)uuid {
+  if (uuid == nil) return nil;
+  return _originalUuidByCurrent[uuid] ?: uuid;
+}
+
 /// Takes every other still-ringing own incoming call out of CallKit right
 /// before [answeredUuid] goes active, marking them deferred. Without this the
 /// answer flips CallKit into "active + ringing" and iOS covers the app with
@@ -437,33 +473,38 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   NSLog(@"[Callkeep][answerCall] uuidString = %@", uuidString);
 #endif
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
-  [self deferOtherRingingOwnCallsForAnswerOf:uuid];
+  [self deferOtherRingingOwnCallsForAnswerOf:[self currentUuidFor:uuid]];
 
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
-    // A deferred call re-enters CallKit only now, at answer time: re-report it
-    // with its remembered metadata and request the answer straight from the
-    // report completion, so the ringing state exists for the shortest possible
-    // moment and the system prompt has no time to take over.
-    NSLog(@"[Callkeep][answerCall] re-reporting deferred call %@", uuidString);
+    // A deferred call re-enters CallKit only now, at answer time, and under a
+    // FRESH UUID: re-reporting the original (already reported-ended) UUID makes
+    // CallKit hand back a zombie whose answer transaction fails. The alias maps
+    // keep the Flutter side on the stable original UUID. The answer is
+    // requested straight from the report completion, so the ringing state
+    // exists for the shortest possible moment.
+    NSUUID *freshUuid = [NSUUID UUID];
+    NSLog(@"[Callkeep][answerCall] re-reporting deferred call %@ as %@", uuidString, freshUuid.UUIDString);
     CXCallUpdate *callUpdate = _incomingCallUpdates[uuid] ?: [[CXCallUpdate alloc] init];
-    [_provider reportNewIncomingCallWithUUID:uuid
+    [_provider reportNewIncomingCallWithUUID:freshUuid
                                       update:callUpdate
                                   completion:^(NSError *error) {
                                     // The report completion arrives on the provider's private queue;
                                     // all plugin state is main-thread-confined (delegate and observer
                                     // callbacks run on main), so hop before touching it.
                                     dispatch_async(dispatch_get_main_queue(), ^{
-                                      if (error != nil && !([error.domain isEqualToString:CXErrorDomainIncomingCall] &&
-                                                            error.code == CXErrorCodeIncomingCallErrorCallUUIDAlreadyExists)) {
+                                      if (error != nil) {
                                         NSLog(@"[Callkeep][answerCall] deferred re-report failed: domain=%@ code=%ld (%@)",
                                               error.domain, (long)error.code, error.localizedDescription);
                                         completion([WTPCallRequestError makeWithValue:WTPCallRequestErrorEnumInternal], nil);
                                         return;
                                       }
-                                      NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@), requesting answer", uuid.UUIDString);
+                                      NSLog(@"[Callkeep][answerCall] deferred re-report ok (%@ -> %@), requesting answer",
+                                            uuid.UUIDString, freshUuid.UUIDString);
                                       [self->_deferredCallUuids removeObject:uuid];
-                                      [self->_ownCallUuids addObject:uuid];
-                                      CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
+                                      self->_currentUuidByOriginal[uuid] = freshUuid;
+                                      self->_originalUuidByCurrent[freshUuid] = uuid;
+                                      [self->_ownCallUuids addObject:freshUuid];
+                                      CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:freshUuid];
                                       CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
                                       [self requestTransaction:transaction completion:completion];
                                     });
@@ -471,7 +512,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     return;
   }
 
-  CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
+  CXAnswerCallAction *action = [[CXAnswerCallAction alloc] initWithCallUUID:[self currentUuidFor:uuid]];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
   [self requestTransaction:transaction completion:completion];
@@ -503,7 +544,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
     completion(nil, nil);
     return;
   }
-  CXEndCallAction *action = [[CXEndCallAction alloc] initWithCallUUID:uuid];
+  CXEndCallAction *action = [[CXEndCallAction alloc] initWithCallUUID:[self currentUuidFor:uuid]];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
   [self requestTransaction:transaction completion:completion];
@@ -515,7 +556,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 #ifdef DEBUG
   NSLog(@"[Callkeep][setHeld] uuidString = %@ held = %d", uuidString, onHold);
 #endif
-  CXSetHeldCallAction *action = [[CXSetHeldCallAction alloc] initWithCallUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  CXSetHeldCallAction *action = [[CXSetHeldCallAction alloc] initWithCallUUID:[self currentUuidFor:[[NSUUID alloc] initWithUUIDString:uuidString]]
                                                                        onHold:onHold];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
@@ -528,7 +569,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 #ifdef DEBUG
   NSLog(@"[Callkeep][setMuted] uuidString = %@ muted = %d", uuidString, muted);
 #endif
-  CXSetMutedCallAction *action = [[CXSetMutedCallAction alloc] initWithCallUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  CXSetMutedCallAction *action = [[CXSetMutedCallAction alloc] initWithCallUUID:[self currentUuidFor:[[NSUUID alloc] initWithUUIDString:uuidString]]
                                                                           muted:muted];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
 
@@ -541,7 +582,7 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 #ifdef DEBUG
   NSLog(@"[Callkeep][sendDTMF] uuidString = %@ key = %@", uuidString, key);
 #endif
-  CXPlayDTMFCallAction *action = [[CXPlayDTMFCallAction alloc] initWithCallUUID:[[NSUUID alloc] initWithUUIDString:uuidString]
+  CXPlayDTMFCallAction *action = [[CXPlayDTMFCallAction alloc] initWithCallUUID:[self currentUuidFor:[[NSUUID alloc] initWithUUIDString:uuidString]]
                                                                          digits:key
                                                                            type:CXPlayDTMFCallActionTypeSingleTone];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:action];
@@ -756,8 +797,16 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   callUpdate.supportsUngrouping = NO;
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
-  BOOL isDeferred = [_deferredCallUuids containsObject:uuid];
-  if (!isDeferred) {
+  // Deferred either explicitly (taken out of CallKit at answer time) or on
+  // arrival (another own call already lives in CallKit - at most one call is
+  // represented there). PushKit still obliges reporting, so the call is
+  // reported and taken right back out; it rings app-side and enters CallKit
+  // under a fresh UUID when answered.
+  BOOL isDeferred = [_deferredCallUuids containsObject:uuid] || _ownCallUuids.count > 0;
+  if (isDeferred) {
+    [_deferredCallUuids addObject:uuid];
+    _incomingCallUpdates[uuid] = callUpdate;
+  } else {
     [_ownCallUuids addObject:uuid];
     _incomingCallUpdates[uuid] = callUpdate;
   }
@@ -854,6 +903,12 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
       if (![_deferredCallUuids containsObject:call.UUID]) {
         [_incomingCallUpdates removeObjectForKey:call.UUID];
       }
+      NSUUID *original = _originalUuidByCurrent[call.UUID];
+      if (original != nil) {
+        [_incomingCallUpdates removeObjectForKey:original];
+        [_currentUuidByOriginal removeObjectForKey:original];
+        [_originalUuidByCurrent removeObjectForKey:call.UUID];
+      }
       continue;
     }
     if (_callWaitingToneOwnCallsOnly && ![_ownCallUuids containsObject:call.UUID]) {
@@ -885,6 +940,8 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   [_answeringCallUuids removeAllObjects];
   [_deferredCallUuids removeAllObjects];
   [_incomingCallUpdates removeAllObjects];
+  [_currentUuidByOriginal removeAllObjects];
+  [_originalUuidByCurrent removeAllObjects];
   [_delegateFlutterApi didReset:^(FlutterError *error) {}];
 }
 
@@ -918,7 +975,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   // Suppress the call-waiting tone from the moment the user accepts: the CXCall stays
   // "ringing" until the answer roundtrip fulfills the action, which can take seconds.
   [_answeringCallUuids addObject:action.callUUID];
-  [_delegateFlutterApi performAnswerCall:action.callUUID.UUIDString
+  [_delegateFlutterApi performAnswerCall:[self originalUuidFor:action.callUUID].UUIDString
                               completion:^(NSNumber *fulfill, FlutterError *error) {
                                 if (error != nil || [fulfill boolValue] != YES) {
                                   [self->_answeringCallUuids removeObject:action.callUUID];
@@ -933,7 +990,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performEndCallAction:]");
 #endif
-  [_delegateFlutterApi performEndCall:action.callUUID.UUIDString
+  [_delegateFlutterApi performEndCall:[self originalUuidFor:action.callUUID].UUIDString
                            completion:^(NSNumber *fulfill, FlutterError *error) {
                              if (error != nil || [fulfill boolValue] != YES) {
                                [action fail];
@@ -948,7 +1005,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performSetHeldCallAction:]");
 #endif
-  [_delegateFlutterApi performSetHeld:action.callUUID.UUIDString
+  [_delegateFlutterApi performSetHeld:[self originalUuidFor:action.callUUID].UUIDString
                                onHold:action.onHold
                            completion:^(NSNumber *fulfill, FlutterError *error) {
                              if (error != nil || [fulfill boolValue] != YES) {
@@ -963,7 +1020,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 #ifdef DEBUG
   NSLog(@"[Callkeep][CXProviderDelegate][provider:performSetMutedCallAction:]");
 #endif
-  [_delegateFlutterApi performSetMuted:action.callUUID.UUIDString
+  [_delegateFlutterApi performSetMuted:[self originalUuidFor:action.callUUID].UUIDString
                                  muted:action.muted
                             completion:^(NSNumber *fulfill, FlutterError *error) {
                               if (error != nil || [fulfill boolValue] != YES) {
@@ -989,7 +1046,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     [action fail];
     return;
   }
-  [_delegateFlutterApi performSendDTMF:action.callUUID.UUIDString
+  [_delegateFlutterApi performSendDTMF:[self originalUuidFor:action.callUUID].UUIDString
                                    key:action.digits
                             completion:^(NSNumber *fulfill, FlutterError *error) {
                               if (error != nil || [fulfill boolValue] != YES) {

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -250,13 +250,12 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     completion(nil, nil);
     return;
   }
-  if (callUuid != nil && _ownCallUuids.count > 0) {
+  if (callUuid != nil && [self hasOwnLiveCallKitCall]) {
     // At most one call is represented in CallKit: an incoming call arriving
     // while any own call already lives there (ringing or active) is deferred
     // right away - it rings app-side only and enters CallKit when answered.
     // Registering it would raise the system call-waiting screen over the app.
-    NSLog(@"[Callkeep][reportNewIncomingCall] deferring on arrival %@ (own calls in CallKit: %lu)",
-          uuidString, (unsigned long)_ownCallUuids.count);
+    NSLog(@"[Callkeep][reportNewIncomingCall] deferring on arrival %@", uuidString);
     [_deferredCallUuids addObject:callUuid];
     _incomingCallUpdates[callUuid] = callUpdate;
     completion(nil, nil);
@@ -445,6 +444,18 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 - (NSUUID *)originalUuidFor:(NSUUID *)uuid {
   if (uuid == nil) return nil;
   return _originalUuidByCurrent[uuid] ?: uuid;
+}
+
+/// Whether any own call currently lives in CallKit. Decided from the call
+/// observer, not from the bookkeeping set: the observer may drop an ended
+/// call from its list before the cleanup pass sees it, so a stale entry in
+/// the set would keep deferring every new incoming call forever.
+- (BOOL)hasOwnLiveCallKitCall {
+  for (CXCall *call in _callController.callObserver.calls) {
+    if (call.hasEnded) continue;
+    if ([_ownCallUuids containsObject:call.UUID]) return YES;
+  }
+  return NO;
 }
 
 /// Takes every other still-ringing own incoming call out of CallKit right
@@ -802,7 +813,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   // represented there). PushKit still obliges reporting, so the call is
   // reported and taken right back out; it rings app-side and enters CallKit
   // under a fresh UUID when answered.
-  BOOL isDeferred = [_deferredCallUuids containsObject:uuid] || _ownCallUuids.count > 0;
+  BOOL isDeferred = [_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall];
   if (isDeferred) {
     [_deferredCallUuids addObject:uuid];
     _incomingCallUpdates[uuid] = callUpdate;

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/WebtritCallkeepPlugin.m
@@ -246,7 +246,16 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
   NSUUID *callUuid = [[NSUUID alloc] initWithUUIDString:uuidString];
-  if (callUuid != nil && [_deferredCallUuids containsObject:callUuid]) {
+  // This very call may already live in CallKit, registered by the racing push
+  // path. Then it must go down the normal-report branch (the provider answers
+  // with a callUUIDAlreadyExists dedup error the Dart side tolerates) - the
+  // deferral checks below would otherwise mistake the call for one arriving
+  // next to a live call and mis-defer it against itself.
+  BOOL alreadyLive = callUuid != nil && [self isLiveCallKitCallWithUuid:[self currentUuidFor:callUuid]];
+  if (alreadyLive) {
+    [self healStaleDeferredMark:callUuid];
+  }
+  if (!alreadyLive && callUuid != nil && [_deferredCallUuids containsObject:callUuid]) {
     // The call is deferred (kept out of CallKit while another call was being
     // answered). Swallow the registration so it does not resurrect the system
     // UI, but remember the freshest metadata for the re-report at answer time.
@@ -257,7 +266,7 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
     completion(nil, nil);
     return;
   }
-  if (callUuid != nil && [self hasOwnLiveCallKitCall]) {
+  if (!alreadyLive && callUuid != nil && [self hasOwnLiveCallKitCall]) {
     // At most one call is represented in CallKit: an incoming call arriving
     // while any own call already lives there (ringing or active) is deferred
     // right away - it rings app-side only and enters CallKit when answered.
@@ -351,6 +360,10 @@ static NSString *const OptionsKey = @"WebtritCallkeepPluginOptions";
   NSLog(@"[Callkeep][reportEndCall] uuidString = %@", uuidString);
 #endif
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  // A stale deferred mark on a call that really lives in CallKit (a lost
+  // report race) must not skip the provider report below - that would leave
+  // the registry entry ringing as a ghost.
+  [self healStaleDeferredMark:uuid];
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
     // The deferred call is not in CallKit - nothing to report, just forget it
     // (remote hangup / cancel of a call that was ringing app-side only).
@@ -465,6 +478,36 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   return NO;
 }
 
+/// Whether [uuid] itself is currently represented in CallKit as a live call.
+/// The signaling and push paths race to report the same call (both are kept
+/// deliberately - the push is the fallback for a dead socket), so either path
+/// can run while the other has already registered this very call. In that case
+/// the call must NOT be treated as "arriving next to a live call" and deferred:
+/// the live call it would be deferred behind is itself. A stale deferred mark
+/// on a really-registered call breaks both exits - decline skips the CallKit
+/// end (leaving a ghost ringing entry), and answer re-attaches a second
+/// registry entry next to the still-ringing original, which flips the registry
+/// into "ringing + active" and summons the system call-waiting screen.
+- (BOOL)isLiveCallKitCallWithUuid:(NSUUID *)uuid {
+  if (uuid == nil) return NO;
+  for (CXCall *call in _callController.callObserver.calls) {
+    if (call.hasEnded) continue;
+    if ([call.UUID isEqual:uuid]) return YES;
+  }
+  return NO;
+}
+
+/// Drops a stale deferred mark from a call that in fact lives in CallKit
+/// (see [isLiveCallKitCallWithUuid]). Returns YES when the mark was stale.
+- (BOOL)healStaleDeferredMark:(NSUUID *)uuid {
+  if (uuid == nil || ![_deferredCallUuids containsObject:uuid]) return NO;
+  if (![self isLiveCallKitCallWithUuid:[self currentUuidFor:uuid]]) return NO;
+  NSLog(@"[Callkeep][healStaleDeferredMark] %@ is live in CallKit - clearing deferred mark", uuid.UUIDString);
+  [_deferredCallUuids removeObject:uuid];
+  [_ownCallUuids addObject:uuid];
+  return YES;
+}
+
 /// Takes every other still-ringing own incoming call out of CallKit right
 /// before [answeredUuid] goes active, marking them deferred. Without this the
 /// answer flips CallKit into "active + ringing" and iOS covers the app with
@@ -492,6 +535,12 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
 #endif
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
   [self deferOtherRingingOwnCallsForAnswerOf:[self currentUuidFor:uuid]];
+
+  // A stale deferred mark on a call that really lives in CallKit (a lost
+  // report race) must not send the answer down the re-attach branch: that
+  // would add an outgoing entry next to the still-ringing original and summon
+  // the system call-waiting screen. Heal the mark and answer normally.
+  [self healStaleDeferredMark:uuid];
 
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
     // A deferred call re-enters CallKit only now, at answer time, under a
@@ -538,6 +587,11 @@ displayNameOrContactIdentifier:(NSString *)displayNameOrContactIdentifier
   NSLog(@"[Callkeep][endCall] uuidString = %@", uuidString);
 #endif
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+  // A stale deferred mark on a call that really lives in CallKit (a lost
+  // report race) must not take the local shortcut below - skipping the
+  // CXEndCallAction would leave the registry entry ringing as a ghost that
+  // later flips "connected + ringing" and summons the system screen.
+  [self healStaleDeferredMark:uuid];
   if (uuid != nil && [_deferredCallUuids containsObject:uuid]) {
     // A deferred call has no CallKit representation to end - clean up locally
     // and drive the same delegate path a fulfilled CXEndCallAction would, so
@@ -803,12 +857,21 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
   callUpdate.supportsUngrouping = NO;
   callUpdate.supportsHolding = YES;
   callUpdate.supportsDTMF = YES;
+  // This very call may already live in CallKit, registered by the racing
+  // signaling path - then the "own live call" the deferral check sees is the
+  // call itself, and deferring would strand a really-registered call behind
+  // the deferred mark. Report normally instead: the provider answers with the
+  // callUUIDAlreadyExists dedup error the Dart side tolerates.
+  BOOL alreadyLive = [self isLiveCallKitCallWithUuid:[self currentUuidFor:uuid]];
+  if (alreadyLive) {
+    [self healStaleDeferredMark:uuid];
+  }
   // Deferred either explicitly (taken out of CallKit at answer time) or on
   // arrival (another own call already lives in CallKit - at most one call is
   // represented there). PushKit still obliges reporting, so the call is
   // reported and taken right back out; it rings app-side and enters CallKit
   // under a fresh UUID when answered.
-  BOOL isDeferred = [_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall];
+  BOOL isDeferred = !alreadyLive && ([_deferredCallUuids containsObject:uuid] || [self hasOwnLiveCallKitCall]);
   if (isDeferred) {
     [_deferredCallUuids addObject:uuid];
     _incomingCallUpdates[uuid] = callUpdate;

--- a/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
+++ b/webtrit_callkeep_ios/ios/webtrit_callkeep_ios/Sources/webtrit_callkeep_ios/include/webtrit_callkeep_ios/Generated.h
@@ -104,7 +104,8 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
     supportsVideo:(BOOL )supportsVideo
     includesCallsInRecents:(BOOL )includesCallsInRecents
     driveIdleTimerDisabled:(BOOL )driveIdleTimerDisabled
-    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly;
+    callWaitingToneOwnCallsOnly:(nullable NSNumber *)callWaitingToneOwnCallsOnly
+    deferredCallKitRegistration:(nullable NSNumber *)deferredCallKitRegistration;
 @property(nonatomic, copy) NSString * localizedName;
 @property(nonatomic, copy, nullable) NSString * ringtoneSound;
 @property(nonatomic, copy, nullable) NSString * ringbackSound;
@@ -118,6 +119,7 @@ typedef NS_ENUM(NSUInteger, WTPCallRequestErrorEnum) {
 @property(nonatomic, assign) BOOL  includesCallsInRecents;
 @property(nonatomic, assign) BOOL  driveIdleTimerDisabled;
 @property(nonatomic, strong, nullable) NSNumber * callWaitingToneOwnCallsOnly;
+@property(nonatomic, strong, nullable) NSNumber * deferredCallKitRegistration;
 @end
 
 @interface WTPAndroidOptions : NSObject

--- a/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
+++ b/webtrit_callkeep_ios/lib/src/common/callkeep.pigeon.dart
@@ -163,6 +163,7 @@ class PIOSOptions {
     required this.includesCallsInRecents,
     required this.driveIdleTimerDisabled,
     this.callWaitingToneOwnCallsOnly,
+    this.deferredCallKitRegistration,
   });
 
   String localizedName;
@@ -191,6 +192,8 @@ class PIOSOptions {
 
   bool? callWaitingToneOwnCallsOnly;
 
+  bool? deferredCallKitRegistration;
+
   List<Object?> _toList() {
     return <Object?>[
       localizedName,
@@ -206,6 +209,7 @@ class PIOSOptions {
       includesCallsInRecents,
       driveIdleTimerDisabled,
       callWaitingToneOwnCallsOnly,
+      deferredCallKitRegistration,
     ];
   }
 
@@ -228,6 +232,7 @@ class PIOSOptions {
       includesCallsInRecents: result[10]! as bool,
       driveIdleTimerDisabled: result[11]! as bool,
       callWaitingToneOwnCallsOnly: result.length > 12 ? result[12] as bool? : null,
+      deferredCallKitRegistration: result.length > 13 ? result[13] as bool? : null,
     );
   }
 
@@ -240,7 +245,7 @@ class PIOSOptions {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(localizedName, other.localizedName) && _deepEquals(ringtoneSound, other.ringtoneSound) && _deepEquals(ringbackSound, other.ringbackSound) && _deepEquals(iconTemplateImageAssetName, other.iconTemplateImageAssetName) && _deepEquals(maximumCallGroups, other.maximumCallGroups) && _deepEquals(maximumCallsPerCallGroup, other.maximumCallsPerCallGroup) && _deepEquals(supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && _deepEquals(supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && _deepEquals(supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && _deepEquals(supportsVideo, other.supportsVideo) && _deepEquals(includesCallsInRecents, other.includesCallsInRecents) && _deepEquals(driveIdleTimerDisabled, other.driveIdleTimerDisabled) && _deepEquals(callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly);
+    return _deepEquals(localizedName, other.localizedName) && _deepEquals(ringtoneSound, other.ringtoneSound) && _deepEquals(ringbackSound, other.ringbackSound) && _deepEquals(iconTemplateImageAssetName, other.iconTemplateImageAssetName) && _deepEquals(maximumCallGroups, other.maximumCallGroups) && _deepEquals(maximumCallsPerCallGroup, other.maximumCallsPerCallGroup) && _deepEquals(supportsHandleTypeGeneric, other.supportsHandleTypeGeneric) && _deepEquals(supportsHandleTypePhoneNumber, other.supportsHandleTypePhoneNumber) && _deepEquals(supportsHandleTypeEmailAddress, other.supportsHandleTypeEmailAddress) && _deepEquals(supportsVideo, other.supportsVideo) && _deepEquals(includesCallsInRecents, other.includesCallsInRecents) && _deepEquals(driveIdleTimerDisabled, other.driveIdleTimerDisabled) && _deepEquals(callWaitingToneOwnCallsOnly, other.callWaitingToneOwnCallsOnly) && _deepEquals(deferredCallKitRegistration, other.deferredCallKitRegistration);
   }
 
   @override

--- a/webtrit_callkeep_ios/lib/src/common/converters.dart
+++ b/webtrit_callkeep_ios/lib/src/common/converters.dart
@@ -125,6 +125,7 @@ extension CallkeepIOSOptionsConverter on CallkeepIOSOptions {
       includesCallsInRecents: includesCallsInRecents,
       driveIdleTimerDisabled: driveIdleTimerDisabled,
       callWaitingToneOwnCallsOnly: callWaitingToneOwnCallsOnly,
+      deferredCallKitRegistration: deferredCallKitRegistration,
     );
   }
 }

--- a/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
+++ b/webtrit_callkeep_ios/pigeons/callkeep.messages.dart
@@ -25,6 +25,7 @@ class PIOSOptions {
   late bool includesCallsInRecents;
   late bool driveIdleTimerDisabled;
   late bool? callWaitingToneOwnCallsOnly;
+  late bool? deferredCallKitRegistration;
 }
 
 class PAndroidOptions {

--- a/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
+++ b/webtrit_callkeep_platform_interface/lib/src/models/callkeep_options.dart
@@ -24,6 +24,7 @@ class CallkeepIOSOptions extends Equatable {
     this.includesCallsInRecents = true,
     this.driveIdleTimerDisabled = true,
     this.callWaitingToneOwnCallsOnly = true,
+    this.deferredCallKitRegistration = false,
   });
 
   final String localizedName;
@@ -42,6 +43,13 @@ class CallkeepIOSOptions extends Equatable {
   /// other VoIP apps) also count towards the connected/ringing combination.
   final bool callWaitingToneOwnCallsOnly;
 
+  /// iOS only: opt-in to the deferred CallKit registration mechanism - at most
+  /// one call is represented in CallKit; extra incoming calls ring app-side
+  /// only and enter CallKit silently when answered, so the system call-waiting
+  /// screen never covers the app. Off by default: incoming calls register with
+  /// CallKit as usual and the standard iOS call-waiting behavior applies.
+  final bool deferredCallKitRegistration;
+
   @override
   List<Object?> get props => [
     localizedName,
@@ -55,6 +63,7 @@ class CallkeepIOSOptions extends Equatable {
     includesCallsInRecents,
     driveIdleTimerDisabled,
     callWaitingToneOwnCallsOnly,
+    deferredCallKitRegistration,
   ];
 }
 


### PR DESCRIPTION
## Overview

When two incoming calls ring at the same time on iOS and the user answers one of them, the system takes over with a full-screen call-waiting UI for the other call, leaving the app's own call screen in a wrong or incomplete state. In some flows the second call was not visible or audible at all.

The iOS plugin now keeps at most one call registered with the system while another one is being answered: the extra ringing call is held back and re-entered afterwards, so the system screen never appears and both calls stay manageable from the app. Verified on a real device with repeated dual-incoming-call cycles (no system screen, no stuck calls).

Known trade-off: the re-entered call is recorded in the system call log as outgoing. Draft until productization is done (diagnostics cleanup, opt-in flag, native tests).